### PR TITLE
add description for workload and trait

### DIFF
--- a/api/types/capability.go
+++ b/api/types/capability.go
@@ -46,6 +46,7 @@ type Capability struct {
 	CrdName        string      `json:"crdName,omitempty"`
 	Center         string      `json:"center,omitempty"`
 	Status         string      `json:"status,omitempty"`
+	Description    string      `json:"description,omitempty"`
 
 	//trait only
 	AppliesTo []string `json:"appliesTo,omitempty"`

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -11,8 +11,9 @@ const (
 )
 
 const (
-	AnnAPIVersion = "definition.oam.dev/apiVersion"
-	AnnKind       = "definition.oam.dev/kind"
+	AnnAPIVersion  = "definition.oam.dev/apiVersion"
+	AnnKind        = "definition.oam.dev/kind"
+	AnnDescription = "definition.oam.dev/description"
 
 	// Indicate which workloadDefinition generate from
 	AnnWorkloadDef = "workload.oam.dev/name"

--- a/charts/vela-core/templates/backend.yaml
+++ b/charts/vela-core/templates/backend.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     definition.oam.dev/apiVersion: "standard.oam.dev/v1alpha1"
     definition.oam.dev/kind: "PodSpecWorkload"
+    definition.oam.dev/description: "Backend worker without ports exposed"
 spec:
   definitionRef:
     name: podspecworkload.standard.oam.dev

--- a/charts/vela-core/templates/manualscalars.yaml
+++ b/charts/vela-core/templates/manualscalars.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     definition.oam.dev/apiVersion: core.oam.dev/v1alpha2
     definition.oam.dev/kind: ManualScalerTrait
+    definition.oam.dev/description: "Scale replica for workload"
   name: manualscalertraits.core.oam.dev
   namespace: default
 spec:

--- a/charts/vela-core/templates/metricstraits.yaml
+++ b/charts/vela-core/templates/metricstraits.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     definition.oam.dev/apiVersion: standard.oam.dev/v1alpha1
     definition.oam.dev/kind: MetricsTrait
+    definition.oam.dev/description: "Add metric monitoring for workload"
 spec:
   appliesToWorkloads:
     - containerizedworkloads.core.oam.dev

--- a/charts/vela-core/templates/routetrait.yaml
+++ b/charts/vela-core/templates/routetrait.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     definition.oam.dev/apiVersion: standard.oam.dev/v1alpha1
     definition.oam.dev/kind: Route
+    definition.oam.dev/description: "Add a route for workload"
 spec:
   appliesToWorkloads:
     - core.oam.dev/v1alpha2.ContainerizedWorkload

--- a/charts/vela-core/templates/tasks.yaml
+++ b/charts/vela-core/templates/tasks.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     definition.oam.dev/apiVersion: "v1"
     definition.oam.dev/kind: "Job"
+    definition.oam.dev/description: "One-time off task or job"
 spec:
   definitionRef:
     name: jobs

--- a/charts/vela-core/templates/webservices.yaml
+++ b/charts/vela-core/templates/webservices.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     definition.oam.dev/apiVersion: "standard.oam.dev/v1alpha1"
     definition.oam.dev/kind: "PodSpecWorkload"
+    definition.oam.dev/description: "Long running service with ports exposed"
 spec:
   definitionRef:
     name: podspecworkloads.standard.oam.dev

--- a/pkg/commands/traits.go
+++ b/pkg/commands/traits.go
@@ -36,10 +36,10 @@ func printTraitList(workloadName *string, ioStreams cmdutil.IOStreams) error {
 	if err != nil {
 		return err
 	}
-	table.AddRow("NAME", "DEFINITION", "APPLIES TO")
+	table.AddRow("NAME", "DESCRIPTION", "APPLIES TO")
 	simplifiedTraits := oam.SimplifyCapabilityStruct(traitDefinitionList)
 	for _, t := range simplifiedTraits {
-		table.AddRow(t.Name, t.Definition, strings.Join(t.AppliesTo, "\n"))
+		table.AddRow(t.Name, t.Description, strings.Join(t.AppliesTo, "\n"))
 	}
 	ioStreams.Info(table.String())
 	return nil

--- a/pkg/commands/workloads.go
+++ b/pkg/commands/workloads.go
@@ -31,9 +31,9 @@ func NewWorkloadsCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 func printWorkloadList(workloadList []types.Capability, ioStreams cmdutil.IOStreams) error {
 	table := uitable.New()
 	table.MaxColWidth = 60
-	table.AddRow("NAME", "DEFINITION")
+	table.AddRow("NAME", "DESCRIPTION")
 	for _, r := range workloadList {
-		table.AddRow(r.Name, r.CrdName)
+		table.AddRow(r.Name, r.Description)
 	}
 	ioStreams.Info(table.String())
 	return nil

--- a/pkg/oam/trait.go
+++ b/pkg/oam/trait.go
@@ -131,9 +131,9 @@ func SimplifyCapabilityStruct(capabilityList []types.Capability) []apis.TraitMet
 	var traitList []apis.TraitMeta
 	for _, c := range capabilityList {
 		traitList = append(traitList, apis.TraitMeta{
-			Name:       c.Name,
-			Definition: c.CrdName,
-			AppliesTo:  c.AppliesTo,
+			Name:        c.Name,
+			Description: c.Description,
+			AppliesTo:   c.AppliesTo,
 		})
 	}
 	return traitList

--- a/pkg/plugins/capcenter.go
+++ b/pkg/plugins/capcenter.go
@@ -161,14 +161,14 @@ func ParseAndSyncCapability(data []byte, syncDir string) (types.Capability, erro
 		if err != nil {
 			return types.Capability{}, err
 		}
-		return HandleDefinition(rd.Name, syncDir, rd.Spec.Reference.Name, rd.Spec.Extension, types.TypeWorkload, nil)
+		return HandleDefinition(rd.Name, syncDir, rd.Spec.Reference.Name, rd.Annotations, rd.Spec.Extension, types.TypeWorkload, nil)
 	case "TraitDefinition":
 		var td v1alpha2.TraitDefinition
 		err = yaml.Unmarshal(data, &td)
 		if err != nil {
 			return types.Capability{}, err
 		}
-		return HandleDefinition(td.Name, syncDir, td.Spec.Reference.Name, td.Spec.Extension, types.TypeTrait, td.Spec.AppliesToWorkloads)
+		return HandleDefinition(td.Name, syncDir, td.Spec.Reference.Name, td.Annotations, td.Spec.Extension, types.TypeTrait, td.Spec.AppliesToWorkloads)
 	case "ScopeDefinition":
 		//TODO(wonderflow): support scope definition here.
 	}

--- a/pkg/plugins/cluster_test.go
+++ b/pkg/plugins/cluster_test.go
@@ -28,13 +28,15 @@ var _ = Describe("DefinitionFiles", func() {
 				Type:     cue.StringKind,
 			},
 		},
-		CrdName: "routes.test",
+		Description: "description not defined",
+		CrdName:     "routes.test",
 	}
 
 	deployment := types.Capability{
-		Name:    "deployment",
-		Type:    types.TypeWorkload,
-		CrdName: "deployments.testapps",
+		Name:        "deployment",
+		Type:        types.TypeWorkload,
+		CrdName:     "deployments.testapps",
+		Description: "description not defined",
 		Parameters: []types.Parameter{
 			{
 				Name:     "name",
@@ -68,6 +70,7 @@ var _ = Describe("DefinitionFiles", func() {
 		Name:           "webservice",
 		Type:           types.TypeWorkload,
 		CueTemplateURI: "https://raw.githubusercontent.com/oam-dev/kubevela/master/vela-templates/web-service.cue",
+		Description:    "description not defined",
 		Parameters: []types.Parameter{
 			{
 				Name:     "name",

--- a/pkg/server/apis/types.go
+++ b/pkg/server/apis/types.go
@@ -53,9 +53,9 @@ type WorkloadMeta struct {
 }
 
 type TraitMeta struct {
-	Name       string   `json:"name"`
-	Definition string   `json:"definition,omitempty"`
-	AppliesTo  []string `json:"appliesTo,omitempty"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	AppliesTo   []string `json:"appliesTo,omitempty"`
 }
 
 //used to present trait which is to be attached and, of which parameters are set
@@ -67,13 +67,6 @@ type TraitBody struct {
 	AppName       string       `json:"appName,omitempty"`
 	Staging       string       `json:"staging,omitempty"`
 }
-
-//type ComponentMeta struct {
-//	Name     string                        `json:"name"`
-//	Status   string                        `json:"status,omitempty"`
-//	Workload runtime.RawExtension          `json:"workload,omitempty"`
-//	Traits   []corev1alpha2.ComponentTrait `json:"traits,omitempty"`
-//}
 
 type ComponentMeta struct {
 	Name     string               `json:"name"`


### PR DESCRIPTION
fixes #349


```
➜  ~ vela workloads
NAME      	DESCRIPTION
backend   	Backend worker without ports exposed
task      	One-time off task or job
webservice	Long running service with ports exposed
➜  ~ vela traits
NAME    	DESCRIPTION                       	APPLIES TO
metrics 	Add metric monitoring for workload
route   	Add a route for workload          	webservice
scale   	Scale replica for workload
```