### PR TITLE
Move GetConfig into specific commands

### DIFF
--- a/apis/types/args.go
+++ b/apis/types/args.go
@@ -3,10 +3,21 @@ package types
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 // Args is args for controller-runtime client
 type Args struct {
 	Config *rest.Config
 	Schema *runtime.Scheme
+}
+
+// SetConfig insert kubeconfig into Args
+func (a *Args) SetConfig() error {
+	restConf, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+	a.Config = restConf
+	return nil
 }

--- a/pkg/commands/capability.go
+++ b/pkg/commands/capability.go
@@ -9,10 +9,9 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
-
 	"github.com/oam-dev/kubevela/apis/types"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	"github.com/oam-dev/kubevela/pkg/serverlib"
 )
 
@@ -22,12 +21,15 @@ func CapabilityCommandGroup(c types.Args, ioStream cmdutil.IOStreams) *cobra.Com
 		Use:   "cap",
 		Short: "Manage capability centers and installing/uninstalling capabilities",
 		Long:  "Manage capability centers and installing/uninstalling capabilities",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeCap,
 		},
 	}
 	cmd.AddCommand(
-		NewCenterCommand(c, ioStream),
+		NewCenterCommand(ioStream),
 		NewCapListCommand(ioStream),
 		NewCapInstallCommand(c, ioStream),
 		NewCapUninstallCommand(c, ioStream),
@@ -36,7 +38,7 @@ func CapabilityCommandGroup(c types.Args, ioStream cmdutil.IOStreams) *cobra.Com
 }
 
 // NewCenterCommand Manage Capability Center
-func NewCenterCommand(c types.Args, ioStream cmdutil.IOStreams) *cobra.Command {
+func NewCenterCommand(ioStream cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "center <command>",
 		Short: "Manage Capability Center",
@@ -84,6 +86,9 @@ func NewCapInstallCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comm
 		Short:   "Install capability into cluster",
 		Long:    "Install capability into cluster",
 		Example: `vela cap install mycenter/route`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			argsLength := len(args)
@@ -115,6 +120,9 @@ func NewCapUninstallCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Co
 		Short:   "Uninstall capability from cluster",
 		Long:    "Uninstall capability from cluster",
 		Example: `vela cap uninstall route`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("you must specify <name> for capability you want to uninstall")

--- a/pkg/commands/cli.go
+++ b/pkg/commands/cli.go
@@ -6,16 +6,14 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/oam-dev/kubevela/pkg/utils/common"
-
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/cmd/vela/fake"
 	"github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
 	"github.com/oam-dev/kubevela/version"
 )
@@ -45,14 +43,8 @@ func NewCommand() *cobra.Command {
 		},
 	}
 	cmds.PersistentFlags().StringP("env", "e", "", "specify environment name for application")
-	restConf, err := config.GetConfig()
-	if err != nil {
-		fmt.Println("get kubeconfig err", err)
-		os.Exit(1)
-	}
 
 	commandArgs := types.Args{
-		Config: restConf,
 		Schema: common.Scheme,
 	}
 
@@ -76,11 +68,11 @@ func NewCommand() *cobra.Command {
 		NewPortForwardCommand(commandArgs, ioStream),
 		NewLogsCommand(commandArgs, ioStream),
 		NewEnvCommand(commandArgs, ioStream),
-		NewConfigCommand(commandArgs, ioStream),
+		NewConfigCommand(ioStream),
 
 		// Capabilities
 		CapabilityCommandGroup(commandArgs, ioStream),
-		NewTemplateCommand(commandArgs, ioStream),
+		NewTemplateCommand(ioStream),
 		NewTraitsCommand(commandArgs, ioStream),
 		NewWorkloadsCommand(commandArgs, ioStream),
 

--- a/pkg/commands/comp.go
+++ b/pkg/commands/comp.go
@@ -6,14 +6,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/commands/util"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 	"github.com/oam-dev/kubevela/pkg/plugins"
 	"github.com/oam-dev/kubevela/pkg/serverlib"
-
-	"github.com/spf13/cobra"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // constants used in `svc` command
@@ -38,6 +38,9 @@ func AddCompCommands(c types.Args, ioStreams util.IOStreams) *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Short:                 "Manage services",
 		Long:                  "Manage services",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 	}
 	compCommands.PersistentFlags().StringP(App, "a", "", "specify the name of application containing the services")
 
