### PR TITLE
Logs need to be printed in real time when vela executes docker command

### DIFF
--- a/pkg/appfile/build.go
+++ b/pkg/appfile/build.go
@@ -1,7 +1,9 @@
 package appfile
 
 import (
+	"io"
 	"os/exec"
+	"strings"
 
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 )
@@ -21,11 +23,47 @@ type Push struct {
 	Registry string `json:"registry,omitempty"`
 }
 
+func asyncLog(reader io.ReadCloser, stream cmdutil.IOStreams) {
+	cache := ""
+	buf := make([]byte, 1024)
+	for {
+		num, err := reader.Read(buf)
+		if err != nil && err != io.EOF {
+			return
+		}
+		if num > 0 {
+			b := buf[:num]
+			s := strings.Split(string(b), "\n")
+			line := strings.Join(s[:len(s)-1], "\n")
+			stream.Infof("%s%s\n", cache, line)
+			cache = s[len(s)-1]
+		}
+		if err == io.EOF {
+			break
+		}
+	}
+}
+
 func (b *Build) BuildImage(io cmdutil.IOStreams, image string) error {
 	cmd := exec.Command("docker", "build", "-t", image, "-f", b.Docker.File, b.Docker.Context)
-	out, err := cmd.CombinedOutput()
-	io.Infof("%s\n", out)
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		io.Errorf("BuildImage exec command error, message:%s\n", err.Error())
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		io.Errorf("BuildImage exec command error, message:%s\n", err.Error())
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		io.Errorf("BuildImage exec command error, message:%s\n", err.Error())
+		return err
+	}
+	go asyncLog(stdout, io)
+	go asyncLog(stderr, io)
+	if err := cmd.Wait(); err != nil {
+		io.Errorf("BuildImage wait for command execution error:%s", err.Error())
 		return err
 	}
 	return b.pushImage(io, image)
@@ -33,17 +71,51 @@ func (b *Build) BuildImage(io cmdutil.IOStreams, image string) error {
 
 func (b *Build) pushImage(io cmdutil.IOStreams, image string) error {
 	io.Infof("pushing image (%s)...\n", image)
-
 	switch {
 	case b.Push.Local == "kind":
 		cmd := exec.Command("kind", "load", "docker-image", image)
-		out, err := cmd.CombinedOutput()
-		io.Infof("%s\n", out)
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			io.Errorf("pushImage(kind) exec command error, message:%s\n", err.Error())
+			return err
+		}
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			io.Errorf("pushImage(kind) exec command error, message:%s\n", err.Error())
+			return err
+		}
+		if err := cmd.Start(); err != nil {
+			io.Errorf("pushImage(kind) exec command error, message:%s\n", err.Error())
+			return err
+		}
+		go asyncLog(stdout, io)
+		go asyncLog(stderr, io)
+		if err := cmd.Wait(); err != nil {
+			io.Errorf("pushImage(kind) wait for command execution error:%s", err.Error())
+			return err
+		}
+		return nil
+	}
+	cmd := exec.Command("docker", "push", image)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		io.Errorf("pushImage(docker push) exec command error, message:%s\n", err.Error())
 		return err
 	}
-
-	cmd := exec.Command("docker", "push", image)
-	out, err := cmd.CombinedOutput()
-	io.Infof("%s\n", out)
-	return err
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		io.Errorf("pushImage(docker push) exec command error, message:%s\n", err.Error())
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		io.Errorf("pushImage(docker push) exec command error, message:%s\n", err.Error())
+		return err
+	}
+	go asyncLog(stdout, io)
+	go asyncLog(stderr, io)
+	if err := cmd.Wait(); err != nil {
+		io.Errorf("pushImage(docker push) wait for command execution error:%s", err.Error())
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
When executing commands such as docker build/push, logs are required to be printed to the console in real time.

Look at the following example:

```
 ✗ ./vela up -f vela.yaml
Parsing vela.yaml ...
Loading templates ...

Building service (express-server)...
Sending build context to Docker daemon   75.2MB
Step 1/10 : FROM mhart/alpine-node:12
 ---> 33d2f6886442
Step 2/10 : WORKDIR /app
 ---> Using cache
 ---> 71ec0bca7ec3
Step 3/10 : COPY package.json ./
 ---> Using cache
 ---> 0d308ba67e7f
Step 4/10 : RUN npm install
 ---> Using cache
 ---> 466b273990f8
Step 5/10 : RUN npm ci --prod
 ---> Using cache
 ---> 16d7da32a4b7

Step 6/10 : FROM mhart/alpine-node:slim-12
 ---> e60b0704d22a

Step 7/10 : WORKDIR /app
 ---> Using cache
 ---> 590136de0706

Step 8/10 : COPY --from=0 /app .
 ---> Using cache
 ---> 50ce30d5f7dc

Step 9/10 : COPY . .
 ---> 04c7ed952994
Step 10/10 : CMD ["node", "server.js"]
 ---> Running in a11fc9a92861
Removing intermediate container a11fc9a92861
 ---> 4fcebd1ac4ce
Successfully built 4fcebd1ac4ce
Successfully tagged testapp:v1
pushing image (testapp:v1)...
The push refers to repository [testapp]
71dbfcf3b91e: Preparing
59775910a717: Preparing
fa9616876c4d: Preparing
1c4fc89bcb75: Preparing
```