### PR TITLE
fix getting CUE template from remote

### DIFF
--- a/pkg/plugins/cluster.go
+++ b/pkg/plugins/cluster.go
@@ -132,6 +132,7 @@ func HandleTemplate(in *runtime.RawExtension, name, syncDir string) (types.Capab
 			return types.Capability{}, err
 		}
 		cueTemplate = string(b)
+		tmp.CueTemplate = cueTemplate
 	} else {
 		if tmp.CueTemplate == "" {
 			return types.Capability{}, errors.New("template not exist in definition")

--- a/pkg/plugins/cluster_test.go
+++ b/pkg/plugins/cluster_test.go
@@ -107,6 +107,9 @@ var _ = Describe("DefinitionFiles", func() {
 		Expect(err).Should(BeNil())
 		logf.Log.Info(fmt.Sprintf("Getting trait definitions %v", traitDefs))
 		for i := range traitDefs {
+			// CueTemplate should always be fulfilled, even those whose CueTemplateURI is assigend,
+			By("check CueTemplate is fulfilled")
+			Expect(traitDefs[i].CueTemplate).ShouldNot(BeEmpty())
 			traitDefs[i].CueTemplate = ""
 			traitDefs[i].DefinitionPath = ""
 		}
@@ -120,6 +123,9 @@ var _ = Describe("DefinitionFiles", func() {
 		Expect(err).Should(BeNil())
 		logf.Log.Info(fmt.Sprintf("Getting workload definitions  %v", workloadDefs))
 		for i := range workloadDefs {
+			// CueTemplate should always be fulfilled, even those whose CueTemplateURI is assigend,
+			By("check CueTemplate is fulfilled")
+			Expect(workloadDefs[i].CueTemplate).ShouldNot(BeEmpty())
 			workloadDefs[i].CueTemplate = ""
 			workloadDefs[i].DefinitionPath = ""
 		}


### PR DESCRIPTION
If CueTemplateURI is assigned in workload/trait definition, while `vela system update`, before this fix, it will fetch the cue template through URI and save it as $VELA_HOME/capabilities/*.cue but not fulfill the template content into CueTemplate field.  Empty CueTemplate field will result in Appfile RenderService error.

Signed-off-by: roy wang <seiwy2010@gmail.com>