### PR TITLE
Fix `charts/vela-core/crds/_.yaml` generation issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,6 @@ core-uninstall: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=charts/vela-core/crds
-	rm charts/vela-core/crds/_.yaml
 
 # Generate code
 generate: controller-gen

--- a/pkg/commands/show.go
+++ b/pkg/commands/show.go
@@ -10,7 +10,6 @@ import (
 	"github.com/oam-dev/kubevela/pkg/application"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewAppShowCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
@@ -42,15 +41,7 @@ func NewAppShowCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 	return cmd
 }
 
-type Unkown struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Spec              interface{} `json:"spec"`
-	Status            interface{} `json:"status"`
-}
-
 func showApplication(cmd *cobra.Command, env *types.EnvMeta, appName string) error {
-
 	app, err := application.Load(env.Name, appName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixed the issue of `charts/vela-core/crds/_.yaml` generation
by removing unkonwn struct in pkg/commands/show.go.