### PR TITLE
fix task( k8s job ) restartpolicy default Always

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -16,7 +16,7 @@ spec:
       		parallelism: parameter.count
       		completions: parameter.count
       		template: spec: {
-      			restartPolicy: parameter.policy
+      			restartPolicy: parameter.restartPolicy
       			containers: [{
       				name:  context.name
       				image: parameter.image
@@ -38,7 +38,7 @@ spec:
       	image: string
       
       	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
-      	policy: *"Never" | string
+      	restartPolicy: *"Never" | string
       
       	// +usage=Commands to run in the container
       	cmd?: [...string]

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -37,8 +37,9 @@ spec:
       	// +short=i
       	image: string
       
-        // +usage=Define job restartpolicy policy, the value should be Never or OnFailur,,is not Always
-        policy: *"Never"|string
+	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
+	policy: *"Never" | string
+
       	// +usage=Commands to run in the container
       	cmd?: [...string]
       }

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -16,7 +16,7 @@ spec:
       		parallelism: parameter.count
       		completions: parameter.count
       		template: spec: {
-      			restartPolicy: parameter.restartPolicy
+      			restartPolicy: parameter.restart
       			containers: [{
       				name:  context.name
       				image: parameter.image
@@ -38,7 +38,7 @@ spec:
       	image: string
       
       	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
-      	restartPolicy: *"Never" | string
+      	restart: *"Never" | string
       
       	// +usage=Commands to run in the container
       	cmd?: [...string]

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -16,6 +16,7 @@ spec:
       		parallelism: parameter.count
       		completions: parameter.count
       		template: spec: {
+                        restartPolicy: parameter.policy
       			containers: [{
       				name:  context.name
       				image: parameter.image
@@ -36,6 +37,8 @@ spec:
       	// +short=i
       	image: string
       
+        // +usage=Define job restartpolicy policy, the value should be Never or OnFailur,,is not Always
+        policy: *"Never"|string
       	// +usage=Commands to run in the container
       	cmd?: [...string]
       }

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -37,7 +37,7 @@ spec:
       	// +short=i
       	image: string
       
-      	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
+      	// +usage=Define the job restart policy, the value can only be Never or OnFailure. By default, it's Never.
       	restart: *"Never" | string
       
       	// +usage=Commands to run in the container

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -37,8 +37,8 @@ spec:
       	// +short=i
       	image: string
       
-	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
-	policy: *"Never" | string
+        // +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
+        policy: *"Never" | string
 
       	// +usage=Commands to run in the container
       	cmd?: [...string]

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -16,7 +16,7 @@ spec:
       		parallelism: parameter.count
       		completions: parameter.count
       		template: spec: {
-                        restartPolicy: parameter.policy
+      			restartPolicy: parameter.policy
       			containers: [{
       				name:  context.name
       				image: parameter.image
@@ -37,9 +37,9 @@ spec:
       	// +short=i
       	image: string
       
-        // +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
-        policy: *"Never" | string
-
+      	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
+      	policy: *"Never" | string
+      
       	// +usage=Commands to run in the container
       	cmd?: [...string]
       }

--- a/hack/vela-templates/cue/task.cue
+++ b/hack/vela-templates/cue/task.cue
@@ -26,7 +26,7 @@ parameter: {
 	// +short=i
 	image: string
 
-	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
+	// +usage=Define the job restart policy, the value can only be Never or OnFailure. By default, it's Never.
 	restart: *"Never" | string
 
 	// +usage=Commands to run in the container

--- a/hack/vela-templates/cue/task.cue
+++ b/hack/vela-templates/cue/task.cue
@@ -5,7 +5,7 @@ output: {
 		parallelism: parameter.count
 		completions: parameter.count
 		template: spec: {
-			restartPolicy: parameter.policy
+                        restartPolicy: parameter.policy
 			containers: [{
 				name:  context.name
 				image: parameter.image
@@ -26,8 +26,8 @@ parameter: {
 	// +short=i
 	image: string
 
-	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
-	policy: *"Never" | string
+        // +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
+        policy: *"Never" | string
 
 	// +usage=Commands to run in the container
 	cmd?: [...string]

--- a/hack/vela-templates/cue/task.cue
+++ b/hack/vela-templates/cue/task.cue
@@ -5,7 +5,7 @@ output: {
 		parallelism: parameter.count
 		completions: parameter.count
 		template: spec: {
-			restartPolicy: parameter.restartPolicy
+			restartPolicy: parameter.restart
 			containers: [{
 				name:  context.name
 				image: parameter.image
@@ -27,7 +27,7 @@ parameter: {
 	image: string
 
 	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
-	restartPolicy: *"Never" | string
+	restart: *"Never" | string
 
 	// +usage=Commands to run in the container
 	cmd?: [...string]

--- a/hack/vela-templates/cue/task.cue
+++ b/hack/vela-templates/cue/task.cue
@@ -5,7 +5,7 @@ output: {
 		parallelism: parameter.count
 		completions: parameter.count
 		template: spec: {
-                        restartPolicy: parameter.policy
+			restartPolicy: parameter.policy
 			containers: [{
 				name:  context.name
 				image: parameter.image
@@ -26,8 +26,8 @@ parameter: {
 	// +short=i
 	image: string
 
-        // +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
-        policy: *"Never" | string
+	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
+	policy: *"Never" | string
 
 	// +usage=Commands to run in the container
 	cmd?: [...string]

--- a/hack/vela-templates/cue/task.cue
+++ b/hack/vela-templates/cue/task.cue
@@ -5,7 +5,7 @@ output: {
 		parallelism: parameter.count
 		completions: parameter.count
 		template: spec: {
-			restartPolicy: parameter.policy
+			restartPolicy: parameter.restartPolicy
 			containers: [{
 				name:  context.name
 				image: parameter.image
@@ -27,7 +27,7 @@ parameter: {
 	image: string
 
 	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
-	policy: *"Never" | string
+	restartPolicy: *"Never" | string
 
 	// +usage=Commands to run in the container
 	cmd?: [...string]

--- a/hack/vela-templates/cue/task.cue
+++ b/hack/vela-templates/cue/task.cue
@@ -5,6 +5,7 @@ output: {
 		parallelism: parameter.count
 		completions: parameter.count
 		template: spec: {
+			restartPolicy: parameter.policy
 			containers: [{
 				name:  context.name
 				image: parameter.image
@@ -24,6 +25,9 @@ parameter: {
 	// +usage=Which image would you like to use for your service
 	// +short=i
 	image: string
+
+	// +usage=Define job restart policy, the value should be Never or OnFailure. By default, it's Never.
+	policy: *"Never" | string
 
 	// +usage=Commands to run in the container
 	cmd?: [...string]


### PR DESCRIPTION
Update the restartpolicy default value Always-->Never。
Task creates job RestartPolicy by default with a value of Always, which obviously does not work. I define a parameter policy, which defaults to Never.