### PR TITLE
WIP: add fields for OAM AppConfig and Component to support CUE server side extension

### DIFF
--- a/apis/core.oam.dev/v1alpha2/core_types.go
+++ b/apis/core.oam.dev/v1alpha2/core_types.go
@@ -215,10 +215,21 @@ type ComponentSpec struct {
 	// A Workload that will be created for each ApplicationConfiguration that
 	// includes this Component. Workload is an instance of a workloadDefinition.
 	// We either use the GVK info or a special "type" field in the workload to associate
-	// the content of the workload with its workloadDefinition
+	// the content of the workload with its workloadDefinition.
+	// The 'workload' field is mutually exclusive with the 'type' and 'settings' field.
 	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Workload runtime.RawExtension `json:"workload"`
+	Workload runtime.RawExtension `json:"workload,omitempty"`
+
+	// Type specify a workload type for this component. Workload type is defined by OAM WorkloadDefinition.
+	// If type used, the component properties should write in settings field.
+	// The 'type' field along with 'settings' field is mutually exclusive with the 'workload' field.
+	Type string `json:"type,omitempty"`
+
+	// Settings specify detail configurations of this component according to the spec defined in WorkloadDefinition template.
+	// The 'settings' field along with 'type' field is mutually exclusive with the 'workload' field.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Settings runtime.RawExtension `json:"settings,omitempty"`
 
 	// Parameters exposed by this component. ApplicationConfigurations that
 	// reference this component may specify values for these parameters, which
@@ -288,6 +299,16 @@ type ComponentTrait struct {
 	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Trait runtime.RawExtension `json:"trait"`
+
+	// Name specify a trait type binding to the component. Trait type is defined by OAM TraitDefinition.
+	// If 'name' used, the configuration of trait should write in the 'properties' field.
+	// The 'name' field along with 'properties' field is mutually exclusive with the 'trait' field.
+	Name string `json:"name,omitempty"`
+
+	// Properties specify detail configurations of this trait according to the spec defined in TraitDefinition template.
+	// The 'properties' field along with 'name' field is mutually exclusive with the 'trait' field.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Properties runtime.RawExtension `json:"properties,omitempty"`
 
 	// DataOutputs specify the data output sources from this trait.
 	// +optional

--- a/apis/core.oam.dev/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/core.oam.dev/v1alpha2/zz_generated.deepcopy.go
@@ -509,6 +509,7 @@ func (in *ComponentScope) DeepCopy() *ComponentScope {
 func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 	*out = *in
 	in.Workload.DeepCopyInto(&out.Workload)
+	in.Settings.DeepCopyInto(&out.Settings)
 	if in.Parameters != nil {
 		in, out := &in.Parameters, &out.Parameters
 		*out = make([]ComponentParameter, len(*in))
@@ -553,6 +554,7 @@ func (in *ComponentStatus) DeepCopy() *ComponentStatus {
 func (in *ComponentTrait) DeepCopyInto(out *ComponentTrait) {
 	*out = *in
 	in.Trait.DeepCopyInto(&out.Trait)
+	in.Properties.DeepCopyInto(&out.Properties)
 	if in.DataOutputs != nil {
 		in, out := &in.DataOutputs, &out.DataOutputs
 		*out = make([]DataOutput, len(*in))

--- a/charts/vela-core/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationconfigurations.yaml
@@ -221,6 +221,13 @@ spec:
                                   type: string
                               type: object
                             type: array
+                          name:
+                            description: Name specify a trait type binding to the component. Trait type is defined by OAM TraitDefinition. If 'name' used, the configuration of trait should write in the 'properties' field. The 'name' field along with 'properties' field is mutually exclusive with the 'trait' field.
+                            type: string
+                          properties:
+                            description: Properties specify detail configurations of this trait according to the spec defined in TraitDefinition template. The 'properties' field along with 'name' field is mutually exclusive with the 'trait' field.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           trait:
                             description: A Trait that will be created for the component
                             type: object

--- a/charts/vela-core/crds/core.oam.dev_components.yaml
+++ b/charts/vela-core/crds/core.oam.dev_components.yaml
@@ -67,13 +67,18 @@ spec:
                   - name
                   type: object
                 type: array
+              settings:
+                description: Settings specify detail configurations of this component according to the spec defined in WorkloadDefinition template. The 'settings' field along with 'type' field is mutually exclusive with the 'workload' field.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              type:
+                description: Type specify a workload type for this component. Workload type is defined by OAM WorkloadDefinition. If type used, the component properties should write in settings field. The 'type' field along with 'settings' field is mutually exclusive with the 'workload' field.
+                type: string
               workload:
-                description: A Workload that will be created for each ApplicationConfiguration that includes this Component. Workload is an instance of a workloadDefinition. We either use the GVK info or a special "type" field in the workload to associate the content of the workload with its workloadDefinition
+                description: A Workload that will be created for each ApplicationConfiguration that includes this Component. Workload is an instance of a workloadDefinition. We either use the GVK info or a special "type" field in the workload to associate the content of the workload with its workloadDefinition. The 'workload' field is mutually exclusive with the 'type' and 'settings' field.
                 type: object
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
-            required:
-            - workload
             type: object
           status:
             description: A ComponentStatus represents the observed state of a Component.

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationconfigurations.yaml
@@ -221,6 +221,13 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        name:
+                          description: Name specify a trait type binding to the component. Trait type is defined by OAM TraitDefinition. If 'name' used, the configuration of trait should write in the 'properties' field. The 'name' field along with 'properties' field is mutually exclusive with the 'trait' field.
+                          type: string
+                        properties:
+                          description: Properties specify detail configurations of this trait according to the spec defined in TraitDefinition template. The 'properties' field along with 'name' field is mutually exclusive with the 'trait' field.
+                          type: object
+                          
                         trait:
                           description: A Trait that will be created for the component
                           type: object

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_components.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_components.yaml
@@ -67,13 +67,18 @@ spec:
                 - name
                 type: object
               type: array
+            settings:
+              description: Settings specify detail configurations of this component according to the spec defined in WorkloadDefinition template. The 'settings' field along with 'type' field is mutually exclusive with the 'workload' field.
+              type: object
+              
+            type:
+              description: Type specify a workload type for this component. Workload type is defined by OAM WorkloadDefinition. If type used, the component properties should write in settings field. The 'type' field along with 'settings' field is mutually exclusive with the 'workload' field.
+              type: string
             workload:
-              description: A Workload that will be created for each ApplicationConfiguration that includes this Component. Workload is an instance of a workloadDefinition. We either use the GVK info or a special "type" field in the workload to associate the content of the workload with its workloadDefinition
+              description: A Workload that will be created for each ApplicationConfiguration that includes this Component. Workload is an instance of a workloadDefinition. We either use the GVK info or a special "type" field in the workload to associate the content of the workload with its workloadDefinition. The 'workload' field is mutually exclusive with the 'type' and 'settings' field.
               type: object
               
               
-          required:
-          - workload
           type: object
         status:
           description: A ComponentStatus represents the observed state of a Component.


### PR DESCRIPTION
- [x] 1. Add fields for OAM AppConfig and Component. 
- [ ] 2. Add `template`fields for Definition.
- [ ] 3. Add webhook validation for both fields.

The name is now aligned to OAM Spec. 

https://github.com/oam-dev/spec/blob/master/3.component.md#examples 

```
apiVersion: core.oam.dev/v1alpha2
kind: Component
metadata:
  name: frontend
spec:
  type: Server # <--- the type of the workload
  settings: # <---- the settings of the workload
    osType: linux
    containers:
    - name: my-cool-workload
      image: example/very-cool-workload:0.1.2@sha256:verytrustworthyhash
      resources:
      ....      
```

https://github.com/oam-dev/spec/blob/master/7.application_configuration.md#example

```
apiVersion: core.oam.dev/v1alpha2
kind: ApplicationConfiguration
spec:
  components:
      ...
      traits:
        - name: manualscaler
          properties:
            replicaCount: 2
```

But maybe there's a little weird that we using `name/properties` in trait while using `type/settings` in component.

 @resouer @hongchaodeng @ryanzhang-oss  What do you think? We will make final decision here. Once confirmed we will not change as we must keep consistency and compatibility for it.