### PR TITLE
multi-arch images support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,18 +8,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Publish to Github Docker Package Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+      - name: Get the version
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          if [[ ${GITHUB_REF} == "refs/heads/master" ]]; then
+            VERSION=latest
+          fi
+          echo ::set-output name=VERSION::${VERSION}
+      - name: Login ghcr.io
+        uses: docker/login-action@v1
         with:
-          name: oam-dev/kubevela/vela-core
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          tags: "latest"
-      - name: Publish to Docker Hub Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Login docker.io
+        uses: docker/login-action@v1
         with:
-          name: oamdev/vela-core
+          registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: "latest"
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/build-push-action@v2
+        name: Build & Pushing
+        with:
+          context: .
+          file: Dockerfile
+          labels: |-
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |-
+            ghcr.io/${{ github.repository }}/vela-core:${{ steps.get_version.outputs.VERSION }}
+            docker.io/oamdev/vela-core:${{ steps.get_version.outputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,14 +15,19 @@ COPY api/ api/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager-${TARGETARCH} main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-# oamdev/gcr.io-distroless-static:nonroot is syncd from gcr.io/distroless/static:nonroot as somewhere can't reach gcr.io
-FROM oamdev/gcr.io-distroless-static:nonroot
+# Could use `--build-arg=BASE_DISTROLESS=gcr.io/distroless/static:nonroot` to overwrite
+ARG BASE_DISTROLESS
+FROM ${BASE_DISTROLESS:-gcr.io/distroless/static:nonroot}
+
 WORKDIR /
-COPY --from=builder /workspace/manager .
+
+ARG TARGETARCH
+COPY --from=builder /workspace/manager-${TARGETARCH} /manager
 USER nonroot:nonroot
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
* Dockerfile updates to support multi-arch image （support `docker build` too）
* github workflow updates
     * migrate to `ghcr.io` ([see more](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images)). need to add a new secret `CR_PAT`
     * switch to `docker/login-action` && `docker/build-push-action@v2` for multi arch image build by `buildx`

examples:
https://github.com/users/morlay/packages/container/package/kubevela%2Fvela-core