### PR TITLE
Remove automatically prefixed "[BUG]" in the issue title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
-name: Bug report
+name: "\U0001F41B Bug report"
 about: Create a report to help us improve
-title: "[BUG]"
+title: ""
 labels: kind/bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: "\U0001F680 Feature request"
 about: Suggest an idea for this project
 title: "[Feature]"
 labels: kind/feature


### PR DESCRIPTION
Remove "[BUG]" from the default issue as maintainers can
use labeling mechanism to tell whether it is