### PR TITLE
clean up vela cli help info to be app focused

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -35,10 +35,10 @@ type EnvMeta struct {
 const (
 	TagCommandType = "commandType"
 
-	TypeStart   = "Getting Started"
-	TypeApp     = "Applications"
-	TypeTraits  = "Traits"
-	TypeRelease = "Release"
-	TypeOthers  = "Others"
-	TypeSystem  = "System"
+	TypeStart  = "Getting Started"
+	TypeApp    = "Managing Applications"
+	TypeCap    = "Managing Capabilities"
+	TypeSystem = "System"
+
+	TypeTraits = "Traits"
 )

--- a/pkg/commands/capability.go
+++ b/pkg/commands/capability.go
@@ -22,7 +22,7 @@ func CapabilityCommandGroup(c types.Args, ioStream cmdutil.IOStreams) *cobra.Com
 		Short: "Capability Management",
 		Long:  "Capability Management with config, list, add, remove capabilities",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
+			types.TagCommandType: types.TypeCap,
 		},
 	}
 	cmd.AddCommand(
@@ -39,9 +39,6 @@ func NewCenterCommand(c types.Args, ioStream cmdutil.IOStreams) *cobra.Command {
 		Use:   "center <command>",
 		Short: "Manage Capability Center",
 		Long:  "Manage Capability Center with config, sync, list",
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
-		},
 	}
 	cmd.AddCommand(
 		NewCapCenterConfigCommand(ioStream),
@@ -71,9 +68,6 @@ func NewCapCenterConfigCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 			}
 			ioStreams.Infof("Successfully configured capability center %s and sync from remote\n", capName)
 			return nil
-		},
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
 		},
 	}
 	cmd.PersistentFlags().StringP("token", "t", "", "Github Repo token")
@@ -105,9 +99,6 @@ func NewCapInstallCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comm
 			}
 			return nil
 		},
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
-		},
 	}
 	cmd.PersistentFlags().StringP("token", "t", "", "Github Repo token")
 	return cmd
@@ -137,9 +128,6 @@ func NewCapUninstallCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Co
 			}
 			return oam.RemoveCapability(newClient, name, ioStreams)
 		},
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
-		},
 	}
 	cmd.PersistentFlags().StringP("token", "t", "", "Github Repo token")
 	return cmd
@@ -161,9 +149,6 @@ func NewCapCenterSyncCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 			}
 			ioStreams.Info("sync finished")
 			return nil
-		},
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
 		},
 	}
 	return cmd
@@ -193,9 +178,6 @@ func NewCapListCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 			ioStreams.Info(table.String())
 			return nil
 		},
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
-		},
 	}
 	return cmd
 }
@@ -209,9 +191,6 @@ func NewCapCenterListCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ListCapCenters(args, ioStreams)
 		},
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
-		},
 	}
 	return cmd
 }
@@ -224,9 +203,6 @@ func NewCapCenterRemoveCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 		Example: "vela cap center remove mycenter",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RemoveCapCenter(args, ioStreams)
-		},
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeOthers,
 		},
 	}
 	return cmd

