### PR TITLE
Use label to mark WorkloadDefinition in workload

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -14,10 +14,10 @@ const (
 	AnnAPIVersion = "definition.oam.dev/apiVersion"
 	AnnKind       = "definition.oam.dev/kind"
 
-	// Indicate which workloadDefinition generate from
-	AnnWorkloadDef = "workload.oam.dev/name"
 	// Indicate which traitDefinition generate from
 	AnnTraitDef = "trait.oam.dev/name"
+	// WorkloadTypeLabel indicates the type of the workloadDefinition
+	WorkloadTypeLabel = "workload.oam.dev/type"
 )
 
 const (

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -205,11 +205,11 @@ func (app *Application) GetWorkload(componentName string) (string, map[string]in
 	if !ok {
 		return "", make(map[string]interface{})
 	}
-	for tp, workload := range comp {
-		if NotWorkload(tp) {
+	for workloadType, workload := range comp {
+		if NotWorkload(workloadType) {
 			continue
 		}
-		return tp, workload.(map[string]interface{})
+		return workloadType, workload.(map[string]interface{})
 	}
 	return "", make(map[string]interface{})
 }
@@ -374,14 +374,17 @@ func (app *Application) OAM(env *types.EnvMeta) ([]v1alpha2.Component, v1alpha2.
 		if err != nil {
 			return nil, v1alpha2.ApplicationConfiguration{}, nil, err
 		}
-		anns := component.Annotations
-		if anns == nil {
-			anns = map[string]string{types.AnnWorkloadDef: workloadType}
+		labels := component.Labels
+		if labels == nil {
+			labels = map[string]string{types.WorkloadTypeLabel: workloadType}
 		} else {
-			anns[types.AnnWorkloadDef] = workloadType
+			labels[types.WorkloadTypeLabel] = workloadType
 		}
-		component.Annotations = anns
+		component.Labels = labels
+		// Set labels for Workload to mark the type of the WorkloadDefinition
+		obj.SetLabels(labels)
 		component.Spec.Workload.Object = obj
+
 		components = append(components, component)
 
 		var appConfigComp v1alpha2.ApplicationConfigurationComponent

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -64,6 +64,7 @@ func NewCompListCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comman
 		Short:                 "List applications",
 		Long:                  "List applications with workloads, traits, status and created time",
 		Example:               `vela comp ls`,
+		Aliases:               []string{"list"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			env, err := GetEnv(cmd)
 			if err != nil {
@@ -130,7 +131,7 @@ func mergeStagingComponents(deployed []oam.ComponentMeta, env *types.EnvMeta, io
 				all = append(all, oam.ComponentMeta{
 					Name:        c.Name,
 					App:         app.Name,
-					Workload:    c.Annotations[types.AnnWorkloadDef],
+					Workload:    c.Labels[types.WorkloadTypeLabel],
 					Traits:      traits,
 					Status:      types.StatusStaging,
 					CreatedTime: app.CreateTime.String(),

--- a/pkg/oam/application.go
+++ b/pkg/oam/application.go
@@ -80,14 +80,14 @@ func ListComponents(ctx context.Context, c client.Client, opt Option) ([]Compone
 				return componentMetaList, err
 			}
 			traitAlias := GetTraitAliasByComponentTraitList(com.Traits)
-			var workload string
-			if component.Annotations != nil {
-				workload = component.Annotations[types.AnnWorkloadDef]
+			var workloadType string
+			if component.Labels != nil {
+				workloadType = component.Labels[types.WorkloadTypeLabel]
 			}
 			componentMetaList = append(componentMetaList, ComponentMeta{
 				Name:        com.ComponentName,
 				App:         a.Name,
-				Workload:    workload,
+				Workload:    workloadType,
 				Status:      types.StatusDeployed,
 				Traits:      traitAlias,
 				CreatedTime: a.ObjectMeta.CreationTimestamp.String(),


### PR DESCRIPTION
Use label "workload.oam.dev/type" to makr the type
of WorkloadDefinition for a Workload, and replace
the corresponding annotation