### PR TITLE
Fix vela install to include all dependencies

### DIFF
--- a/charts/vela-core/templates/velaConfig.yaml
+++ b/charts/vela-core/templates/velaConfig.yaml
@@ -26,5 +26,21 @@ data:
       "urL": "https://kedacore.github.io/charts",
       "name": "keda",
       "namespace": "vela-system",
-      "version": "2.0.0-rc2"
+      "version": "1.5.0"
+    }
+  ingresses.networking.k8s.io: |
+    {
+      "repo": "ingress-nginx",
+      "urL": "https://kubernetes.github.io/ingress-nginx",
+      "name": "ingress-nginx",
+      "namespace": "vela-system",
+      "version": "3.7.1"
+    }
+  flagger.app: |
+    {
+      "repo": "flagger",
+      "urL": "https://flagger.app",
+      "name": "flagger",
+      "namespace": "vela-system",
+      "version": "1.2.0"
     }

--- a/charts/vela-core/templates/velaConfig.yaml
+++ b/charts/vela-core/templates/velaConfig.yaml
@@ -12,6 +12,14 @@ data:
       "namespace": "cert-manager",
       "version": "1.0.3"
     }
+  grafana: |
+    {
+      "repo": "grafana",
+      "urL": "https://grafana.github.io/helm-charts",
+      "name": "grafana",
+      "namespace": "monitoring",
+      "version": "6.0.1"
+    }
   servicemonitors.monitoring.coreos.com: |
     {
       "repo": "prometheus-community",
@@ -19,14 +27,6 @@ data:
       "name": "kube-prometheus-stack",
       "namespace": "monitoring",
       "version": "9.4.4"
-    }
-  scaledobjects.keda.sh: |
-    {
-      "repo": "kedacore",
-      "urL": "https://kedacore.github.io/charts",
-      "name": "keda",
-      "namespace": "vela-system",
-      "version": "1.5.0"
     }
   ingresses.networking.k8s.io: |
     {

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -114,10 +114,7 @@ func main() {
 		setupLog.Error(err, "unable to create a kubernetes client")
 		os.Exit(1)
 	}
-	if err = dependency.Install(k8sClient); err != nil {
-		setupLog.Error(err, "unable to install the dependency")
-		os.Exit(1)
-	}
+	go dependency.Install(k8sClient)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"time"
 
 	monitoring "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -16,6 +18,7 @@ import (
 	oamcontroller "github.com/crossplane/oam-kubernetes-runtime/pkg/controller"
 	oamv1alpha2 "github.com/crossplane/oam-kubernetes-runtime/pkg/controller/v1alpha2"
 	oamwebhook "github.com/crossplane/oam-kubernetes-runtime/pkg/webhook/v1alpha2"
+	"github.com/go-logr/logr"
 	injectorv1alpha1 "github.com/oam-dev/trait-injector/api/v1alpha1"
 	injectorcontroller "github.com/oam-dev/trait-injector/controllers"
 	"github.com/oam-dev/trait-injector/pkg/injector"
@@ -177,10 +180,11 @@ func main() {
 	}
 
 	setupLog.Info("starting the vela controller manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(makeSignalHandler(setupLog, k8sClient)); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+	setupLog.Info("program safely stops...")
 }
 
 // registerHealthChecks is used to create readiness&liveness probes
@@ -228,4 +232,23 @@ func waitWebhookSecretVolume(certDir string, timeout, interval time.Duration) er
 			}
 		}
 	}
+}
+
+func makeSignalHandler(log logr.Logger, kubecli client.Client) (stopCh <-chan struct{}) {
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-c
+		dependency.Uninstall(kubecli)
+		close(stop)
+
+		// second signal. Exit directly.
+		<-c
+		os.Exit(1)
+	}()
+
+	return stop
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,10 +26,13 @@ $ sudo mv ./vela /usr/local/bin/vela
 
 ## Initialize KubeVela
 
+Run:
+
 ```console
-$ vela install
+vela install
 ```
-This command will install KubeVela server components in your Kubernetes cluster.
+
+This will install KubeVela server component and its dependency components.
 
 ## Verify
 
@@ -42,17 +45,12 @@ This command will install KubeVela server components in your Kubernetes cluster.
 
 ## Clean Up
 
-```console
-$ helm uninstall kubevela -n vela-system
-release "kubevela" uninstalled
-```
+Run:
 
 ```console
-$ kubectl delete crd workloaddefinitions.core.oam.dev traitdefinitions.core.oam.dev  scopedefinitions.core.oam.dev
-customresourcedefinition.apiextensions.k8s.io "workloaddefinitions.core.oam.dev" deleted
-customresourcedefinition.apiextensions.k8s.io "traitdefinitions.core.oam.dev" deleted
+helm uninstall -n vela-system kubevela
+rm -r ~/.vela
 ```
 
