### PR TITLE
build version into vela-core and lock helm version on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,11 @@ jobs:
             VERSION=latest
           fi
           echo ::set-output name=VERSION::${VERSION}
+      - name: Get git revision
+        id: vars
+        shell: bash
+        run: |
+          echo "::set-output name=git_revision::$(git rev-parse --short HEAD)"
       - name: Login ghcr.io
         uses: docker/login-action@v1
         with:
@@ -43,6 +48,9 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            GITVERSION=git-${{ steps.vars.outputs.git_revision }}
+            VERSION=${{ steps.get_version.outputs.VERSION }}
           tags: |-
             ghcr.io/${{ github.repository }}/vela-core:${{ steps.get_version.outputs.VERSION }}
             docker.io/oamdev/vela-core:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Use Node.js 10.x
         uses: actions/setup-node@v1
         with:
@@ -30,6 +33,8 @@ jobs:
         run: make npm-build
       - name: Run generate-source
         run: make generate-source
+      - name: Tag helm chart image
+        run: sed -i 's/latest/${{ steps.get_version.outputs.VERSION }}/g' charts/vela-core/values.yaml
       - name: Run cross-build
         run: make cross-build
       - name: Run compress binary
@@ -40,9 +45,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Upload Linux tar.gz
         uses: actions/upload-release-asset@v1.0.2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,15 @@ RUN go mod download
 COPY cmd/core/main.go main.go
 COPY apis/ apis/
 COPY pkg/ pkg/
+COPY version/ version/
 
 # Build
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager-${TARGETARCH} main.go
+ARG VERSION
+ARG GITVERSION
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on \
+    go build -a -ldflags "-X github.com/oam-dev/kubevela/version.VelaVersion=${VERSION:-undefined} -X github.com/oam-dev/kubevela/version.GitRevision=${GITVERSION:-undefined}" \
+    -o manager-${TARGETARCH} main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Vela version
-VELA_VERSION ?= 0.1.0
+VELA_VERSION ?= master
 # Repo info
 GIT_COMMIT          ?= git-$(shell git rev-parse --short HEAD)
 VELA_VERSION_VAR    := github.com/oam-dev/kubevela/version.VelaVersion
@@ -104,8 +104,8 @@ check-diff: reviewable
 	@$(OK) branch is clean
 
 # Build the docker image
-docker-build: test
-	docker build . -t ${IMG}
+docker-build:
+	docker build --build-arg=VERSION=$(VELA_VERSION) --build-arg=GITVERSION=$(GIT_COMMIT) . -t ${IMG}
 
 # Push the docker image
 docker-push:

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
 	velawebhook "github.com/oam-dev/kubevela/pkg/webhook"
 	oamwebhook "github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2"
+	"github.com/oam-dev/kubevela/version"
 )
 
 const (
@@ -66,6 +67,9 @@ func init() {
 }
 
 func main() {
+
+	setupLog.Info(fmt.Sprintf("KubeVela Version: %s, GIT Revision: %s.", version.VelaVersion, version.GitRevision))
+
 	var metricsAddr, logFilePath, leaderElectionNamespace string
 	var enableLeaderElection, logCompress bool
 	var logRetainDate int
@@ -188,6 +192,7 @@ func main() {
 	}
 
 	setupLog.Info("starting the vela controller manager")
+
 	if controllerArgs.ApplyOnceOnly {
 		setupLog.Info("applyOnceOnly is enabled that means workload or trait only apply once if no spec change even they are changed by others")
 	}

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/update_trait_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/update_trait_test.go
@@ -237,12 +237,12 @@ spec:
 
 			By("Apply appConfig & check successfully")
 			Expect(k8sClient.Apply(ctx, &appConfigUpdated)).Should(Succeed())
-			Eventually(func() bool {
+			Eventually(func() int64 {
 				if err := k8sClient.Get(ctx, appConfigKey, &appConfig); err != nil {
-					return false
+					return 0
 				}
-				return appConfig.GetGeneration() == 2
-			}, time.Second, 300*time.Millisecond).Should(BeTrue())
+				return appConfig.GetGeneration()
+			}, time.Second, 300*time.Millisecond).Should(Equal(int64(2)))
 
 			By("Reconcile")
 			reconcileRetry(reconciler, req)
@@ -262,13 +262,13 @@ spec:
 			var traitObj unstructured.Unstructured
 			traitObj.SetAPIVersion("example.com/v1")
 			traitObj.SetKind("Bar")
-			Eventually(func() bool {
+			Eventually(func() int64 {
 				if err := k8sClient.Get(ctx,
 					client.ObjectKey{Namespace: namespace, Name: traitName}, &traitObj); err != nil {
-					return false
+					return 0
 				}
-				return traitObj.GetGeneration() == 2
-			}, 3*time.Second, time.Second).Should(BeTrue())
+				return traitObj.GetGeneration()
+			}, 3*time.Second, time.Second).Should(Equal(int64(2)))
 
 			By("Check labels are removed")
 			_, found, _ := unstructured.NestedString(traitObj.UnstructuredContent(), "metadata", "labels", "test.label")


### PR DESCRIPTION
1. This PR will use `sed` to replace image tag from `latest` to release version, so our chart will lock in the fixed image version. fix #712
2. Build vela-core image with version and git revision, so we can get the specified version for debug. fix #531