@@ -57,6 +60,9 @@ func NewCompDeployCommands(c types.Args, ioStreams util.IOStreams) *cobra.Comman
 		Short:              "Initialize and run a service",
 		Long:               "Initialize and run a service. The app name would be the same as service name, if it's not specified.",
 		Example:            "vela svc deploy -t <SERVICE_TYPE>",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "-h" {
 				err := cmd.Help()

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -21,7 +21,7 @@ import (
 // The format is the same as k8s Secret.Data field with value base64 encoded.
 
 // NewConfigCommand will create command for config management for AppFile
-func NewConfigCommand(args types.Args, io cmdutil.IOStreams) *cobra.Command {
+func NewConfigCommand(io cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "config",
 		DisableFlagsInUseLine: true,

--- a/pkg/commands/dashboard.go
+++ b/pkg/commands/dashboard.go
@@ -15,13 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/oam-dev/kubevela/apis/types"
-	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
-	"github.com/oam-dev/kubevela/pkg/server"
-	"github.com/oam-dev/kubevela/pkg/server/util"
-	"github.com/oam-dev/kubevela/pkg/utils/helm"
-	"github.com/oam-dev/kubevela/pkg/utils/system"
-
 	"github.com/mholt/archiver/v3"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
@@ -29,6 +22,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/server"
+	"github.com/oam-dev/kubevela/pkg/server/util"
+	"github.com/oam-dev/kubevela/pkg/utils/helm"
+	"github.com/oam-dev/kubevela/pkg/utils/system"
 )
 
 // NewDashboardCommand creates `dashboard` command and its nested children commands
@@ -41,6 +41,9 @@ func NewDashboardCommand(c types.Args, ioStreams cmdutil.IOStreams, frontendSour
 		Short:   "Setup API Server and launch Dashboard",
 		Long:    "Setup API Server and launch Dashboard",
 		Example: `dashboard`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
 			if err != nil {

--- a/pkg/commands/delete.go
+++ b/pkg/commands/delete.go
@@ -3,13 +3,13 @@ package commands
 import (
 	"errors"
 
-	"github.com/oam-dev/kubevela/apis/types"
-	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
-	"github.com/oam-dev/kubevela/pkg/serverlib"
-
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/serverlib"
 )
 
 // NewDeleteCommand Delete App
@@ -19,6 +19,9 @@ func NewDeleteCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 		DisableFlagsInUseLine: true,
 		Short:                 "Delete an application",
 		Long:                  "Delete an application",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeApp,
 		},

--- a/pkg/commands/env.go
+++ b/pkg/commands/env.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gosuri/uitable"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/oam-dev/kubevela/apis/types"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 	"github.com/oam-dev/kubevela/pkg/utils/env"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
-
-	"github.com/gosuri/uitable"
-	"github.com/spf13/cobra"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewEnvCommand creates `env` command and its nested children
@@ -62,6 +62,9 @@ func NewEnvInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 		Short:                 "Create environments",
 		Long:                  "Create environment and set the currently using environment",
 		Example:               `vela env init test --namespace test --email my@email.com`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
 			if err != nil {

--- a/pkg/commands/env_test.go
+++ b/pkg/commands/env_test.go
@@ -8,16 +8,13 @@ import (
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
-
-	"github.com/oam-dev/kubevela/pkg/utils/env"
-
-	"github.com/oam-dev/kubevela/apis/types"
-
-	"github.com/oam-dev/kubevela/pkg/utils/system"
-
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/oam-dev/kubevela/apis/types"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/utils/env"
+	"github.com/oam-dev/kubevela/pkg/utils/system"
 )
 
 func TestENV(t *testing.T) {
@@ -100,4 +97,11 @@ func TestENV(t *testing.T) {
 	// set success
 	err = SetEnv([]string{"default"}, ioStream)
 	assert.NoError(t, err)
+}
+
+func TestEnvInitCommandPersistentPreRunE(t *testing.T) {
+	io := cmdutil.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	fakeC := types.Args{}
+	cmd := NewEnvInitCommand(fakeC, io)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }

--- a/pkg/commands/exec.go
+++ b/pkg/commands/exec.go
@@ -14,12 +14,11 @@ import (
 	cmdexec "k8s.io/kubectl/pkg/cmd/exec"
 	k8scmdutil "k8s.io/kubectl/pkg/cmd/util"
 
-	"github.com/oam-dev/kubevela/pkg/oam"
-
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/application"
 	"github.com/oam-dev/kubevela/pkg/commands/util"
 	velacmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 const (
@@ -59,12 +58,18 @@ func NewExecCommand(c types.Args, ioStreams velacmdutil.IOStreams) *cobra.Comman
 			},
 			Executor: &cmdexec.DefaultRemoteExecutor{},
 		},
-		VelaC: c,
 	}
 	cmd := &cobra.Command{
 		Use:   "exec [flags] APP_NAME -- COMMAND [args...]",
 		Short: "Execute command in a container",
 		Long:  "Execute command in a container",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := c.SetConfig(); err != nil {
+				return err
+			}
+			o.VelaC = c
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				ioStreams.Error("Please specify an application name.")

--- a/pkg/commands/exec_test.go
+++ b/pkg/commands/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,12 +13,11 @@ import (
 	"k8s.io/kubectl/pkg/cmd/exec"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 
-	"github.com/oam-dev/kubevela/pkg/oam"
-
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	"github.com/oam-dev/kubevela/pkg/application"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 func TestExecCommand(t *testing.T) {
@@ -59,4 +59,11 @@ func TestExecCommand(t *testing.T) {
 	o.App = fakeApp
 	err = o.Complete()
 	assert.NoError(t, err)
+}
+
+func TestExecCommandPersistentPreRunE(t *testing.T) {
+	io := cmdutil.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	fakeC := types.Args{}
+	cmd := NewExecCommand(fakeC, io)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }

--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -43,6 +43,9 @@ func NewInitCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 		Short:                 "Create scaffold for an application",
 		Long:                  "Create scaffold for an application",
 		Example:               "vela init",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
 			if err != nil {

--- a/pkg/commands/logs.go
+++ b/pkg/commands/logs.go
@@ -8,17 +8,17 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/oam-dev/kubevela/apis/types"
-	"github.com/oam-dev/kubevela/pkg/application"
-	"github.com/oam-dev/kubevela/pkg/commands/util"
-	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
-
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/wercker/stern/stern"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/application"
+	"github.com/oam-dev/kubevela/pkg/commands/util"
+	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 )
 
 // NewLogsCommand creates `logs` command to tail logs of application
@@ -28,6 +28,13 @@ func NewLogsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 	cmd.Use = "logs"
 	cmd.Short = "Tail logs for application"
 	cmd.Long = "Tail logs for application"
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := c.SetConfig(); err != nil {
+			return err
+		}
+		largs.C = c
+		return nil
+	}
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			ioStreams.Errorf("please specify app name")

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -10,12 +10,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
-
-	runtimeoam "github.com/oam-dev/kubevela/pkg/oam"
-
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/application"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	runtimeoam "github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/server/apis"
 	"github.com/oam-dev/kubevela/pkg/serverlib"
 )
@@ -30,6 +28,9 @@ func NewListCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 		Short:                 "List services",
 		Long:                  "List services of all applications",
 		Example:               `vela ls`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			env, err := GetEnv(cmd)
 			if err != nil {

--- a/pkg/commands/portforward_test.go
+++ b/pkg/commands/portforward_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,10 +13,9 @@ import (
 	"k8s.io/kubectl/pkg/cmd/portforward"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 
-	"github.com/oam-dev/kubevela/pkg/oam"
-
 	"github.com/oam-dev/kubevela/apis/types"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 func TestPortForwardCommand(t *testing.T) {
@@ -50,4 +50,11 @@ func TestPortForwardCommand(t *testing.T) {
 	}
 	err := o.Init(context.Background(), cmd, []string{"fakeApp", "8081:8080"})
 	assert.NoError(t, err)
+}
+
+func TestNewPortForwardCommandPersistentPreRunE(t *testing.T) {
+	io := cmdutil.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	fakeC := types.Args{}
+	cmd := NewPortForwardCommand(fakeC, io)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }

--- a/pkg/commands/status.go
+++ b/pkg/commands/status.go
@@ -19,12 +19,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
-
-	"github.com/oam-dev/kubevela/pkg/oam"
-
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/application"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/oam"
 	oam2 "github.com/oam-dev/kubevela/pkg/serverlib"
 )
 
@@ -102,6 +100,9 @@ func NewAppStatusCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 		Short:   "Show status of an application",
 		Long:    "Show status of an application, including workloads and traits of each service.",
 		Example: `vela status APP_NAME`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsLength := len(args)
 			if argsLength == 0 {

--- a/pkg/commands/system.go
+++ b/pkg/commands/system.go
@@ -105,6 +105,9 @@ func NewInstallCommand(c types.Args, chartContent string, ioStreams cmdutil.IOSt
 		Use:   "install",
 		Short: "Install Vela Core with built-in capabilities",
 		Long:  "Install Vela Core with built-in capabilities",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newClient, err := client.New(c.Config, client.Options{Scheme: c.Schema})
 			if err != nil {

--- a/pkg/commands/template.go
+++ b/pkg/commands/template.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewTemplateCommand creates `template` command and its nested children command
-func NewTemplateCommand(c types.Args, ioStream cmdutil.IOStreams) *cobra.Command {
+func NewTemplateCommand(ioStream cmdutil.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "template",
 		DisableFlagsInUseLine: true,

--- a/pkg/commands/trait.go
+++ b/pkg/commands/trait.go
@@ -5,15 +5,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/application"
 	"github.com/oam-dev/kubevela/pkg/commands/util"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 	"github.com/oam-dev/kubevela/pkg/plugins"
 	"github.com/oam-dev/kubevela/pkg/serverlib"
-
-	"github.com/spf13/cobra"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type commandOptions struct {
@@ -48,6 +48,9 @@ func AddTraitCommands(parentCmd *cobra.Command, c types.Args, ioStreams cmdutil.
 			Short:                 "Attach " + name + " trait to an app",
 			Long:                  "Attach " + name + " trait to an app",
 			Example:               "vela " + name + " frontend",
+			PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+				return c.SetConfig()
+			},
 			RunE: func(cmd *cobra.Command, args []string) error {
 				o := &commandOptions{IOStreams: ioStreams, traitType: name}
 				o.Template = tmp

--- a/pkg/commands/traits.go
+++ b/pkg/commands/traits.go
@@ -23,6 +23,9 @@ func NewTraitsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 		Short:                 "List traits",
 		Long:                  "List traits",
 		Example:               `vela traits`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if syncCluster {
 				if err := RefreshDefinitions(ctx, c, ioStreams, true); err != nil {

--- a/pkg/commands/traits_test.go
+++ b/pkg/commands/traits_test.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/gosuri/uitable"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/oam-dev/kubevela/apis/types"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
@@ -89,4 +90,11 @@ func Test_printTraitList(t *testing.T) {
 		nn := c.workloadName
 		assert.NoError(t, printTraitList(&nn, iostream))
 	}
+}
+
+func TestNewTraitsCommandPersistentPreRunE(t *testing.T) {
+	io := cmdutil.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	fakeC := types.Args{}
+	cmd := NewTraitsCommand(fakeC, io)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }

--- a/pkg/commands/up.go
+++ b/pkg/commands/up.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/oam-dev/kubevela/pkg/utils/common"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,6 +24,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/application"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 	"github.com/oam-dev/kubevela/pkg/oam"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
 )
 
 var (

--- a/pkg/commands/up.go
+++ b/pkg/commands/up.go
@@ -20,14 +20,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
-
-	"github.com/oam-dev/kubevela/pkg/oam"
-
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	"github.com/oam-dev/kubevela/pkg/appfile/template"
 	"github.com/oam-dev/kubevela/pkg/application"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 var (
@@ -43,6 +41,9 @@ func NewUpCommand(c types.Args, ioStream cmdutil.IOStreams) *cobra.Command {
 		Long:                  "Apply an appfile",
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeStart,
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			velaEnv, err := GetEnv(cmd)

--- a/pkg/commands/up_test.go
+++ b/pkg/commands/up_test.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
-
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/commands/util"
 )
@@ -38,4 +38,11 @@ func TestUp(t *testing.T) {
 	msg := o.Info(appName, services)
 	assert.Contains(t, msg, "App has been deployed")
 	assert.Contains(t, msg, fmt.Sprintf("App status: vela status %s", appName))
+}
+
+func TestNewUpCommandPersistentPreRunE(t *testing.T) {
+	io := util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	fakeC := types.Args{}
+	cmd := NewUpCommand(fakeC, io)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }

--- a/pkg/commands/workloads.go
+++ b/pkg/commands/workloads.go
@@ -3,12 +3,12 @@ package commands
 import (
 	"context"
 
+	"github.com/gosuri/uitable"
+	"github.com/spf13/cobra"
+
 	"github.com/oam-dev/kubevela/apis/types"
 	cmdutil "github.com/oam-dev/kubevela/pkg/commands/util"
 	"github.com/oam-dev/kubevela/pkg/plugins"
-
-	"github.com/gosuri/uitable"
-	"github.com/spf13/cobra"
 )
 
 // NewWorkloadsCommand creates `workloads` command
@@ -21,6 +21,9 @@ func NewWorkloadsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 		Short:                 "List workloads",
 		Long:                  "List workloads",
 		Example:               `vela workloads`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if syncCluster {
 				if err := RefreshDefinitions(ctx, c, ioStreams, true); err != nil {


### PR DESCRIPTION
Fix https://github.com/oam-dev/kubevela/issues/655

This PR move GetConfig into specific vela commands to make sure other commands can work without kubeconfig.

During updating, I found some commands that don't need the controller-runtime client arguments. Thus, I removed the controller-runtime client argument from their function parameters.

Moreover, I found some imports don't follow the `goimports` formatting, I sort them up as well.