### PR TITLE
[Feature #443] should report capability not exist instead of file not found

### DIFF
--- a/pkg/appfile/service.go
+++ b/pkg/appfile/service.go
@@ -104,7 +104,7 @@ func (s Service) RenderService(tm template.Manager, name, ns string, cg configGe
 		}
 		ctxData["config"] = data
 	}
-	u, err := evalComponent(tm.LoadTemplate(wtype), ctxData, intifyValues(workloadKeys))
+	u, err := evalComponent(tm, wtype, ctxData, intifyValues(workloadKeys))
 	if err != nil {
 		return nil, nil, fmt.Errorf("eval service failed: %w", err)
 	}
@@ -240,8 +240,12 @@ func renderAllOutputs(field cue.FieldInfo) ([]*unstructured.Unstructured, error)
 	return us, nil
 }
 
-func evalComponent(raw string, ctxValues, userValues interface{}) (*unstructured.Unstructured, error) {
-	appValue, err := getValueStruct(raw, ctxValues, userValues)
+func evalComponent(tm template.Manager, wtype string, ctxValues, userValues interface{}) (*unstructured.Unstructured, error) {
+	workloadCueTemplate := tm.LoadTemplate(wtype)
+	if workloadCueTemplate == "" {
+		return nil, fmt.Errorf("capability %s unexist", wtype)
+	}
+	appValue, err := getValueStruct(workloadCueTemplate, ctxValues, userValues)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Example:
```
version: "1.0-alpha.1"
name: test1
secrets: {}
services:
  hello:
    image: nginx:latest
    name: hello
    port: 80
    route:
      domain: hello.y
      issuer: oam-env-default
    type: webservice1
```

Error: eval service failed: capability webservice1 unexist