### PR TITLE
add liveness & readiness probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: build
 
 # Run tests
 test: fmt vet lint
-	go test ./pkg/... -coverprofile cover.out
+	go test ./pkg/... ./cmd/... -coverprofile cover.out
 
 # Build manager binary
 build: fmt vet lint
@@ -78,7 +78,7 @@ docker-push:
 e2e-setup:
 	ginkgo version
 	ginkgo -v -r e2e/setup
-	kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=vela-core,app.kubernetes.io/instance=kubevela -n vela-system --timeout=600s
+	# kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=vela-core,app.kubernetes.io/instance=kubevela -n vela-system --timeout=600s
 	bin/vela dashboard &
 
 e2e-test:

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -111,6 +111,7 @@ spec:
             - "--use-webhook=true"
             - "--webhook-port={{ .Values.webhookService.port }}"
             - "--webhook-cert-dir={{ .Values.certificate.mountPath }}"
+            - "--health-addr=:{{ .Values.healthCheck.port }}"
           {{ end }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
@@ -121,6 +122,21 @@ spec:
             - containerPort: {{ .Values.webhookService.port }}
               name: webhook-server
               protocol: TCP
+            - containerPort: {{ .Values.healthCheck.port }}
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+            initialDelaySeconds: 90
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 90
+            periodSeconds: 5
           volumeMounts:
             - mountPath: {{ .Values.certificate.mountPath }}
               name: tls-cert-vol

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -63,6 +63,9 @@ webhookService:
   type: ClusterIP
   port: 9443
 
+healthCheck:
+  port: 9440
+
 nodeSelector: {}
 
 tolerations: []

--- a/cmd/core/main_test.go
+++ b/cmd/core/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	testdir      = "testdir"
+	testTimeout  = 2 * time.Second
+	testInterval = 1 * time.Second
+)
+
+func TestGinkgo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "test main")
+}
+
+var _ = Describe("test waitSecretVolume", func() {
+	BeforeEach(func() {
+		err := os.MkdirAll(testdir, 0755)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	AfterEach(func() {
+		os.RemoveAll(testdir)
+	})
+
+	When("dir not exist or empty", func() {
+		It("return timeout error", func() {
+			err := waitWebhookSecretVolume(testdir, testTimeout, testInterval)
+			Expect(err).To(HaveOccurred())
+			By("remove dir")
+			os.RemoveAll(testdir)
+			err = waitWebhookSecretVolume(testdir, testTimeout, testInterval)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("dir contains empty file", func() {
+		It("return timeout error", func() {
+			By("add empty file")
+			_, err := os.Create(testdir + "/emptyFile")
+			Expect(err).NotTo(HaveOccurred())
+			err = waitWebhookSecretVolume(testdir, testTimeout, testInterval)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("files in dir are not empty", func() {
+		It("return nil", func() {
+			By("add non-empty file")
+			_, err := os.Create(testdir + "/file")
+			Expect(err).NotTo(HaveOccurred())
+			err = ioutil.WriteFile(testdir+"/file", []byte("test"), os.ModeAppend)
+			Expect(err).NotTo(HaveOccurred())
+			err = waitWebhookSecretVolume(testdir, testTimeout, testInterval)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+})


### PR DESCRIPTION
#371 
- Controller-runtime allows [adding liveness & readiness probes for ctrl-mgr.](https://github.com/kubernetes-sigs/controller-runtime/pull/419) Use probes to help determining the manager is ready to go.
- Add a looping check for webhook secrets volume mounted before start mgr, which can avoid unnecessary pod restart.

Signed-off-by: roy wang <seiwy2010@gmail.com>