### PR TITLE
vela exec

### DIFF
--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -28,6 +28,7 @@ var _ = ginkgo.Describe("Application", func() {
 	e2e.ApplicationShowContext("app show", applicationName, workloadType)
 	e2e.ApplicationStatusContext("app status", applicationName, workloadType)
 	e2e.ApplicationCompStatusContext("comp status", applicationName, workloadType, envName)
+	e2e.ApplicationExecContext("exec -- COMMAND", applicationName)
 	e2e.ApplicationInitIntercativeCliContext("init", appNameForInit, workloadType)
 	e2e.WorkloadDeleteContext("delete", applicationName)
 	e2e.WorkloadDeleteContext("delete", appNameForInit)

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -228,6 +228,17 @@ var (
 		})
 	}
 
+	ApplicationExecContext = func(context string, appName string) bool {
+		return ginkgo.Context(context, func() {
+			ginkgo.It("should get output of exec /bin/ls", func() {
+				cli := fmt.Sprintf("vela exec %s -- /bin/ls ", appName)
+				output, err := Exec(cli)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(output).To(gomega.ContainSubstring("bin"))
+			})
+		})
+	}
+
 	ApplicationInitIntercativeCliContext = func(context string, appName string, workloadType string) bool {
 		return ginkgo.Context(context, func() {
 			ginkgo.It("should init app through interactive questions", func() {

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 // indirect
-	k8s.io/kubectl v0.18.6 // indirect
+	k8s.io/kubectl v0.18.6
 	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66
 	sigs.k8s.io/controller-runtime v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,7 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 h1:7aWHqerlJ41y6FOsEUvknqgXnGmJyJSbjhAWq5pO4F8=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -363,6 +364,7 @@ github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v0.0.0-20180516100307-2d684516a886/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/pkg/commands/cli.go
+++ b/pkg/commands/cli.go
@@ -86,6 +86,7 @@ func NewCommand() *cobra.Command {
 
 		NewDashboardCommand(commandArgs, ioStream, fake.FrontendSource),
 
+		NewExecCommand(commandArgs, ioStream),
 		NewLogsCommand(commandArgs, ioStream),
 
 		NewTemplateCommand(commandArgs, ioStream),

--- a/pkg/commands/exec.go
+++ b/pkg/commands/exec.go
@@ -1,0 +1,193 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
+	"github.com/oam-dev/kubevela/api/types"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/oam-dev/kubevela/pkg/application"
+	velacmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	cmdexec "k8s.io/kubectl/pkg/cmd/exec"
+	k8scmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+const (
+	podRunningTimeoutFlag = "pod-running-timeout"
+	defaultPodExecTimeout = 60 * time.Second
+	defaultStdin          = true
+	defaultTTY            = true
+)
+
+type VelaExecOptions struct {
+	Cmd   *cobra.Command
+	Args  []string
+	Stdin bool
+	TTY   bool
+
+	context.Context
+	VelaC types.Args
+	Env   *types.EnvMeta
+	App   *application.Application
+
+	f             k8scmdutil.Factory
+	kcExecOptions *cmdexec.ExecOptions
+	ClientSet     kubernetes.Interface
+}
+
+func NewExecCommand(c types.Args, ioStreams velacmdutil.IOStreams) *cobra.Command {
+	o := &VelaExecOptions{
+		kcExecOptions: &cmdexec.ExecOptions{
+			StreamOptions: cmdexec.StreamOptions{
+				IOStreams: genericclioptions.IOStreams{
+					In:     ioStreams.In,
+					Out:    ioStreams.Out,
+					ErrOut: ioStreams.ErrOut,
+				},
+			},
+			Executor: &cmdexec.DefaultRemoteExecutor{},
+		},
+		VelaC: c,
+	}
+	cmd := &cobra.Command{
+		Use:   "exec [flags] AppName -- COMMAND [args...]",
+		Short: "Execute a command in a container",
+		Long:  "Execute a command in the 1st container of specific Application => Component => (1st)Pod",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				ioStreams.Error("Please specify an application name.")
+				return nil
+			}
+			argsLenAtDash := cmd.ArgsLenAtDash()
+			if argsLenAtDash != 1 {
+				ioStreams.Error("Please specify at least one commnad for the container.")
+				return nil
+			}
+
+			if err := o.Init(context.Background(), cmd, args); err != nil {
+				return err
+			}
+			if err := o.Complete(); err != nil {
+				return err
+			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
+		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeApp,
+		},
+	}
+	cmd.Flags().BoolVarP(&o.Stdin, "stdin", "i", defaultStdin, "Pass stdin to the container")
+	cmd.Flags().BoolVarP(&o.TTY, "tty", "t", defaultTTY, "Stdin is a TTY")
+	cmd.Flags().Duration(podRunningTimeoutFlag, defaultPodExecTimeout,
+		"The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
+	)
+	return cmd
+}
+
+func (o *VelaExecOptions) Init(ctx context.Context, c *cobra.Command, argsIn []string) error {
+	o.Context = ctx
+	o.Cmd = c
+	o.Args = argsIn
+
+	env, err := GetEnv(o.Cmd)
+	if err != nil {
+		return err
+	}
+	app, err := application.Load(env.Name, o.Args[0])
+	if err != nil {
+		return err
+	}
+	o.Env = env
+	o.App = app
+
+	cf := genericclioptions.NewConfigFlags(true)
+	cf.Namespace = &o.Env.Namespace
+	o.f = k8scmdutil.NewFactory(k8scmdutil.NewMatchVersionFlags(cf))
+
+	if o.ClientSet == nil {
+		c, err := kubernetes.NewForConfig(o.VelaC.Config)
+		if err != nil {
+			return err
+		}
+		o.ClientSet = c
+	}
+	return nil
+}
+
+func (o *VelaExecOptions) Complete() error {
+	compName, err := o.askComponent()
+	if err != nil {
+		return err
+	}
+	podName, err := o.getPodName(compName)
+	if err != nil {
+		return err
+	}
+	o.kcExecOptions.StreamOptions.Stdin = o.Stdin
+	o.kcExecOptions.StreamOptions.TTY = o.TTY
+
+	args := make([]string, len(o.Args))
+	copy(args, o.Args)
+	// args for kcExecOptions MUST be in such formart:
+	// [podName, COMMAND...]
+	args[0] = podName
+	return o.kcExecOptions.Complete(o.f, o.Cmd, args, 1)
+}
+
+func (o *VelaExecOptions) askComponent() (string, error) {
+	comps := o.App.GetComponents()
+	if len(comps) == 1 {
+		return comps[0], nil
+	}
+	prompt := &survey.Select{
+		Message: "You have multiple Components in your app. Please choose one component for logs: ",
+		Options: comps,
+	}
+	var compName string
+	err := survey.AskOne(prompt, &compName)
+	if err != nil {
+		return "", fmt.Errorf("choosing component name err %v", err)
+	}
+	return compName, nil
+}
+
+func (o *VelaExecOptions) getPodName(compName string) (string, error) {
+	podList, err := o.ClientSet.CoreV1().Pods(o.Env.Namespace).List(o.Context, v1.ListOptions{
+		LabelSelector: labels.Set(map[string]string{
+			//TODO(roywang) except core workloads, not any workloads will pass these label to pod
+			// find a rigorous way to get pod by compname
+			oam.LabelAppName:      o.App.Name,
+			oam.LabelAppComponent: compName,
+		}).String(),
+	})
+	if err != nil {
+		return "", nil
+	}
+	if podList != nil && len(podList.Items) == 0 {
+		return "", fmt.Errorf("cannot get pods")
+	}
+	for _, p := range podList.Items {
+		if strings.HasPrefix(p.Name, compName+"-") {
+			return p.Name, nil
+		}
+	}
+	// if no pod with name matched prefix as component name
+	// just return the first one
+	return podList.Items[0].Name, nil
+}
+
+func (o *VelaExecOptions) Run() error {
+	return o.kcExecOptions.Run()
+}

--- a/pkg/commands/exec_test.go
+++ b/pkg/commands/exec_test.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
+	"github.com/oam-dev/kubevela/api/types"
+	"github.com/oam-dev/kubevela/pkg/appfile"
+	"github.com/oam-dev/kubevela/pkg/application"
+	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubectl/pkg/cmd/exec"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func TestExecCommand(t *testing.T) {
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+	io := cmdutil.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	fakeC := types.Args{
+		Config: tf.ClientConfigVal,
+	}
+	cmd := NewExecCommand(fakeC, io)
+	cmd.PersistentFlags().StringP("env", "e", "", "")
+	o := &VelaExecOptions{
+		kcExecOptions: &exec.ExecOptions{},
+		f:             tf,
+		ClientSet: fake.NewSimpleClientset(&corev1.PodList{
+			Items: []corev1.Pod{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "fakePod",
+						Namespace: "default",
+						Labels: map[string]string{
+							oam.LabelAppName:      "fakeApp",
+							oam.LabelAppComponent: "fakeComp",
+						}},
+				},
+			},
+		}),
+	}
+	err := o.Init(context.Background(), cmd, []string{"fakeApp"})
+	assert.NoError(t, err)
+	fakeApp := &application.Application{
+		AppFile: &appfile.AppFile{
+			Name: "fakeApp",
+			Services: map[string]appfile.Service{
+				"fakeComp": map[string]interface{}{},
+			},
+		},
+	}
+	o.App = fakeApp
+	err = o.Complete()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
to fix #171 
`vela exec` reused core functions of `kubectl exec` but doesn't accept global flags of `kubectl options`,e.g., --namespace, because those args are from vela env.

screenshot
![image](https://user-images.githubusercontent.com/5107364/97021955-7d7fd100-158e-11eb-8fec-38fcc57be478.png)

![image](https://user-images.githubusercontent.com/5107364/97021815-48737e80-158e-11eb-915d-797eb042f8e1.png)


Signed-off-by: roy wang <seiwy2010@gmail.com>