### PR TITLE
fix datarace for map

### DIFF
--- a/pkg/controller/v1alpha1/metrics/metricstrait_controller.go
+++ b/pkg/controller/v1alpha1/metrics/metricstrait_controller.go
@@ -55,16 +55,19 @@ var (
 )
 
 var (
-	// oamServiceLabel is the pre-defined labels for any serviceMonitor
-	// created by the MetricsTrait,  prometheus operator listens on this
-	oamServiceLabel = map[string]string{
-		"k8s-app":    "oam",
-		"controller": "metricsTrait",
-	}
 	// ServiceMonitorNSName is the name of the namespace in which the serviceMonitor resides
 	// it must be the same that the prometheus operator is listening to
 	ServiceMonitorNSName = "monitoring"
 )
+
+// GetOAMServiceLabel will return oamServiceLabel as the pre-defined labels for any serviceMonitor
+// created by the MetricsTrait,  prometheus operator listens on this
+func GetOAMServiceLabel() map[string]string {
+	return map[string]string{
+		"k8s-app":    "oam",
+		"controller": "metricsTrait",
+	}
+}
 
 // Reconciler reconciles a MetricsTrait object
 type Reconciler struct {
@@ -200,7 +203,7 @@ func (r *Reconciler) createService(ctx context.Context, mLog logr.Logger, worklo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oam-" + workload.GetName(),
 			Namespace: workload.GetNamespace(),
-			Labels:    oamServiceLabel,
+			Labels:    GetOAMServiceLabel(),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         metricsTrait.GetObjectKind().GroupVersionKind().GroupVersion().String(),
@@ -291,7 +294,7 @@ func constructServiceMonitor(metricsTrait *v1alpha1.MetricsTrait, targetPort int
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      metricsTrait.Name,
 			Namespace: ServiceMonitorNSName,
-			Labels:    oamServiceLabel,
+			Labels:    GetOAMServiceLabel(),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         metricsTrait.GetObjectKind().GroupVersionKind().GroupVersion().String(),
@@ -305,7 +308,7 @@ func constructServiceMonitor(metricsTrait *v1alpha1.MetricsTrait, targetPort int
 		},
 		Spec: monitoring.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
-				MatchLabels: oamServiceLabel,
+				MatchLabels: GetOAMServiceLabel(),
 			},
 			// we assumed that the service is in the same namespace as the trait
 			NamespaceSelector: monitoring.NamespaceSelector{

--- a/pkg/controller/v1alpha1/metrics/metricstrait_controller_integration_test.go
+++ b/pkg/controller/v1alpha1/metrics/metricstrait_controller_integration_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Metrics Trait Integration Test", func() {
 			time.Second*10, time.Millisecond*500).Should(BeNil())
 		logf.Log.Info("[TEST] Get the created service", "service ports", createdService.Spec.Ports)
 		Expect(createdService.GetNamespace()).Should(Equal(namespaceName))
-		Expect(createdService.Labels).Should(Equal(oamServiceLabel))
+		Expect(createdService.Labels).Should(Equal(GetOAMServiceLabel()))
 		Expect(len(createdService.Spec.Ports)).Should(Equal(1))
 		Expect(createdService.Spec.Ports[0].Port).Should(BeEquivalentTo(servicePort))
 		Expect(createdService.Spec.Selector).Should(Equal(deployLabel))
@@ -156,7 +156,7 @@ var _ = Describe("Metrics Trait Integration Test", func() {
 			time.Second*5, time.Millisecond*50).Should(BeNil())
 		logf.Log.Info("[TEST] Get the created serviceMonitor", "service end ports", serviceMonitor.Spec.Endpoints)
 		Expect(serviceMonitor.GetNamespace()).Should(Equal(ServiceMonitorNSName))
-		Expect(serviceMonitor.Spec.Selector.MatchLabels).Should(Equal(oamServiceLabel))
+		Expect(serviceMonitor.Spec.Selector.MatchLabels).Should(Equal(GetOAMServiceLabel()))
 		Expect(serviceMonitor.Spec.Selector.MatchExpressions).Should(BeNil())
 		Expect(serviceMonitor.Spec.NamespaceSelector.MatchNames).Should(Equal([]string{metricsTrait.Namespace}))
 		Expect(serviceMonitor.Spec.NamespaceSelector.Any).Should(BeFalse())
@@ -192,7 +192,7 @@ var _ = Describe("Metrics Trait Integration Test", func() {
 			},
 			time.Second*10, time.Millisecond*500).Should(BeNil())
 		logf.Log.Info("[TEST] Get the created service", "service ports", createdService.Spec.Ports)
-		Expect(createdService.Labels).Should(Equal(oamServiceLabel))
+		Expect(createdService.Labels).Should(Equal(GetOAMServiceLabel()))
 		Expect(createdService.Spec.Selector).Should(Equal(deployLabel))
 		By("Check that we have created the serviceMonitor in the pre-defined namespaceName")
 		var serviceMonitor monitoringv1.ServiceMonitor
@@ -204,7 +204,7 @@ var _ = Describe("Metrics Trait Integration Test", func() {
 			},
 			time.Second*5, time.Millisecond*50).Should(BeNil())
 		logf.Log.Info("[TEST] Get the created serviceMonitor", "service end ports", serviceMonitor.Spec.Endpoints)
-		Expect(serviceMonitor.Spec.Selector.MatchLabels).Should(Equal(oamServiceLabel))
+		Expect(serviceMonitor.Spec.Selector.MatchLabels).Should(Equal(GetOAMServiceLabel()))
 		Expect(serviceMonitor.Spec.Selector.MatchExpressions).Should(BeNil())
 		Expect(serviceMonitor.Spec.NamespaceSelector.MatchNames).Should(Equal([]string{metricsTrait.Namespace}))
 		Expect(serviceMonitor.Spec.NamespaceSelector.Any).Should(BeFalse())


### PR DESCRIPTION
 fix #444

It will cause data race if we use pointer(map is pointer) for data construct when we get value with controller-runtime.client.