### PR TITLE
support vela logs

### DIFF
--- a/examples/testapp/Dockerfile
+++ b/examples/testapp/Dockerfile
@@ -24,11 +24,11 @@
 
 FROM mhart/alpine-node:12
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY package.json ./
 
 # If you have native dependencies, you'll need extra tools
 # RUN apk add --no-cache make gcc g++ python
-
+RUN npm install
 RUN npm ci --prod
 
 # Then we copy over the modules from above onto a `slim` image

--- a/pkg/commands/logs.go
+++ b/pkg/commands/logs.go
@@ -2,42 +2,48 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"text/template"
+	"time"
 
 	"github.com/oam-dev/kubevela/api/types"
+	"github.com/oam-dev/kubevela/pkg/application"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	sternCmd "github.com/wercker/stern/cmd"
-	"github.com/wercker/stern/kubernetes"
 	"github.com/wercker/stern/stern"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 )
 
 func NewLogsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	largs := &Args{C: c}
 	cmd := &cobra.Command{}
-	cmd.Use = "logs <appname>"
-	cmd.Short = "Tail pods logs of an application"
-	cmd.Long = "Tail pods logs of an application"
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+	cmd.Use = "logs"
+	cmd.Short = "Tail logs for application"
+	cmd.Long = "Tail logs for application"
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			ioStreams.Errorf("please specify the application name")
+			ioStreams.Errorf("please specify app name")
+			return nil
 		}
-		appName := args[0]
-		cmd.SetArgs([]string{appName + ".*"})
 		env, err := GetEnv(cmd)
 		if err != nil {
 			return err
 		}
-		namespace := env.Namespace
-		cmd.Flags().String("namespace", namespace, "")
-		return nil
-	}
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		config, err := sternCmd.ParseConfig(args)
+		app, err := application.Load(env.Name, args[0])
 		if err != nil {
 			return err
 		}
+		largs.App = app
+		largs.Env = env
 		ctx := context.Background()
-		if err := Run(ctx, config, ioStreams); err != nil {
+		if err := largs.Run(ctx, ioStreams); err != nil {
 			return err
 		}
 		return nil
@@ -45,18 +51,54 @@ func NewLogsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd.Annotations = map[string]string{
 		types.TagCommandType: types.TypeApp,
 	}
+	cmd.Flags().StringVarP(&largs.Output, "output", "o", "default", "output format for logs, support: [default, raw, json]")
 	return cmd
 }
 
+type Args struct {
+	Output string
+	Env    *types.EnvMeta
+	C      types.Args
+	App    *application.Application
+}
+
+func (l *Args) AskComponent() (string, error) {
+	comps := l.App.GetComponents()
+	if len(comps) == 1 {
+		return comps[0], nil
+	}
+	prompt := &survey.Select{
+		Message: "You have multiple Component in your app. Choose one component for logs: ",
+		Options: comps,
+	}
+	var compName string
+	err := survey.AskOne(prompt, &compName)
+	if err != nil {
+		return "", fmt.Errorf("choosing component name err %v", err)
+	}
+	return compName, nil
+}
+
 // Run refer to the implementation at https://github.com/oam-dev/stern/blob/master/stern/main.go