-```console
-$ rm -r ~/.vela
-```
+This will uninstall KubeVela server component and its dependency components.
+This also cleans up local CLI cache.

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,28 +29,84 @@ $ sudo mv ./vela /usr/local/bin/vela
 Run:
 
 ```console
-vela install
+$ vela install
 ```
 
 This will install KubeVela server component and its dependency components.
 
 ## Verify
 
-> TODO Paste a output of successful installation here.
+Check Vela Helm Chart has been installed:
+```
+$ helm list -n vela-system
+NAME    	NAMESPACE  	REVISION	...
+kubevela	vela-system	1       	...
+```
+
+Later on, check that the dependency components has been installed:
+```
+$ helm list --all-namespaces
+NAME                 	NAMESPACE   	REVISION	...
+cert-manager         	cert-manager	1       	...
+flagger              	vela-system 	1
+ingress-nginx        	vela-system 	1
+kube-prometheus-stack	monitoring  	1
+grafana              	monitoring  	1
+...
+```
 
 ## Dependencies
 
-> TODO Describe how vela install handle Prometheus & Grafana, Flagger and KEDA, and what if user want to replace them with his own version. (It's fine to say KEDA, Flagger is a temporary fork and we will ship the fixes to upstreams very soon)
+We have installed the following dependency components along with Vela server component:
 
+- [Prometheus](https://prometheus-community.github.io/helm-charts/) & [Grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana)
+- [Cert-manager](https://cert-manager.io/)
+- [Ingress-nginx](https://github.com/kubernetes/ingress-nginx/)
+- [Flagger](https://flagger.app/)
+
+The config has been saved in a ConfigMap in "vela-system/vela-config":
+
+```
+$ kubectl -n vela-system get cm vela-config -o yaml
+apiVersion: v1
+data:
+  certificates.cert-manager.io: |
+    {
+      "repo": "jetstack",
+      "urL": "https://charts.jetstack.io",
+      "name": "cert-manager",
+      "namespace": "cert-manager",
+      "version": "1.0.3"
+    }
+  flagger.app: |
+  ...
+kind: ConfigMap
+```
+
+User can specify their own dependencies by editing the `vela-config` ConfigMap.
+Currently adding new chart or updating existing chart requires redeploying Vela:
+```
+$ kubectl -n vela-system edit cm vela-config
+...
+
+$ helm uninstall -n vela-system kubevela
+$ helm install -n vela-system kubevela
+```
 
 ## Clean Up
 
 Run:
 
 ```console
-helm uninstall -n vela-system kubevela
-rm -r ~/.vela
+$ helm uninstall -n vela-system kubevela
+$ rm -r ~/.vela
 ```
 
 This will uninstall KubeVela server component and its dependency components.
 This also cleans up local CLI cache.
+
+Then clean up CRDs:
+
+```
+$ kubectl delete crd workloaddefinitions.core.oam.dev traitdefinitions.core.oam.dev  scopedefinitions.core.oam.dev
+```

--- a/pkg/commands/dashboard.go
+++ b/pkg/commands/dashboard.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/oam-dev/kubevela/api/types"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
-	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/server"
 	"github.com/oam-dev/kubevela/pkg/server/util"
+	"github.com/oam-dev/kubevela/pkg/utils/helm"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
 
 	"github.com/mholt/archiver/v3"
@@ -198,7 +198,7 @@ func OpenBrowser(url string) error {
 }
 
 func CheckVelaRuntimeInstalledAndReady(ioStreams cmdutil.IOStreams, c client.Client) (bool, error) {
-	if !oam.IsHelmReleaseRunning(types.DefaultOAMReleaseName, types.DefaultOAMRuntimeChartName, ioStreams) {
+	if !helm.IsHelmReleaseRunning(types.DefaultOAMReleaseName, types.DefaultOAMRuntimeChartName, types.DefaultOAMNS, ioStreams) {
 		ioStreams.Info(fmt.Sprintf("\n%s %s", emojiFail, "KubeVela runtime is not installed yet."))
 		ioStreams.Info(fmt.Sprintf("\n%s %s%s or %s",
 			emojiLightBulb,

--- a/pkg/commands/util/init.go
+++ b/pkg/commands/util/init.go
@@ -49,10 +49,7 @@ func DoesNamespaceExist(c client.Client, namespace string) (bool, error) {
 	var ns corev1.Namespace
 	err := c.Get(context.Background(), types.NamespacedName{Name: namespace}, &ns)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
+		return false, client.IgnoreNotFound(err)
 	}
 	return true, nil
 }

--- a/pkg/controller/dependency/install_test.go
+++ b/pkg/controller/dependency/install_test.go
@@ -59,7 +59,7 @@ func TestSuccessfulInstall(t *testing.T) {
 		},
 	}
 	client := fake.NewFakeClientWithScheme(scheme, velaConfig, &crd)
-	if err := Install(client); err != nil {
+	if err := installHelmChart(client, []byte("{}"), log); err != nil {
 		t.Errorf("failed to install dependency error: %v", err)
 	}
 }
@@ -68,28 +68,8 @@ func TestFailedInstall(t *testing.T) {
 	helmInstallFunc = failedHelmInstall
 	velaConfig := velaConfigBase.DeepCopy()
 	client := fake.NewFakeClientWithScheme(scheme, velaConfig)
-	if err := Install(client); errors.Cause(err) != errHelm {
+	if err := installHelmChart(client, []byte("{}"), log); errors.Cause(err) != errHelm {
 		t.Errorf("failed to get install dependency error: %v", err)
-	}
-}
-
-func TestNoNeedToInstall(t *testing.T) {
-	// set it to fail as we won't get to it
-	helmInstallFunc = failedHelmInstall
-	velaConfig := velaConfigBase.DeepCopy()
-	certManagerCRD := crdv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "certificates.cert-manager.io",
-		},
-	}
-	prometheusCRD := crdv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "prometheuses.monitoring.coreos.com",
-		},
-	}
-	client := fake.NewFakeClientWithScheme(scheme, velaConfig, &certManagerCRD, &prometheusCRD)
-	if err := Install(client); err != nil {
-		t.Errorf("failed to install dependency error: %v", err)
 	}
 }
 

--- a/pkg/oam/capability.go
+++ b/pkg/oam/capability.go
@@ -20,6 +20,7 @@ import (
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 	"github.com/oam-dev/kubevela/pkg/plugins"
 	"github.com/oam-dev/kubevela/pkg/server/apis"
+	"github.com/oam-dev/kubevela/pkg/utils/helm"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
 )
 
@@ -161,7 +162,7 @@ func GetSyncedCapabilities(repoName, addonName string) (types.Capability, error)
 }
 
 func InstallHelmChart(ioStreams cmdutil.IOStreams, c types.Chart) error {
-	return HelmInstall(ioStreams, c.Repo, c.URL, c.Name, c.Version, c.Namespace, c.Name, nil)
+	return helm.Install(ioStreams, c.Repo, c.URL, c.Name, c.Version, c.Namespace, c.Name, nil)
 }
 
 func ListCapabilityCenters() ([]apis.CapabilityCenterMeta, error) {
@@ -253,7 +254,7 @@ func UninstallCap(client client.Client, cap types.Capability, ioStreams cmdutil.
 
 	if cap.Install != nil && cap.Install.Helm.Name != "" {
 		// 2. Remove Helm chart if there is
-		if err := HelmUninstall(ioStreams, cap.Install.Helm.Name, cap.Name); err != nil {
+		if err := helm.Uninstall(ioStreams, cap.Install.Helm.Name, types.DefaultOAMNS, cap.Name); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
ref https://github.com/oam-dev/kubevela/issues/441#issuecomment-716862454

Currently vela core server relies on CRD to install dependency components. But it doesn't work for ingress, doesn't update more dependencies over time, and doesn't uninstall them.

This PR rewrites server dependency component installation logic:

1. Don't rely on crd name. Continue installing all charts.
    ```
    NAME                 	NAMESPACE   	REVISION	UPDATED                                	STATUS  	CHART                      	APP VERSION
    cert-manager         	cert-manager	1       	2020-10-28 19:44:39.877674984 -0700 PDT	deployed	cert-manager-v1.0.3        	v1.0.3
    flagger              	vela-system 	1       	2020-10-28 19:47:21.716232979 -0700 PDT	deployed	flagger-1.2.0              	1.2.0
    ingress-nginx        	vela-system 	1       	2020-10-28 19:47:36.708763023 -0700 PDT	deployed	ingress-nginx-3.7.1        	0.40.2
    keda                 	vela-system 	1       	2020-10-28 19:53:28.220427379 -0700 PDT	deployed	keda-1.5.0                 	1.5.0
    kube-prometheus-stack	monitoring  	1       	2020-10-28 19:46:34.177159174 -0700 PDT	deployed	kube-prometheus-stack-9.4.4	0.38.1
    ```


2. Rewrite signal handler to uninstall dependencies before exiting.
    <img width="724" alt="D71D03F2-618C-47A3-91C2-4D2FD4332187" src="https://user-images.githubusercontent.com/920884/97519179-09f70e80-1956-11eb-92b1-f47adef92a20.png">


