### PR TITLE
fix check route status when using local kind

### DIFF
--- a/pkg/controller/v1alpha1/routes/ingress/nginx_ingress.go
+++ b/pkg/controller/v1alpha1/routes/ingress/nginx_ingress.go
@@ -88,10 +88,10 @@ func (n *Nginx) CheckStatus(routeTrait *standardv1alpha1.Route) (string, []runti
 				Message: err.Error()}}
 		}
 		ingressvalue := ingress.Status.LoadBalancer.Ingress
-		if len(ingressvalue) < 1 || ingressvalue[0].IP == "" {
+		if len(ingressvalue) < 1 || (ingressvalue[0].IP == "" && ingressvalue[0].Hostname == "") {
 			return StatusSynced, []runtimev1alpha1.Condition{{Type: runtimev1alpha1.TypeSynced,
 				Status: v1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: runtimev1alpha1.ReasonCreating,
-				Message: fmt.Sprintf("IP of %s ingress is generating", in.Name)}}
+				Message: fmt.Sprintf("IP/Hostname of %s ingress is generating", in.Name)}}
 		}
 	}
 	return StatusReady, []runtimev1alpha1.Condition{{Type: runtimev1alpha1.TypeReady, Status: v1.ConditionTrue,

--- a/pkg/oam/trait_checker.go
+++ b/pkg/oam/trait_checker.go
@@ -96,7 +96,11 @@ func (d *RouteChecker) Check(ctx context.Context, reference runtimev1alpha1.Type
 		} else {
 			url = "http://" + in.Spec.Rules[0].Host
 		}
-		message += fmt.Sprintf("\tVisiting URL: %s\tIP: %s\n", url, value[0].IP)
+		addr := value[0].IP
+		if value[0].Hostname != "" {
+			addr = value[0].Hostname
+		}
+		message += fmt.Sprintf("\tVisiting URL: %s\tIP: %s\n", url, addr)
 	}
 	return StatusDone, message, nil
 }


### PR DESCRIPTION
Local kind cluster ingress will have hostname not IP.
`vela svc status` will complain with error. With this fix it will be fine:

```
	route: 	Visiting URL: http://example.com	IP: localhost
```