### PR TITLE
Add missing TagCommandType

### DIFF
--- a/pkg/commands/traits.go
+++ b/pkg/commands/traits.go
@@ -23,6 +23,9 @@ func NewTraitsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 		Short:                 "List traits",
 		Long:                  "List traits",
 		Example:               `vela traits`,
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeTraits,
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if syncCluster {
 				newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})

--- a/pkg/commands/workloads.go
+++ b/pkg/commands/workloads.go
@@ -21,6 +21,9 @@ func NewWorkloadsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 		Short:                 "List workloads",
 		Long:                  "List workloads",
 		Example:               `vela workloads`,
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeApp,
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if syncCluster {
 				newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})


### PR DESCRIPTION
The help description of commands `vela traits`, `vela workload` are missing in `vela -h`.
Add correct `TagCommandType` annotation to fix it.