### PR TITLE
only choose OAM app labels for route trait

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
 	"github.com/oam-dev/kubevela/api/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -81,4 +82,21 @@ func getContainerPorts(cs []v1.Container) []intstr.IntOrString {
 		}
 	}
 	return ports
+}
+
+// SelectOAMAppLabelsWithoutRevision will filter and return OAM app labels only, if no labels, return the original one.
+func SelectOAMAppLabelsWithoutRevision(labels map[string]string) map[string]string {
+	newLabel := make(map[string]string)
+	for k, v := range labels {
+		// Note: we don't include revision label by design
+		// if we want to distinguish with different revisions, we should include it in other function.
+		if k != oam.LabelAppName && k != oam.LabelAppComponent {
+			continue
+		}
+		newLabel[k] = v
+	}
+	if len(newLabel) <= 0 {
+		return labels
+	}
+	return newLabel
 }

--- a/pkg/controller/v1alpha1/routes/route_controller.go
+++ b/pkg/controller/v1alpha1/routes/route_controller.go
@@ -201,7 +201,7 @@ func (r *Reconciler) fillBackendByCreatedService(ctx context.Context, mLog logr.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      routeTrait.GetName(),
 			Namespace: routeTrait.GetNamespace(),
-			Labels:    filterLabels(routeTrait.GetLabels()),
+			Labels:    utils.SelectOAMAppLabelsWithoutRevision(routeTrait.GetLabels()),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         routeTrait.GetObjectKind().GroupVersionKind().GroupVersion().String(),
@@ -263,7 +263,7 @@ func DiscoverPortsLabel(ctx context.Context, workload *unstructured.Unstructured
 		if err != nil {
 			return nil, nil, err
 		}
-		return ports, filterLabels(workload.GetLabels()), nil
+		return ports, utils.SelectOAMAppLabelsWithoutRevision(workload.GetLabels()), nil
 	}
 	if ok {
 		return utils.DiscoveryFromPodTemplate(workload, "spec", "template")

--- a/pkg/controller/v1alpha1/routes/route_controller_test.go
+++ b/pkg/controller/v1alpha1/routes/route_controller_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Route Trait Integration Test", func() {
 	})
 	It("Test with podSpecPath specified using deploy workload", func() {
 		compName := "test-deploy"
-		comp, workloadLabel, _ := getComponent("deploy", compName)
+		comp, _, _ := getComponent("deploy", compName)
 		ac := getAC(compName)
 		Expect(k8sClient.Create(ctx, &comp)).ToNot(HaveOccurred())
 		Expect(k8sClient.Create(ctx, &ac)).ToNot(HaveOccurred())
@@ -343,7 +343,7 @@ var _ = Describe("Route Trait Integration Test", func() {
 			},
 			time.Second*30, time.Millisecond*500).Should(BeNil())
 		logf.Log.Info("[TEST] Get the created service", "service ports", createdSvc.Spec.Ports)
-		for k, v := range workloadLabel {
+		for k, v := range map[string]string{"app.oam.dev/component": compName, "app.oam.dev/name": "test-app-" + compName} {
 			Expect(createdSvc.Spec.Selector).Should(HaveKeyWithValue(k, v))
 		}
 		Expect(createdSvc.Spec.Ports[0].TargetPort.IntVal).Should(Equal(int32(podPort)))

--- a/pkg/controller/v1alpha1/routes/suite_test.go
+++ b/pkg/controller/v1alpha1/routes/suite_test.go
@@ -21,15 +21,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/oam-dev/kubevela/pkg/controller/v1alpha1/podspecworkload"
-
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
-	"github.com/crossplane/oam-kubernetes-runtime/pkg/controller"
-	"github.com/crossplane/oam-kubernetes-runtime/pkg/controller/v1alpha2/applicationconfiguration"
-
 	oamCore "github.com/crossplane/oam-kubernetes-runtime/apis/core"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/controller"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/controller/v1alpha2/applicationconfiguration"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	certmanager "github.com/wonderflow/cert-manager-api/pkg/apis/certmanager/v1"
@@ -45,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	standardv1alpha1 "github.com/oam-dev/kubevela/api/v1alpha1"
+	"github.com/oam-dev/kubevela/pkg/controller/v1alpha1/podspecworkload"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/pkg/controller/v1alpha1/routes/util.go
+++ b/pkg/controller/v1alpha1/routes/util.go
@@ -1,8 +1,6 @@
 package routes
 
 import (
-	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
-
 	"github.com/oam-dev/kubevela/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -69,15 +67,4 @@ func FillRouteTraitWithService(service *corev1.Service, routeTrait *v1alpha1.Rou
 			}
 		}
 	}
-}
-
-func filterLabels(labels map[string]string) map[string]string {
-	newLabel := make(map[string]string)
-	for k, v := range labels {
-		if k == oam.LabelOAMResourceType || k == oam.WorkloadTypeLabel {
-			continue
-		}
-		newLabel[k] = v
-	}
-	return newLabel
 }


### PR DESCRIPTION
The original labels will select all label from podtemplate, this will introduce revision different labels, so the route trait can not route ingress and service to different revisions when they are rolling update. So I narrow the labels, only choose two labels which represent `OAM app config name` and `component name`