### PR TITLE
Fix vela init webservice failed

### DIFF
--- a/pkg/appfile/service.go
+++ b/pkg/appfile/service.go
@@ -85,6 +85,7 @@ func (s Service) RenderService(tm template.Manager, name, ns string, cg configGe
 		}
 		workloadKeys[k] = v
 	}
+	workloadKeys["name"] = name
 
 	// render component
 	component := &v1alpha2.Component{


### PR DESCRIPTION
`vela init` to init a webservice app without `parameter.name` configured, cause marshalling the cue template to json failed.
Fix #549 