### PR TITLE
use return instead of break

### DIFF
--- a/pkg/commands/logs.go
+++ b/pkg/commands/logs.go
@@ -69,7 +69,7 @@ func Run(ctx context.Context, config *stern.Config, ioStreams cmdutil.IOStreams)
 			case str := <-logC:
 				ioStreams.Infonln(str)
 			case <-ctx.Done():
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
use `return` instead of `break` to break out of the outer loop