### PR TITLE
Some revisions for the printed out messages

### DIFF
--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -261,15 +261,15 @@ var (
 						q, a string
 					}{
 						{
-							q: "Do you want to setup a domain for web service: ",
+							q: "What is the domain of your application service (optional): ",
 							a: "testdomain",
 						},
 						{
-							q: "Provide an email for production certification: ",
+							q: "What is your email (optional, used to generate certification): ",
 							a: "test@mail",
 						},
 						{
-							q: "What would you like to name your application: ",
+							q: "What would you like to name your application (required): ",
 							a: appName,
 						},
 						{
@@ -277,7 +277,7 @@ var (
 							a: workloadType,
 						},
 						{
-							q: "What would you name this webservice: ",
+							q: "What would you like to name this webservice (required): ",
 							a: "mysvc",
 						},
 						{

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -56,7 +56,7 @@ func NewInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			o.IOStreams.Info("Welcome to use KubeVela CLI! We're going to help you run applications through a couple of questions.")
+			o.IOStreams.Info("Welcome to use KubeVela CLI! Please describe your applications.")
 			o.IOStreams.Info()
 			if err = o.CheckEnv(); err != nil {
 				return err
@@ -83,7 +83,7 @@ func NewInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			o.IOStreams.Info("\nRendered and written deployment config to " + color.New(color.FgCyan).Sprint("vela.yaml"))
+			o.IOStreams.Info("\nDeployment config is rendered and written to " + color.New(color.FgCyan).Sprint("vela.yaml"))
 
 			if o.renderOnly {
 				return nil
@@ -112,7 +112,7 @@ func NewInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 
 func (o *appInitOptions) Naming() error {
 	prompt := &survey.Input{
-		Message: "What would you like to name your application: ",
+		Message: "What would you like to name your application (required): ",
 	}
 	err := survey.AskOne(prompt, &o.appName)
 	if err != nil {
@@ -128,20 +128,20 @@ func (o *appInitOptions) CheckEnv() error {
 	o.Infof("Environment: %s, namespace: %s\n\n", o.Env.Name, o.Env.Namespace)
 	if o.Env.Domain == "" {
 		prompt := &survey.Input{
-			Message: "Do you want to setup a domain for web service: ",
+			Message: "What is the domain of your application service (optional): ",
 		}
 		err := survey.AskOne(prompt, &o.Env.Domain)
 		if err != nil {
-			return fmt.Errorf("read app name err %v", err)
+			return fmt.Errorf("read domain err %v", err)
 		}
 	}
 	if o.Env.Email == "" {
 		prompt := &survey.Input{
-			Message: "Provide an email for production certification: ",
+			Message: "What is your email (optional, used to generate certification): ",
 		}
 		err := survey.AskOne(prompt, &o.Env.Email)
 		if err != nil {
-			return fmt.Errorf("read app name err %v", err)
+			return fmt.Errorf("read email err %v", err)
 		}
 	}
 	if _, err := env.CreateOrUpdateEnv(context.Background(), o.client, o.Env.Name, o.Env); err != nil {
@@ -160,7 +160,7 @@ func (o *appInitOptions) Workload() error {
 		workloadList = append(workloadList, w.Name)
 	}
 	prompt := &survey.Select{
-		Message: "Choose workload type for your service: ",
+		Message: "Choose the workload type for your application (required, e.g., webservice): ",
 		Options: workloadList,
 	}
 	err = survey.AskOne(prompt, &o.workloadType)
@@ -172,11 +172,11 @@ func (o *appInitOptions) Workload() error {
 		return err
 	}
 	namePrompt := &survey.Input{
-		Message: fmt.Sprintf("What would you name this %s: ", o.workloadType),
+		Message: fmt.Sprintf("What would you like to name this %s (required): ", o.workloadType),
 	}
 	err = survey.AskOne(namePrompt, &o.workloadName)
 	if err != nil {
-		return fmt.Errorf("read name err %v", err)
+		return fmt.Errorf("read workload name err %v", err)
 	}
 	fs := pflag.NewFlagSet("workload", pflag.ContinueOnError)
 	for _, p := range workload.Parameters {

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -56,7 +56,7 @@ func NewInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			o.IOStreams.Info("Welcome to use KubeVela CLI! Please describe your applications.")
+			o.IOStreams.Info("Welcome to use KubeVela CLI! Please describe your application.")
 			o.IOStreams.Info()
 			if err = o.CheckEnv(); err != nil {
 				return err

--- a/pkg/commands/up.go
+++ b/pkg/commands/up.go
@@ -132,7 +132,7 @@ func (o *AppfileOptions) Run(filePath string) error {
 	}
 
 	deployFilePath := ".vela/deploy.yaml"
-	o.IO.Infof("writing deploy config to (%s)\n", deployFilePath)
+	o.IO.Infof("Writing deploy config to (%s)\n", deployFilePath)
 	if err := os.MkdirAll(filepath.Dir(deployFilePath), 0700); err != nil {
 		return err
 	}
@@ -168,9 +168,9 @@ func (o *AppfileOptions) ApplyAppConfig(ac *v1alpha2.ApplicationConfiguration, c
 	err := o.Kubecli.Get(context.TODO(), key, &tmpAC)
 	switch {
 	case apierrors.IsNotFound(err):
-		o.IO.Infof("app has not been deployed, creating a new deployment...\n")
+		o.IO.Infof("App has not been deployed, creating a new deployment...\n")
 	case err == nil:
-		o.IO.Infof("app existed, updating existing deployment...\n")
+		o.IO.Infof("App exists, updating existing deployment...\n")
 	default:
 		return err
 	}
@@ -195,7 +195,7 @@ func (o *AppfileOptions) apply(ac *v1alpha2.ApplicationConfiguration, comps []*v
 }
 
 func (o *AppfileOptions) Info(appName string, comps []*v1alpha2.Component) string {
-	var appUpMessage = "✅ app has been deployed 🚀🚀🚀\n" +
+	var appUpMessage = "✅ App has been deployed 🚀🚀🚀\n" +
 		fmt.Sprintf("    Port forward: vela port-forward %s\n", appName) +
 		fmt.Sprintf("             SSH: vela exec %s\n", appName) +
 		fmt.Sprintf("         Logging: vela logs %s\n", appName) +

--- a/pkg/commands/up_test.go
+++ b/pkg/commands/up_test.go
@@ -38,6 +38,6 @@ func TestUp(t *testing.T) {
 		},
 	}
 	msg := o.Info(appName, services)
-	assert.Contains(t, msg, "app has been deployed")
+	assert.Contains(t, msg, "App has been deployed")
 	assert.Contains(t, msg, fmt.Sprintf("App status: vela status %s", appName))
 }


### PR DESCRIPTION
I focus on the printed out messages in the quick start example. 

I wish to change  
 `specify app image` to `Specify application image`  
 `specify port for container` to `specify application service port` 
as well but this requires a lot of changes since the texts come from the workload definition. Hence, I omit them in this change.

