### PR TITLE
The return value of `vela ls` must contain the TYPE and TRAITS fields.

### DIFF
--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -23,8 +23,8 @@ var _ = ginkgo.Describe("Application", func() {
 	e2e.EnvSetContext("env set", envName)
 	e2e.WorkloadRunContext("deploy", fmt.Sprintf("vela svc deploy -t %s %s -p 80 --image nginx:1.9.4",
 		workloadType, applicationName))
-	e2e.ComponentListContext("ls", applicationName, "")
 	e2e.TraitManualScalerAttachContext("vela attach scaler trait", traitAlias, applicationName)
+	e2e.ComponentListContext("ls", applicationName, workloadType, traitAlias)
 	e2e.ApplicationShowContext("show", applicationName, workloadType)
 	e2e.ApplicationStatusContext("status", applicationName, workloadType)
 	e2e.ApplicationStatusDeeplyContext("status", applicationName, workloadType, envName)

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -184,13 +184,14 @@ var (
 	}
 
 	// ComponentListContext used for test vela svc ls
-	ComponentListContext = func(context string, applicationName string, traitAlias string) bool {
+	ComponentListContext = func(context string, applicationName string, workloadType string, traitAlias string) bool {
 		return ginkgo.Context("ls", func() {
 			ginkgo.It("should list all applications", func() {
 				output, err := Exec("vela ls")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(output).To(gomega.ContainSubstring("SERVICE"))
 				gomega.Expect(output).To(gomega.ContainSubstring(applicationName))
+				gomega.Expect(output).To(gomega.ContainSubstring(workloadType))
 				if traitAlias != "" {
 					gomega.Expect(output).To(gomega.ContainSubstring(traitAlias))
 				}

--- a/pkg/commands/exec.go
+++ b/pkg/commands/exec.go
@@ -69,7 +69,7 @@ func NewExecCommand(c types.Args, ioStreams velacmdutil.IOStreams) *cobra.Comman
 			}
 			argsLenAtDash := cmd.ArgsLenAtDash()
 			if argsLenAtDash != 1 {
-				ioStreams.Error("Please specify at least one commnad for the container.")
+				ioStreams.Error("Please specify at least one command for the container.")
 				return nil
 			}
 

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -100,6 +100,8 @@ func mergeStagingComponents(deployed []apis.ComponentMeta, env *types.EnvMeta, i
 				})
 				continue
 			}
+			compMeta.TraitNames = traits
+			compMeta.WorkloadName = app.AppFile.Services[c.Name].GetType()
 			cspec := c.Spec.DeepCopy()
 			cspec.Workload.Raw, _ = cspec.Workload.MarshalJSON()
 			cspec.Workload.Object = nil


### PR DESCRIPTION
before fixing:
```
➜  bin git:(master) ./vela ls
SERVICE             APP             TYPE    TRAITS  STATUS          CREATED-TIME                 
vela-go-demo    vela-demo                              Deployed        2020-11-05 11:47:50 +0800 CST

```
after fixing:
```
➜  bin git:(master) ./vela ls
SERVICE             APP                 TYPE                 TRAITS  STATUS          CREATED-TIME                 
vela-go-demo    vela-demo       webservice      route     Deployed        2020-11-05 11:47:50 +0800 CST
```