### PR TITLE
Fix `vela ls` issue

### DIFF
--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -64,12 +64,12 @@ func (app *AppFile) BuildOAM(ns string, io cmdutil.IOStreams, tm template.Manage
 }
 
 // RenderOAM renders Appfile into AppConfig, Components.
-func (app *AppFile) RenderOAM(ns string, io cmdutil.IOStreams, tm template.Manager, slience bool) (
+func (app *AppFile) RenderOAM(ns string, io cmdutil.IOStreams, tm template.Manager, silence bool) (
 	[]*v1alpha2.Component, *v1alpha2.ApplicationConfiguration, []oam.Object, error) {
-	return app.buildOAM(ns, io, false, tm, slience)
+	return app.buildOAM(ns, io, false, tm, silence)
 }
 
-func (app *AppFile) buildOAM(ns string, io cmdutil.IOStreams, buildImage bool, tm template.Manager, slience bool) (
+func (app *AppFile) buildOAM(ns string, io cmdutil.IOStreams, buildImage bool, tm template.Manager, silence bool) (
 	[]*v1alpha2.Component, *v1alpha2.ApplicationConfiguration, []oam.Object, error) {
 
 	appConfig := &v1alpha2.ApplicationConfiguration{
@@ -99,7 +99,7 @@ func (app *AppFile) buildOAM(ns string, io cmdutil.IOStreams, buildImage bool, t
 				}
 			}
 		}
-		if !slience {
+		if !silence {
 			io.Infof("\nRendering configs for service (%s)...\n", sname)
 		}
 		acComp, comp, err := svc.RenderService(tm, sname, ns, app.configGetter)

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -221,8 +221,8 @@ func (app *Application) GetTraitsByType(componentName, traitType string) (map[st
 }
 
 // TODO(wonderflow) add scope support here
-func (app *Application) OAM(env *types.EnvMeta, io cmdutil.IOStreams, slience bool) ([]*v1alpha2.Component, *v1alpha2.ApplicationConfiguration, []oam.Object, error) {
-	comps, appConfig, scopes, err := app.RenderOAM(env.Namespace, io, app.tm, slience)
+func (app *Application) OAM(env *types.EnvMeta, io cmdutil.IOStreams, silence bool) ([]*v1alpha2.Component, *v1alpha2.ApplicationConfiguration, []oam.Object, error) {
+	comps, appConfig, scopes, err := app.RenderOAM(env.Namespace, io, app.tm, silence)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/controller/v1alpha1/routes/route_controller_test.go
+++ b/pkg/controller/v1alpha1/routes/route_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
+
 	"github.com/oam-dev/kubevela/api/v1alpha1"
 
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
@@ -134,7 +136,7 @@ var _ = Describe("Route Trait Integration Test", func() {
 									"kind":       "Route",
 									"metadata": map[string]interface{}{
 										"labels": map[string]interface{}{
-											"trait.oam.dev/type": "route",
+											oam.TraitTypeLabel: "route",
 										},
 									},
 									"spec": map[string]interface{}{


### PR DESCRIPTION
By default, all svc deployed without `--staging` will appear
to be `staging` in cmd `vela ls`.
To fix #534