### PR TITLE
setup core-controllers before e2e-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ e2e-setup:
 	ginkgo version
 	ginkgo -v -r e2e/setup
 	bin/vela dashboard &
+	bin/vela install &
+	bin/manager &
 
 e2e-test:
 	# Run e2e test


### PR DESCRIPTION
Some e2e tests cannot work correctly for there's no oam-core-controller reconciling resources.
e.g. `vela comp status`  need to get reconciled AppConfig object.

Signed-off-by: roy wang <seiwy2010@gmail.com>