### PR TITLE
update vela init UI

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -34,7 +34,7 @@ spec:
       	// +short=c
       	count: *1 | int
       
-      	// +usage=specify app image
+      	// +usage=Which image would you like to use for your service
       	// +short=i
       	image: string
       

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -64,15 +64,15 @@ spec:
       	}
       }
       parameter: {
-      	// +usage=specify app image
+      	// +usage=Which image would you like to use for your service
       	// +short=i
       	image: string
       
       	cmd?: [...string]
       
-      	// +usage=specify port for container
+      	// +usage=Which port do you want customer traffic sent to
       	// +short=p
-      	port: *6379 | int
+      	port: *80 | int
       
       	env?: [...{
       		name:   string
@@ -84,7 +84,7 @@ spec:
       			}
       		}
       	}]
-      	// +usage=CPU core requests for the workload
+      	// +usage=CPU core requests for the workload, specify like '0.5', '1'.
       	// +alias=cpu-requests
       	cpuRequests?: string
       }

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -43,7 +43,7 @@ spec:
       }
       
       parameter: {
-      	// +usage=specify app image
+      	// +usage=Which image would you like to use for your service
       	// +short=i
       	image: string
       

--- a/design/api/vela-restful-api-reference.md
+++ b/design/api/vela-restful-api-reference.md
@@ -444,7 +444,7 @@ sample response
 	"data": {
 		"name": "podspecworkload",
 		"type": "workload",
-		"template": "#Template: {\n\tapiVersion: \"core.oam.dev/v1alpha2\"\n\tkind:       \"PodSpecWorkload\"\n\tmetadata: name: podspecworkload.name\n\tspec: {\n\t\tcontainers: [{\n\t\t\timage: containerized.image\n\t\t\tname:  containerized.name\n\t\t\tports: [{\n\t\t\t\tcontainerPort: containerized.port\n\t\t\t\tprotocol:      \"TCP\"\n\t\t\t\tname:          \"default\"\n\t\t\t}]\n\t\t}]\n\t}\n}\ncontainerized: {\n\tname: string\n\t// +usage=specify app image\n\t// +short=i\n\timage: string\n\t// +usage=specify port for container\n\t// +short=p\n\tport: *6379 | int\n}\n",
+		"template": "#Template: {\n\tapiVersion: \"core.oam.dev/v1alpha2\"\n\tkind:       \"PodSpecWorkload\"\n\tmetadata: name: podspecworkload.name\n\tspec: {\n\t\tcontainers: [{\n\t\t\timage: containerized.image\n\t\t\tname:  containerized.name\n\t\t\tports: [{\n\t\t\t\tcontainerPort: containerized.port\n\t\t\t\tprotocol:      \"TCP\"\n\t\t\t\tname:          \"default\"\n\t\t\t}]\n\t\t}]\n\t}\n}\ncontainerized: {\n\tname: string\n\t// +usage=Which image would you like to use for your service\n\t// +short=i\n\timage: string\n\t// +usage=Which port do you want customer traffic sent to\n\t// +short=p\n\tport: *6379 | int\n}\n",
 		"parameters": [{
 			"name": "name",
 			"required": true,
@@ -455,13 +455,13 @@ sample response
 			"short": "i",
 			"required": true,
 			"default": "",
-			"usage": "specify app image",
+			"usage": "Which image would you like to use for your service",
 			"type": 16
 		}, {
 			"name": "port",
 			"short": "p",
 			"default": 6379,
-			"usage": "specify port for container",
+			"usage": "Which port do you want customer traffic sent to",
 			"type": 4
 		}],
 		"definition": "/Users/zhouzhengxi/.vela/capabilities/containerizedworkloads.core.oam.dev.cue",
@@ -492,13 +492,13 @@ sample response
 			"short": "i",
 			"required": true,
 			"default": "",
-			"usage": "specify app image",
+			"usage": "Which image would you like to use for your service",
 			"type": 16
 		}, {
 			"name": "port",
 			"short": "p",
 			"default": 6379,
-			"usage": "specify port for container",
+			"usage": "Which port do you want customer traffic sent to",
 			"type": 4
 		}]
 	}, {
@@ -675,7 +675,7 @@ sample response
 	"data": [{
 		"name": "podspecworkload",
 		"type": "workload",
-		"template": "#Template: {\n\tapiVersion: \"core.oam.dev/v1alpha2\"\n\tkind:       \"ContainerizedWorkload\"\n\tmetadata: name: podspecworkload.name\n\tspec: {\n\t\tcontainers: [{\n\t\t\timage: containerized.image\n\t\t\tname:  containerized.name\n\t\t\tports: [{\n\t\t\t\tcontainerPort: containerized.port\n\t\t\t\tprotocol:      \"TCP\"\n\t\t\t\tname:          \"default\"\n\t\t\t}]\n\t\t}]\n\t}\n}\ncontainerized: {\n\tname: string\n\t// +usage=specify app image\n\t// +short=i\n\timage: string\n\t// +usage=specify port for container\n\t// +short=p\n\tport: *6379 | int\n}\n",
+		"template": "#Template: {\n\tapiVersion: \"core.oam.dev/v1alpha2\"\n\tkind:       \"ContainerizedWorkload\"\n\tmetadata: name: podspecworkload.name\n\tspec: {\n\t\tcontainers: [{\n\t\t\timage: containerized.image\n\t\t\tname:  containerized.name\n\t\t\tports: [{\n\t\t\t\tcontainerPort: containerized.port\n\t\t\t\tprotocol:      \"TCP\"\n\t\t\t\tname:          \"default\"\n\t\t\t}]\n\t\t}]\n\t}\n}\ncontainerized: {\n\tname: string\n\t// +usage=Which image would you like to use for your service\n\t// +short=i\n\timage: string\n\t// +usage=Which port do you want customer traffic sent to\n\t// +short=p\n\tport: *6379 | int\n}\n",
 		"parameters": [{
 			"name": "name",
 			"required": true,
@@ -686,13 +686,13 @@ sample response
 			"short": "i",
 			"required": true,
 			"default": "",
-			"usage": "specify app image",
+			"usage": "Which image would you like to use for your service",
 			"type": 16
 		}, {
 			"name": "port",
 			"short": "p",
 			"default": 6379,
-			"usage": "specify port for container",
+			"usage": "Which port do you want customer traffic sent to",
 			"type": 4
 		}],
 		"definition": "/Users/zhouzhengxi/.vela/centers/c1/.tmp/containerizedworkloads.core.oam.dev.cue",

--- a/docs/en/developers/alternative-cmd.md
+++ b/docs/en/developers/alternative-cmd.md
@@ -21,8 +21,8 @@ Environment: default, namespace: default
 ? What would you like to name your application (required):  testapp
 ? Choose the workload type for your application (required, e.g., webservice):  webservice
 ? What would you like to name this webservice (required):  testsvc
-? specify app image crccheck/hello-world
-? specify port for container 8000
+? Which image would you like to use for your service (required): crccheck/hello-world
+? Which port do you want customer traffic sent to (optional, default is 80): 8000
 
 ...
 ✅ Application Deployed Successfully!

--- a/docs/en/developers/references/workload-types/task.md
+++ b/docs/en/developers/references/workload-types/task.md
@@ -6,4 +6,4 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cmd** | **[]string** |  | [optional] 
 **Count** | **int32** | specify number of tasks to run in parallel | [default to 1]
-**Image** | **string** | specify app image | 
+**Image** | **string** | Which image would you like to use for your service | 

--- a/docs/en/developers/references/workload-types/web-service.md
+++ b/docs/en/developers/references/workload-types/web-service.md
@@ -6,8 +6,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cmd** | **[]string** |  | [optional]
 **Env** | [**[]WebserviceEnv**](#webserviceenv) |  | [optional]
-**Image** | **string** | specify app image |
-**Port** | **int32** | specify port for container | [default to 6379]
+**Image** | **string** | Which image would you like to use for your service |
+**Port** | **int32** | Which port do you want customer traffic sent to | [default to 6379]
 
 
 ### WebserviceEnv

--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -21,8 +21,8 @@ Environment: default, namespace: default
 ? What would you like to name your application (required):  testapp
 ? Choose the workload type for your application (required, e.g., webservice):  webservice
 ? What would you like to name this webservice (required):  testsvc
-? specify app image crccheck/hello-world
-? specify port for container 8000
+? Which image would you like to use for your service (required): crccheck/hello-world
+? Which port do you want customer traffic sent to (optional, default is 80): 8000
 
 Deployment config is rendered and written to vela.yaml
 ```

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -278,16 +278,16 @@ var (
 							a: "mysvc",
 						},
 						{
-							q: "specify app image ",
+							q: "Which image would you like to use for your service ",
 							a: "nginx:latest",
 						},
 						{
-							q: "specify port for container ",
+							q: "Which port do you want customer traffic sent to ",
 							a: "8080",
 						},
 						{
-							q: "CPU core requests for the workload ",
-							a: "",
+							q: "CPU core requests for the workload, specify like '0.5', '1'. (optional):",
+							a: "0.5",
 						},
 					}
 					for _, qa := range data {

--- a/hack/vela-templates/cue/task.cue
+++ b/hack/vela-templates/cue/task.cue
@@ -21,7 +21,7 @@ parameter: {
 	// +short=c
 	count: *1 | int
 
-	// +usage=specify app image
+	// +usage=Which image would you like to use for your service
 	// +short=i
 	image: string
 

--- a/hack/vela-templates/cue/webservice.cue
+++ b/hack/vela-templates/cue/webservice.cue
@@ -51,15 +51,15 @@ output: {
 	}
 }
 parameter: {
-	// +usage=specify app image
+	// +usage=Which image would you like to use for your service
 	// +short=i
 	image: string
 
 	cmd?: [...string]
 
-	// +usage=specify port for container
+	// +usage=Which port do you want customer traffic sent to
 	// +short=p
-	port: *6379 | int
+	port: *80 | int
 
 	env?: [...{
 		name:   string
@@ -71,7 +71,7 @@ parameter: {
 			}
 		}
 	}]
-	// +usage=CPU core requests for the workload
+	// +usage=CPU core requests for the workload, specify like '0.5', '1'.
 	// +alias=cpu-requests
 	cpuRequests?: string
 }

--- a/hack/vela-templates/cue/worker.cue
+++ b/hack/vela-templates/cue/worker.cue
@@ -30,7 +30,7 @@ output: {
 }
 
 parameter: {
-	// +usage=specify app image
+	// +usage=Which image would you like to use for your service
 	// +short=i
 	image: string
 

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -114,7 +114,7 @@ func (o *appInitOptions) Naming() error {
 	prompt := &survey.Input{
 		Message: "What would you like to name your application (required): ",
 	}
-	err := survey.AskOne(prompt, &o.appName)
+	err := survey.AskOne(prompt, &o.appName, survey.WithValidator(survey.Required))
 	if err != nil {
 		return fmt.Errorf("read app name err %v", err)
 	}
@@ -163,7 +163,7 @@ func (o *appInitOptions) Workload() error {
 		Message: "Choose the workload type for your application (required, e.g., webservice): ",
 		Options: workloadList,
 	}
-	err = survey.AskOne(prompt, &o.workloadType)
+	err = survey.AskOne(prompt, &o.workloadType, survey.WithValidator(survey.Required))
 	if err != nil {
 		return fmt.Errorf("read workload type err %v", err)
 	}
@@ -174,7 +174,7 @@ func (o *appInitOptions) Workload() error {
 	namePrompt := &survey.Input{
 		Message: fmt.Sprintf("What would you like to name this %s (required): ", o.workloadType),
 	}
-	err = survey.AskOne(namePrompt, &o.workloadName)
+	err = survey.AskOne(namePrompt, &o.workloadName, survey.WithValidator(survey.Required))
 	if err != nil {
 		return fmt.Errorf("read workload name err %v", err)
 	}
@@ -186,6 +186,16 @@ func (o *appInitOptions) Workload() error {
 		usage := p.Usage
 		if usage == "" {
 			usage = "what would you configure for parameter '" + color.New(color.FgCyan).Sprintf("%s", p.Name) + "'"
+		}
+		if p.Required {
+			usage += " (required): "
+		} else {
+			defaultValue := fmt.Sprintf("%v", p.Default)
+			if defaultValue != "" {
+				usage += fmt.Sprintf(" (optional, default is %s): ", defaultValue)
+			} else {
+				usage += " (optional): "
+			}
 		}
 		switch p.Type {
 		case cue.StringKind:

--- a/pkg/cue/convert_test.go
+++ b/pkg/cue/convert_test.go
@@ -70,9 +70,10 @@ func TestGetParameter(t *testing.T) {
 	assert.Equal(t, []types.Parameter{
 		{Name: "name", Required: true, Default: "", Type: cue.StringKind},
 		{Name: "env", Required: false, Default: nil, Type: cue.ListKind},
-		{Name: "image", Short: "i", Required: true, Usage: "specify app image", Default: "", Type: cue.StringKind},
-		{Name: "port", Short: "p", Required: false, Usage: "specify port for container", Default: int64(8080),
-			Type: cue.IntKind}},
+		{Name: "image", Short: "i", Required: true, Usage: "Which image would you like to use for your service", Default: "", Type: cue.StringKind},
+		{Name: "port", Short: "p", Required: false, Usage: "Which port do you want customer traffic sent to", Default: int64(8080),
+			Type: cue.IntKind},
+		{Name: "cpuRequests", Short: "", Required: false, Usage: "", Default: "", Type: cue.StringKind}},
 		params)
 
 	params, err = GetParameters("testdata/workloads/test-param.cue")
@@ -80,8 +81,8 @@ func TestGetParameter(t *testing.T) {
 	assert.Equal(t, []types.Parameter{
 		{Name: "name", Required: true, Default: "", Type: cue.StringKind},
 		{Name: "env", Required: false, Default: nil, Type: cue.ListKind},
-		{Name: "image", Short: "i", Required: true, Usage: "specify app image", Default: "", Type: cue.StringKind},
-		{Name: "port", Short: "p", Usage: "specify port for container", Default: int64(8080), Type: cue.IntKind},
+		{Name: "image", Short: "i", Required: true, Usage: "Which image would you like to use for your service", Default: "", Type: cue.StringKind},
+		{Name: "port", Short: "p", Usage: "Which port do you want customer traffic sent to", Default: int64(8080), Type: cue.IntKind},
 		{Name: "enable", Default: false, Type: cue.BoolKind},
 		{Name: "fval", Default: 64.3, Type: cue.FloatKind},
 		{Name: "nval", Default: float64(0), Required: true, Type: cue.NumberKind}}, params)

--- a/pkg/cue/testdata/workloads/deployment.cue
+++ b/pkg/cue/testdata/workloads/deployment.cue
@@ -1,15 +1,16 @@
 #deployment: {
 	name: string
-	// +usage=specify app image
+	// +usage=Which image would you like to use for your service
 	// +short=i
 	image: string
-	// +usage=specify port for container
+	// +usage=Which port do you want customer traffic sent to
 	// +short=p
 	port: *8080 | int
 	env: [...{
 		name:  string
 		value: string
 	}]
+	cpuRequests?: string
 }
 output: {
 	apiVersion: "apps/v1"
@@ -32,8 +33,16 @@ output: {
 					protocol:      "TCP"
 					name:          "default"
 				}]
+				if parameter["cpuRequests"] != _|_ {
+					resources: {
+						limits:
+							cpu: parameter.cpuRequests
+						requests:
+							cpu: parameter.cpuRequests
+					}
+				}
 			}]
-		}
+	}
 	}
 }
 parameter: #deployment

--- a/pkg/cue/testdata/workloads/test-param.cue
+++ b/pkg/cue/testdata/workloads/test-param.cue
@@ -3,10 +3,10 @@ Template: {
 
 parameter: {
 	name: string
-	// +usage=specify app image
+	// +usage=Which image would you like to use for your service
 	// +short=i
 	image: string
-	// +usage=specify port for container
+	// +usage=Which port do you want customer traffic sent to
 	// +short=p
 	port: *8080 | int
 	env: [...{

--- a/pkg/plugins/cluster_test.go
+++ b/pkg/plugins/cluster_test.go
@@ -48,14 +48,14 @@ var _ = Describe("DefinitionFiles", func() {
 				Default:  "",
 				Short:    "i",
 				Required: true,
-				Usage:    "specify app image",
+				Usage:    "Which image would you like to use for your service",
 			},
 			{
 				Name:    "port",
 				Type:    cue.IntKind,
 				Short:   "p",
 				Default: int64(8080),
-				Usage:   "specify port for container",
+				Usage:   "Which port do you want customer traffic sent to",
 			},
 		},
 	}
@@ -72,13 +72,13 @@ var _ = Describe("DefinitionFiles", func() {
 			Default:  "",
 			Short:    "i",
 			Required: true,
-			Usage:    "specify app image",
+			Usage:    "Which image would you like to use for your service",
 		}, {
 			Name:    "port",
 			Type:    cue.IntKind,
 			Short:   "p",
 			Default: int64(6379),
-			Usage:   "specify port for container",
+			Usage:   "Which port do you want customer traffic sent to",
 		}},
 		CrdName: "webservice.testapps",
 	}

--- a/pkg/plugins/testdata/websvcWorkloadDef.yaml
+++ b/pkg/plugins/testdata/websvcWorkloadDef.yaml
@@ -28,11 +28,11 @@ spec:
         }
       }
       parameter: {
-        // +usage=specify app image
+        // +usage=Which image would you like to use for your service
         // +short=i
         image: string
 
-        // +usage=specify port for container
+        // +usage=Which port do you want customer traffic sent to
         // +short=p
         port:  *6379 | int
         

--- a/pkg/plugins/testdata/workloadDef.yaml
+++ b/pkg/plugins/testdata/workloadDef.yaml
@@ -27,10 +27,10 @@ spec:
       	}
       }
       parameter: {
-      	// +usage=specify app image
+      	// +usage=Which image would you like to use for your service
       	// +short=i
       	image: string
-      	// +usage=specify port for container
+      	// +usage=Which port do you want customer traffic sent to
       	// +short=p
       	port: *8080 | int
       	env: [...{


### PR DESCRIPTION
fix #557 

Updated like this, the optional value was explicit declared:



```
Welcome to use KubeVela CLI! Please describe your application, user could just skip it.

Environment: myenv, namespace: default

? What is your email (optional, used to generate certification):
? What would you like to name your application (required):  myapp
? Choose the workload type for your application (required, e.g., webservice):  webservice
? What would you like to name this webservice (required):  myweb
? Which image would you like to use for your service (required):  nginx
? Which port do you want customer traffic sent to (optional, default is 80):  8080
? CPU core requests for the workload, specify like '0.5', '1'. (optional):

Deployment config is rendered and written to vela.yaml
⠋ Checking Status ...
✅ Application Deployed Successfully!
  - Name: myweb
    Type: webservice
    HEALTHY Ready: 1/1
    Traits:
      - ✅ route: 	Visiting URL: http://myweb.myapp	IP: 39.97.232.19

    Last Deployment:
      Created at: 2020-11-11 15:00:52 +0800 CST
      Updated at: 2020-11-11T15:21:00+08:00
```