### PR TITLE
fix `vela comp run` panic when args empty

### DIFF
--- a/pkg/commands/comp.go
+++ b/pkg/commands/comp.go
@@ -58,8 +58,7 @@ func NewCompRunCommands(c types.Args, ioStreams util.IOStreams) *cobra.Command {
 		Long:               "Init and Run workloads",
 		Example:            "vela comp run -t <workload-type>",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			if args[0] == "-h" {
+			if len(args) == 0 || args[0] == "-h" {
 				err := cmd.Help()
 				if err != nil {
 					return err


### PR DESCRIPTION
Ref: #283 
`vela comp run` show help info now when args empty.
```
$ vela comp run

Init and Run workloads

Usage:
  vela comp run [args]

Examples:
vela comp run -t <workload-type>

Flags:
  -h, --help          help for run
  -s, --staging       only save changes locally without real update application
  -t, --type string   specify workload type for application

Global Flags:
  -a, --app string   specify application name for component
  -e, --env string   specify env name for application
```