--- a/pkg/commands/cli.go
+++ b/pkg/commands/cli.go
@@ -29,9 +29,8 @@ func NewCommand() *cobra.Command {
 			cmd.Printf("✈️  The Extensible Application Platform Based on Kubernetes and Open Application Model (OAM).\n\nUsage:\n  vela [flags]\n  vela [command]\n\nAvailable Commands:\n\n")
 			PrintHelpByTag(cmd, allCommands, types.TypeStart)
 			PrintHelpByTag(cmd, allCommands, types.TypeApp)
-			PrintHelpByTag(cmd, allCommands, types.TypeTraits)
+			PrintHelpByTag(cmd, allCommands, types.TypeCap)
 			PrintHelpByTag(cmd, allCommands, types.TypeSystem)
-			PrintHelpByTag(cmd, allCommands, types.TypeOthers)
 			cmd.Println("Flags:")
 			cmd.Println("  -h, --help   help for vela")
 			cmd.Println()
@@ -62,10 +61,6 @@ func NewCommand() *cobra.Command {
 	cmds.AddCommand(
 		// Getting Start
 		NewInstallCommand(commandArgs, fake.ChartSource, ioStream),
-		NewEnvCommand(commandArgs, ioStream),
-		NewConfigCommand(commandArgs, ioStream),
-		NewVersionCommand(),
-		NewInitCommand(commandArgs, ioStream),
 		NewUpCommand(commandArgs, ioStream),
 
 		// Apps
@@ -73,27 +68,27 @@ func NewCommand() *cobra.Command {
 		NewDeleteCommand(commandArgs, ioStream),
 		NewAppShowCommand(ioStream),
 		NewAppStatusCommand(commandArgs, ioStream),
-
-		// Workloads
-		AddCompCommands(commandArgs, ioStream),
-
-		// Capability Systems
-		CapabilityCommandGroup(commandArgs, ioStream),
-
-		// System
-		SystemCommandGroup(commandArgs, ioStream),
-		NewCompletionCommand(),
-
-		NewTraitsCommand(commandArgs, ioStream),
-		NewWorkloadsCommand(commandArgs, ioStream),
-
-		NewDashboardCommand(commandArgs, ioStream, fake.FrontendSource),
-
 		NewExecCommand(commandArgs, ioStream),
 		NewPortForwardCommand(commandArgs, ioStream),
 		NewLogsCommand(commandArgs, ioStream),
+		NewEnvCommand(commandArgs, ioStream),
+		NewConfigCommand(commandArgs, ioStream),
 
+		// Capabilities
+		CapabilityCommandGroup(commandArgs, ioStream),
 		NewTemplateCommand(commandArgs, ioStream),
+		NewTraitsCommand(commandArgs, ioStream),
+		NewWorkloadsCommand(commandArgs, ioStream),
+
+		// Helper
+		SystemCommandGroup(commandArgs, ioStream),
+		NewDashboardCommand(commandArgs, ioStream, fake.FrontendSource),
+		NewCompletionCommand(),
+		NewVersionCommand(),
+
+		NewInitCommand(commandArgs, ioStream),
+
+		AddCompCommands(commandArgs, ioStream),
 	)
 
 	// Traits
@@ -116,18 +111,9 @@ func PrintHelpByTag(cmd *cobra.Command, all []*cobra.Command, tag string) {
 	for _, c := range all {
 		if val, ok := c.Annotations[types.TagCommandType]; ok && val == tag {
 			table.AddRow("    "+c.Use, c.Long)
-			for _, subcmd := range c.Commands() {
-				table.AddRow("      "+subcmd.Use, "  "+subcmd.Long)
-			}
 		}
 	}
 	cmd.Println(table.String())
-	if tag == types.TypeTraits {
-		if len(table.Rows) > 0 {
-			cmd.Println()
-		}
-		cmd.Println("    Want more? < install more capabilities by `vela cap` >")
-	}
 	cmd.Println()
 }
 
@@ -146,7 +132,7 @@ GolangVersion: %v
 				runtime.Version())
 		},
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeStart,
+			types.TagCommandType: types.TypeSystem,
 		},
 	}
 }

--- a/pkg/commands/cli.go
+++ b/pkg/commands/cli.go
@@ -61,6 +61,7 @@ func NewCommand() *cobra.Command {
 	cmds.AddCommand(
 		// Getting Start
 		NewInstallCommand(commandArgs, fake.ChartSource, ioStream),
+		NewInitCommand(commandArgs, ioStream),
 		NewUpCommand(commandArgs, ioStream),
 
 		// Apps
@@ -85,8 +86,6 @@ func NewCommand() *cobra.Command {
 		NewDashboardCommand(commandArgs, ioStream, fake.FrontendSource),
 		NewCompletionCommand(),
 		NewVersionCommand(),
-
-		NewInitCommand(commandArgs, ioStream),
 
 		AddCompCommands(commandArgs, ioStream),
 	)

--- a/pkg/commands/comp.go
+++ b/pkg/commands/comp.go
@@ -34,9 +34,6 @@ func AddCompCommands(c types.Args, ioStreams util.IOStreams) *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Short:                 "Manage services",
 		Long:                  "Manage services",
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeApp,
-		},
 	}
 	compCommands.PersistentFlags().StringP(App, "a", "", "specify the name of application containing the services")
 

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -27,7 +27,7 @@ func NewConfigCommand(args types.Args, io cmdutil.IOStreams) *cobra.Command {
 		Short:                 "Manage application configurations",
 		Long:                  "Manage application configurations under given env",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeStart,
+			types.TagCommandType: types.TypeApp,
 		},
 	}
 	cmd.SetOut(io.Out)

