### PR TITLE
skip capability e2e due to rate limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ e2e-setup:
 
 e2e-test:
 	# Run e2e test
-	ginkgo -v -skipPackage setup,apiserver -r e2e
+	ginkgo -v -skipPackage capability,setup,apiserver -r e2e
 
 e2e-api-test:
 	# Run e2e test

--- a/e2e/capability/capability_test.go
+++ b/e2e/capability/capability_test.go
@@ -14,7 +14,7 @@ import (
 var (
 	capabilityCenterBasic = apis.CapabilityCenterMeta{
 		Name: "capability-center-e2e-basic",
-		URL:  "https://github.com/hongchaodeng/kubevela/tree/master/pkg/plugins/testdata",
+		URL:  "https://github.com/oam-dev/kubevela/tree/master/pkg/plugins/testdata",
 	}
 
 	scaleCapability = types.Capability{
@@ -27,6 +27,8 @@ var (
 		Type: types.TypeTrait,
 	}
 )
+
+// TODO: chagne this into a mock UT to avoid remote call.
 
 var _ = ginkgo.Describe("Capability", func() {
 	ginkgo.Context("capability center", func() {


### PR DESCRIPTION
plan to change e2e into a mock UT to avoid remote call.

Signed-off-by: Hongchao Deng <hongchaodeng1@gmail.com>