-func Run(ctx context.Context, config *stern.Config, ioStreams cmdutil.IOStreams) error {
-	clientConfig := kubernetes.NewClientConfig(config.KubeConfig, config.ContextName)
-	clientSet, err := kubernetes.NewClientSet(clientConfig)
+func (l *Args) Run(ctx context.Context, ioStreams cmdutil.IOStreams) error {
+
+	clientSet, err := kubernetes.NewForConfig(l.C.Config)
 	if err != nil {
 		return err
 	}
-	namespace := config.Namespace
-	added, removed, err := stern.Watch(ctx, clientSet.CoreV1().Pods(namespace), config.PodQuery, config.ContainerQuery, config.ExcludeContainerQuery, config.ContainerState, config.LabelSelector)
+	compName, err := l.AskComponent()
+	if err != nil {
+		return err
+	}
+	//TODO(wonderflow): we could get labels from service to narrow the pods scope selected
+	labelSelector := labels.Everything()
+	pod, err := regexp.Compile(compName + "-.*")
+	if err != nil {
+		return fmt.Errorf("fail to compile '%s' for logs query", compName+".*")
+	}
+	container := regexp.MustCompile(".*")
+	namespace := l.Env.Namespace
+	added, removed, err := stern.Watch(ctx, clientSet.CoreV1().Pods(namespace), pod, container, nil, stern.RUNNING, labelSelector)
 	if err != nil {
 		return err
 	}
@@ -74,20 +116,51 @@ func Run(ctx context.Context, config *stern.Config, ioStreams cmdutil.IOStreams)
 		}
 	}()
 
+	var t string
+	switch l.Output {
+	case "default":
+		if color.NoColor {
+			t = "{{.PodName}} {{.ContainerName}} {{.Message}}"
+		} else {
+			t = "{{color .PodColor .PodName}} {{color .ContainerColor .ContainerName}} {{.Message}}"
+		}
+	case "raw":
+		t = "{{.Message}}"
+	case "json":
+		t = "{{json .}}\n"
+	}
+	funs := map[string]interface{}{
+		"json": func(in interface{}) (string, error) {
+			b, err := json.Marshal(in)
+			if err != nil {
+				return "", err
+			}
+			return string(b), nil
+		},
+		"color": func(color color.Color, text string) string {
+			return color.SprintFunc()(text)
+		},
+	}
+	template, err := template.New("log").Funcs(funs).Parse(t)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse template")
+	}
+
 	go func() {
 		for p := range added {
 			id := p.GetID()
 			if tails[id] != nil {
 				continue
 			}
-
-			tail := stern.NewTail(p.Namespace, p.Pod, p.Container, config.Template, &stern.TailOptions{
-				Timestamps:   config.Timestamps,
-				SinceSeconds: int64(config.Since.Seconds()),
-				Exclude:      config.Exclude,
-				Include:      config.Include,
-				Namespace:    config.AllNamespaces,
-				TailLines:    config.TailLines,
+			//48h
+			dur, _ := time.ParseDuration("48h")
+			tail := stern.NewTail(p.Namespace, p.Pod, p.Container, template, &stern.TailOptions{
+				Timestamps:   true,
+				SinceSeconds: int64(dur.Seconds()),
+				Exclude:      nil,
+				Include:      nil,
+				Namespace:    false,
+				TailLines:    nil, //default for all logs
 			})
 			tails[id] = tail
 

--- a/pkg/commands/logs.go
+++ b/pkg/commands/logs.go
@@ -68,7 +68,7 @@ func (l *Args) AskComponent() (string, error) {
 		return comps[0], nil
 	}
 	prompt := &survey.Select{
-		Message: "You have multiple Component in your app. Choose one component for logs: ",
+		Message: "You have multiple Components in your app. Please choose one component for logs: ",
 		Options: comps,
 	}
 	var compName string


### PR DESCRIPTION
```
➜  kubevela git:(logs) vela logs myapp
? You have multiple Component in your app. Choose one component for logs:  mycomp2
+ mycomp2-667957dbd9-zglzz › mycomp2
mycomp2-667957dbd9-zglzz mycomp2 2020-10-20T12:46:42.287212932Z /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
mycomp2-667957dbd9-zglzz mycomp2 2020-10-20T12:46:42.287273498Z /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
mycomp2-667957dbd9-zglzz mycomp2 2020-10-20T12:46:42.288166788Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
mycomp2-667957dbd9-zglzz mycomp2 2020-10-20T12:46:42.29590541Z 10-listen-on-ipv6-by-default.sh: Getting the checksum of /etc/nginx/conf.d/default.conf
mycomp2-667957dbd9-zglzz mycomp2 2020-10-20T12:46:42.302285973Z 10-listen-on-ipv6-by-default.sh: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
```