--- a/pkg/commands/delete.go
+++ b/pkg/commands/delete.go
@@ -15,7 +15,7 @@ import (
 // NewDeleteCommand Delete App
 func NewDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "delete <APPLICATION_NAME>",
+		Use:                   "delete APP_NAME",
 		DisableFlagsInUseLine: true,
 		Short:                 "Delete Applications",
 		Long:                  "Delete Applications",

--- a/pkg/commands/env.go
+++ b/pkg/commands/env.go
@@ -22,7 +22,7 @@ func NewEnvCommand(c types.Args, ioStream cmdutil.IOStreams) *cobra.Command {
 		Short:                 "Manage application environments",
 		Long:                  "Manage application environments",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeStart,
+			types.TagCommandType: types.TypeApp,
 		},
 	}
 	cmd.SetOut(ioStream.Out)

--- a/pkg/commands/exec.go
+++ b/pkg/commands/exec.go
@@ -59,7 +59,7 @@ func NewExecCommand(c types.Args, ioStreams velacmdutil.IOStreams) *cobra.Comman
 		VelaC: c,
 	}
 	cmd := &cobra.Command{
-		Use:   "exec [flags] AppName -- COMMAND [args...]",
+		Use:   "exec [flags] APP_NAME -- COMMAND [args...]",
 		Short: "Execute a command in a container",
 		Long:  "Execute a command in the 1st container of specific Application => Service => (1st)Pod",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -101,6 +101,9 @@ func NewInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 
 			return printComponentStatus(context.Background(), o.client, o.IOStreams, o.workloadName, o.appName, o.Env)
 		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeStart,
+		},
 	}
 	cmd.Flags().BoolVar(&o.renderOnly, "render-only", false, "Rendering vela.yaml in current dir and do not deploy")
 	cmd.SetOut(ioStreams.Out)

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -42,10 +42,7 @@ func NewInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Short:                 "Init an OAM Application",
 		Long:                  "Init an OAM Application by one command",
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeStart,
-		},
-		Example: "vela init",
+		Example:               "vela init",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
 			if err != nil {

--- a/pkg/commands/show.go
+++ b/pkg/commands/show.go
@@ -15,10 +15,10 @@ import (
 
 func NewAppShowCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "show <APPLICATION-NAME>",
+		Use:     "show APP_NAME",
 		Short:   "Get details of an application",
 		Long:    "Get details of an application",
-		Example: `vela show <APPLICATION-NAME>`,
+		Example: `vela show APP_NAME`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLength := len(args)
 			if argsLength == 0 {

--- a/pkg/commands/status.go
+++ b/pkg/commands/status.go
@@ -105,10 +105,10 @@ const (
 func NewAppStatusCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 	ctx := context.Background()
 	cmd := &cobra.Command{
-		Use:     "status <APPLICATION-NAME>",
+		Use:     "status APP_NAME",
 		Short:   "get status of an application",
 		Long:    "get status of an application, including workloads and traits of each service.",
-		Example: `vela status <APPLICATION-NAME>`,
+		Example: `vela status APP_NAME`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLength := len(args)
 			if argsLength == 0 {

--- a/pkg/commands/status.go
+++ b/pkg/commands/status.go
@@ -106,8 +106,8 @@ func NewAppStatusCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 	ctx := context.Background()
 	cmd := &cobra.Command{
 		Use:     "status APP_NAME",
-		Short:   "get status of an application",
-		Long:    "get status of an application, including workloads and traits of each service.",
+		Short:   "Get status of an application",
+		Long:    "Get status of an application, including workloads and traits of each service.",
 		Example: `vela status APP_NAME`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLength := len(args)

--- a/pkg/commands/template.go
+++ b/pkg/commands/template.go
@@ -15,7 +15,7 @@ func NewTemplateCommand(c types.Args, ioStream cmdutil.IOStreams) *cobra.Command
 		Short:                 "Manage templates",
 		Long:                  "Manage templates",
 		Annotations: map[string]string{
-			types.TagCommandType: types.TypeSystem,
+			types.TagCommandType: types.TypeCap,
 		},
 	}
 	cmd.SetOut(ioStream.Out)

--- a/pkg/commands/trait.go
+++ b/pkg/commands/trait.go
@@ -40,6 +40,7 @@ func AddTraitCommands(parentCmd *cobra.Command, c types.Args, ioStreams cmdutil.
 
 		var name = tmp.Name
 		pluginCmd := &cobra.Command{
+			Hidden:                true,
 			Use:                   name + " <appname> [args]",
 			DisableFlagsInUseLine: true,
 			Short:                 "Attach " + name + " trait to an app",
@@ -69,9 +70,6 @@ func AddTraitCommands(parentCmd *cobra.Command, c types.Args, ioStreams cmdutil.
 					}
 				}
 				return o.Run(ctx, cmd, ioStreams)
-			},
-			Annotations: map[string]string{
-				types.TagCommandType: types.TypeTraits,
 			},
 		}
 		pluginCmd.SetOut(ioStreams.Out)

--- a/pkg/commands/traits.go
+++ b/pkg/commands/traits.go
@@ -17,7 +17,7 @@ func NewTraitsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 	var syncCluster bool
 	ctx := context.Background()
 	cmd := &cobra.Command{
-		Use:                   "traits [--apply-to WORKLOADNAME]",
+		Use:                   "traits [--apply-to WORKLOAD_NAME]",
 		DisableFlagsInUseLine: true,
 		Short:                 "List traits",
 		Long:                  "List traits",

--- a/pkg/commands/traits.go
+++ b/pkg/commands/traits.go
@@ -22,9 +22,6 @@ func NewTraitsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 		Short:                 "List traits",
 		Long:                  "List traits",
 		Example:               `vela traits`,
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeTraits,
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if syncCluster {
 				if err := RefreshDefinitions(ctx, c, ioStreams, true); err != nil {
@@ -32,6 +29,9 @@ func NewTraitsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 				}
 			}
 			return printTraitList(&workloadName, ioStreams)
+		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeCap,
 		},
 	}
 

--- a/pkg/commands/workloads.go
+++ b/pkg/commands/workloads.go
@@ -20,9 +20,6 @@ func NewWorkloadsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 		Short:                 "List workloads",
 		Long:                  "List workloads",
 		Example:               `vela workloads`,
-		Annotations: map[string]string{
-			types.TagCommandType: types.TypeApp,
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if syncCluster {
 				if err := RefreshDefinitions(ctx, c, ioStreams, true); err != nil {
@@ -34,6 +31,9 @@ func NewWorkloadsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 				return err
 			}
 			return printWorkloadList(workloads, ioStreams)
+		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeCap,
 		},
 	}
 	cmd.SetOut(ioStreams.Out)


### PR DESCRIPTION
ref: https://github.com/oam-dev/kubevela/issues/590#issuecomment-726421554

```
Available Commands:

  Getting Started:

    init   	Init an OAM Application by one command
    install	Install OAM runtime and vela builtin capabilities.
    up     	Apply an appfile, by default vela.yaml

  Managing Applications:

    config                                                                                    	Manage application configurations under given env
    delete APP_NAME                                                                           	Delete Applications
    env                                                                                       	Manage application environments
    exec [flags] APP_NAME -- COMMAND [args...]                                                	Execute a command in the 1st container of specific Application => Service => (1st)Pod
    logs                                                                                      	Tail logs for application
    ls                                                                                        	List services with their application, type, traits, status and created time, etc.
    port-forward APP_NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]	Forward one or more local ports to a Pod of a service in an application
    show APP_NAME                                                                             	Get details of an application
    status APP_NAME                                                                           	Get status of an application, including workloads and traits of each service.

  Managing Capabilities:

    cap                              	Capability Management with config, list, add, remove capabilities
    template                         	Manage templates
    traits [--apply-to WORKLOAD_NAME]	List traits
    workloads                        	List workloads

  System:

    completion < bash | zsh >	Output shell completion code for the specified shell (bash or zsh...
    dashboard                	Setup API Server and launch Dashboard
    system                   	System management utilities
    version                  	Prints out build version information

Flags:
  -h, --help   help for vela
```