### PR TITLE
change term "component" to "service" in commands 

### DIFF
--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -21,13 +21,13 @@ var _ = ginkgo.Describe("Application", func() {
 	e2e.DeleteEnvFunc("env delete", envName)
 	e2e.EnvInitContext("env init", envName)
 	e2e.EnvSetContext("env set", envName)
-	e2e.WorkloadRunContext("deploy", fmt.Sprintf("vela comp deploy -t %s %s -p 80 --image nginx:1.9.4",
+	e2e.WorkloadRunContext("deploy", fmt.Sprintf("vela svc deploy -t %s %s -p 80 --image nginx:1.9.4",
 		workloadType, applicationName))
-	e2e.ComponentListContext("comp ls", applicationName, "")
+	e2e.ComponentListContext("svc ls", applicationName, "")
 	e2e.TraitManualScalerAttachContext("vela attach scaler trait", traitAlias, applicationName)
 	e2e.ApplicationShowContext("app show", applicationName, workloadType)
 	e2e.ApplicationStatusContext("app status", applicationName, workloadType)
-	e2e.ApplicationCompStatusContext("comp status", applicationName, workloadType, envName)
+	e2e.ApplicationCompStatusContext("svc status", applicationName, workloadType, envName)
 	e2e.ApplicationExecContext("exec -- COMMAND", applicationName)
 	e2e.ApplicationInitIntercativeCliContext("init", appNameForInit, workloadType)
 	e2e.WorkloadDeleteContext("delete", applicationName)

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -130,7 +130,7 @@ var (
 		})
 	}
 
-	//WorkloadRunContext used for test vela comp deploy
+	//WorkloadRunContext used for test vela svc deploy
 	WorkloadRunContext = func(context string, cli string) bool {
 		return ginkgo.Context(context, func() {
 			ginkgo.It("should print successful creation information", func() {
@@ -165,11 +165,11 @@ var (
 		})
 	}
 
-	// ComponentListContext used for test vela comp ls
+	// ComponentListContext used for test vela svc ls
 	ComponentListContext = func(context string, applicationName string, traitAlias string) bool {
 		return ginkgo.Context("ls", func() {
 			ginkgo.It("should list all applications", func() {
-				output, err := Exec("vela comp ls")
+				output, err := Exec("vela svc ls")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(output).To(gomega.ContainSubstring("NAME"))
 				gomega.Expect(output).To(gomega.ContainSubstring(applicationName))
@@ -194,7 +194,7 @@ var (
 
 	ApplicationCompStatusContext = func(context string, applicationName, workloadType, envName string) bool {
 		return ginkgo.Context(context, func() {
-			ginkgo.It("should get status for the component", func() {
+			ginkgo.It("should get status of the service", func() {
 				ginkgo.By("init new k8s client")
 				k8sclient, err := newK8sClient()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -206,7 +206,7 @@ var (
 					return len(appConfig.Status.Workloads)
 				}, 90*time.Second, 1*time.Second).ShouldNot(gomega.Equal(0))
 
-				cli := fmt.Sprintf("vela comp status %s", applicationName)
+				cli := fmt.Sprintf("vela svc status %s", applicationName)
 				output, err := LongTimeExec(cli, 120*time.Second)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(output).To(gomega.ContainSubstring("Checking health status"))

--- a/e2e/trait/trait_test.go
+++ b/e2e/trait/trait_test.go
@@ -21,7 +21,7 @@ var _ = ginkgo.Describe("Trait", func() {
 	e2e.RefreshContext("refresh")
 	e2e.EnvInitContext("env init", envName)
 	e2e.EnvSetContext("env set", envName)
-	e2e.WorkloadRunContext("deploy", fmt.Sprintf("vela comp deploy -t webservice %s -p 80 --image nginx:1.9.4", applicationName))
+	e2e.WorkloadRunContext("deploy", fmt.Sprintf("vela svc deploy -t webservice %s -p 80 --image nginx:1.9.4", applicationName))
 
 	e2e.TraitManualScalerAttachContext("vela attach trait", traitAlias, applicationName)
 

--- a/e2e/workload/workload_test.go
+++ b/e2e/workload/workload_test.go
@@ -18,11 +18,11 @@ var _ = ginkgo.Describe("Workload", func() {
 	e2e.RefreshContext("refresh")
 	e2e.EnvInitContext("env init", envName)
 	e2e.EnvSetContext("env set", envName)
-	e2e.WorkloadRunContext("deploy", fmt.Sprintf("vela comp deploy -t webservice %s -p 80 --image nginx:1.9.4", applicationName))
+	e2e.WorkloadRunContext("deploy", fmt.Sprintf("vela svc deploy -t webservice %s -p 80 --image nginx:1.9.4", applicationName))
 
 	ginkgo.Context("run without enough flags", func() {
 		ginkgo.It("should throw error message: some flags are NOT set", func() {
-			cli := fmt.Sprintf("vela comp deploy -t webservice %s -p 80", notEnoughFlagsApplicationName)
+			cli := fmt.Sprintf("vela svc deploy -t webservice %s -p 80", notEnoughFlagsApplicationName)
 			output, err := e2e.Exec(cli)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(output).To(gomega.ContainSubstring("required flag(s) \"image\" not set"))

--- a/pkg/commands/comp.go
+++ b/pkg/commands/comp.go
@@ -30,15 +30,15 @@ func newRunOptions(ioStreams util.IOStreams) *runOptions {
 
 func AddCompCommands(c types.Args, ioStreams util.IOStreams) *cobra.Command {
 	compCommands := &cobra.Command{
-		Use:                   "comp",
+		Use:                   "svc",
 		DisableFlagsInUseLine: true,
-		Short:                 "Manage Components",
-		Long:                  "Manage Components",
+		Short:                 "Manage services",
+		Long:                  "Manage services",
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeApp,
 		},
 	}
-	compCommands.PersistentFlags().StringP(App, "a", "", "specify application name for component")
+	compCommands.PersistentFlags().StringP(App, "a", "", "specify the name of application containing the services")
 
 	compCommands.AddCommand(
 		NewCompListCommand(c, ioStreams),
@@ -56,9 +56,9 @@ func NewCompDeployCommands(c types.Args, ioStreams util.IOStreams) *cobra.Comman
 		DisableFlagsInUseLine: true,
 		// Dynamic flag parse in compeletion
 		DisableFlagParsing: true,
-		Short:              "Init and Run workloads",
-		Long:               "Init and Run workloads",
-		Example:            "vela comp deploy -t <workload-type>",
+		Short:              "Initialize and run a service",
+		Long:               "Initialize and run a service. The app name would be the same as service name, if it's not specified.",
+		Example:            "vela svc deploy -t <SERVICE_TYPE>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "-h" {
 				err := cmd.Help()
@@ -89,7 +89,7 @@ func NewCompDeployCommands(c types.Args, ioStreams util.IOStreams) *cobra.Comman
 	runCmd.SetOut(ioStreams.Out)
 
 	runCmd.Flags().BoolP(Staging, "s", false, "only save changes locally without real update application")
-	runCmd.Flags().StringP(WorkloadType, "t", "", "specify workload type for application")
+	runCmd.Flags().StringP(WorkloadType, "t", "", "specify workload type of the service")
 
 	return runCmd
 }
@@ -97,7 +97,7 @@ func NewCompDeployCommands(c types.Args, ioStreams util.IOStreams) *cobra.Comman
 func GetWorkloadNameFromArgs(args []string) (string, error) {
 	argsLength := len(args)
 	if argsLength < 1 {
-		return "", errors.New("must specify name for component")
+		return "", errors.New("must specify the name of service")
 	}
 	return args[0], nil
 
@@ -137,7 +137,7 @@ func (o *runOptions) Complete(cmd *cobra.Command, args []string) error {
 		}
 		errMsg := "can not find workload, check workloads by `vela workloads` and choose a suitable one."
 		if workloadList != nil {
-			errMsg = fmt.Sprintf("must specify type of workload, please use `-t` and choose from %v.", workloadList)
+			errMsg = fmt.Sprintf("must specify the workload type of service, please use `-t` and choose from %v.", workloadList)
 		}
 		return errors.New(errMsg)
 	}

--- a/pkg/commands/delete.go
+++ b/pkg/commands/delete.go
@@ -60,14 +60,14 @@ func NewDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 // NewCompDeleteCommand delete component
 func NewCompDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "delete <ComponentName>",
+		Use:                   "delete <SERVICE_NAME>",
 		DisableFlagsInUseLine: true,
-		Short:                 "Delete Component From Application",
-		Long:                  "Delete Component From Application",
+		Short:                 "Delete a service from an application",
+		Long:                  "Delete a service from an application",
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeApp,
 		},
-		Example: "vela comp delete frontend",
+		Example: "vela svc delete frontend",
 	}
 	cmd.SetOut(ioStreams.Out)
 
@@ -83,7 +83,7 @@ func NewCompDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comm
 			return err
 		}
 		if len(args) < 1 {
-			return errors.New("must specify name for the component")
+			return errors.New("must specify the service name")
 		}
 		o.CompName = args[0]
 		appName, err := cmd.Flags().GetString(App)
@@ -96,7 +96,7 @@ func NewCompDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comm
 			o.AppName = o.CompName
 		}
 
-		ioStreams.Infof("Deleting Component '%s' from Application '%s'\n", o.CompName, o.AppName)
+		ioStreams.Infof("Deleting service '%s' from Application '%s'\n", o.CompName, o.AppName)
 		message, err := o.DeleteComponent(ioStreams)
 		if err != nil {
 			return err

--- a/pkg/commands/exec.go
+++ b/pkg/commands/exec.go
@@ -61,7 +61,7 @@ func NewExecCommand(c types.Args, ioStreams velacmdutil.IOStreams) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "exec [flags] AppName -- COMMAND [args...]",
 		Short: "Execute a command in a container",
-		Long:  "Execute a command in the 1st container of specific Application => Component => (1st)Pod",
+		Long:  "Execute a command in the 1st container of specific Application => Service => (1st)Pod",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				ioStreams.Error("Please specify an application name.")

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -147,7 +147,7 @@ func (o *appInitOptions) Workload() error {
 		workloadList = append(workloadList, w.Name)
 	}
 	prompt := &survey.Select{
-		Message: "Choose an workload for your component: ",
+		Message: "Choose workload type for your service: ",
 		Options: workloadList,
 	}
 	err = survey.AskOne(prompt, &o.workloadType)

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -64,9 +64,9 @@ func NewCompListCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comman
 		Use:                   "ls",
 		Aliases:               []string{"list"},
 		DisableFlagsInUseLine: true,
-		Short:                 "List components",
-		Long:                  "List components with its application, workloads, traits, status and created time",
-		Example:               `vela comp ls`,
+		Short:                 "List services",
+		Long:                  "List services with their application, type, traits, status and created time, etc.",
+		Example:               `vela svc ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			env, err := GetEnv(cmd)
 			if err != nil {
@@ -96,12 +96,12 @@ func printComponentList(ctx context.Context, c client.Client, appName string, en
 		Namespace: env.Namespace,
 	})
 	if err != nil {
-		ioStreams.Infof("listing Components: %s\n", err)
+		ioStreams.Infof("listing services: %s\n", err)
 		return
 	}
 	all := mergeStagingComponents(deployedComponentList, env, ioStreams)
 	table := uitable.New()
-	table.AddRow("NAME", "APP", "WORKLOAD", "TRAITS", "STATUS", "CREATED-TIME")
+	table.AddRow("NAME", "APP", "TYPE", "TRAITS", "STATUS", "CREATED-TIME")
 	for _, a := range all {
 		traitAlias := strings.Join(a.TraitNames, ",")
 		table.AddRow(a.Name, a.App, a.WorkloadName, traitAlias, a.Status, a.CreatedTime)

--- a/pkg/commands/show.go
+++ b/pkg/commands/show.go
@@ -69,7 +69,7 @@ func showApplication(cmd *cobra.Command, env *types.EnvMeta, appName string) err
 	cmd.Println()
 
 	table = uitable.New()
-	cmd.Printf("Components:\n\n")
+	cmd.Printf("Services:\n\n")
 
 	table.AddRow("  Name", "Type", "Traits")
 
@@ -89,14 +89,14 @@ func showApplication(cmd *cobra.Command, env *types.EnvMeta, appName string) err
 
 func NewCompShowCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "show <COMPONENT-NAME>",
-		Short:   "get component detail",
-		Long:    "get component detail, including arguments of workload and trait",
-		Example: `vela comp show <COMPONENT-NAME>`,
+		Use:     "show <SERVICE_NAME>",
+		Short:   "show service details",
+		Long:    "show service details, including arguments of workload and traits",
+		Example: `vela svc show <SERVICE_NAME>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLength := len(args)
 			if argsLength == 0 {
-				ioStreams.Errorf("Hint: please specify the application name\n")
+				ioStreams.Errorf("Hint: please specify the service name\n")
 				os.Exit(1)
 			}
 			compName := args[0]

--- a/pkg/commands/trait.go
+++ b/pkg/commands/trait.go
@@ -80,7 +80,7 @@ func AddTraitCommands(parentCmd *cobra.Command, c types.Args, ioStreams cmdutil.
 		}
 		pluginCmd.Flags().StringP(Service, "", "", "specify one service belonging to the application")
 		pluginCmd.Flags().BoolP(Staging, "s", false, "only save changes locally without real update application")
-		pluginCmd.Flags().BoolP(TraitDetach, "", false, "detach trait from component")
+		pluginCmd.Flags().BoolP(TraitDetach, "", false, "detach trait from service")
 
 		parentCmd.AddCommand(pluginCmd)
 	}

--- a/pkg/commands/up.go
+++ b/pkg/commands/up.go
@@ -118,7 +118,7 @@ func (o *appfileOptions) Run(filePath string) error {
 		}
 		b, err := yaml.Marshal(comp)
 		if err != nil {
-			return fmt.Errorf("marshal Component (%s) failed: %w", comp.Name, err)
+			return fmt.Errorf("marshal service (%s) failed: %w", comp.Name, err)
 		}
 		cfg.Write(b)
 		cfg.WriteByte('\n')

--- a/pkg/commands/util/helpers.go
+++ b/pkg/commands/util/helpers.go
@@ -183,7 +183,7 @@ func AskToChooseOneService(svcNames []string) (string, error) {
 		return svcNames[0], nil
 	}
 	prompt := &survey.Select{
-		Message: "You have multiple Services in your app. Please choose one Service: ",
+		Message: "You have multiple services in your app. Please choose one service: ",
 		Options: svcNames,
 	}
 	var svcName string


### PR DESCRIPTION
related to #412 
This PR changed term "component" in CLI (usage and outputs) to "service". 

Signed-off-by: roy wang <seiwy2010@gmail.com>