### PR TITLE
fix cmd uitable wrap issue

### DIFF
--- a/pkg/commands/capability.go
+++ b/pkg/commands/capability.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -184,7 +183,7 @@ func NewCapListCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			table := uitable.New()
+			table := newUITable()
 			table.AddRow("NAME", "CENTER", "TYPE", "DEFINITION", "STATUS", "APPLIES-TO")
 
 			for _, c := range capabilityList {
@@ -226,7 +225,7 @@ func NewCapCenterRemoveCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 }
 
 func listCapCenters(ioStreams cmdutil.IOStreams) error {
-	table := uitable.New()
+	table := newUITable()
 	table.AddRow("NAME", "ADDRESS")
 	capabilityCenterList, err := serverlib.ListCapabilityCenters()
 	if err != nil {

--- a/pkg/commands/cli.go
+++ b/pkg/commands/cli.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
@@ -103,7 +102,7 @@ func NewCommand() *cobra.Command {
 // PrintHelpByTag print custom defined help message
 func PrintHelpByTag(cmd *cobra.Command, all []*cobra.Command, tag string) {
 	cmd.Printf("  %s:\n\n", tag)
-	table := uitable.New()
+	table := newUITable()
 	for _, c := range all {
 		if val, ok := c.Annotations[types.TagCommandType]; ok && val == tag {
 			table.AddRow("    "+c.Use, c.Long)

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 
 	"github.com/oam-dev/kubevela/apis/types"
@@ -75,8 +74,7 @@ func ListConfigs(ioStreams cmdutil.IOStreams, cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	table := uitable.New()
-	table.MaxColWidth = 60
+	table := newUITable()
 	table.AddRow("NAME")
 	cfgList, err := listConfigs(d)
 	if err != nil {

--- a/pkg/commands/env.go
+++ b/pkg/commands/env.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -131,8 +130,7 @@ func NewEnvSetCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 
 // ListEnvs shows info of all environments
 func ListEnvs(args []string, ioStreams cmdutil.IOStreams) error {
-	table := uitable.New()
-	table.MaxColWidth = 60
+	table := newUITable()
 	table.AddRow("NAME", "CURRENT", "NAMESPACE", "EMAIL", "DOMAIN")
 	var envName = ""
 	if len(args) > 0 {

--- a/pkg/commands/ls.go
+++ b/pkg/commands/ls.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -65,7 +64,7 @@ func printComponentList(ctx context.Context, c client.Client, appName string, en
 		return
 	}
 	all := mergeStagingComponents(deployedComponentList, env, ioStreams)
-	table := uitable.New()
+	table := newUITable()
 	table.AddRow("SERVICE", "APP", "TYPE", "TRAITS", "STATUS", "CREATED-TIME")
 	for _, a := range all {
 		traitAlias := strings.Join(a.TraitNames, ",")

--- a/pkg/commands/print.go
+++ b/pkg/commands/print.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/fatih/color"
+	"github.com/gosuri/uitable"
+	"github.com/kyokomi/emoji"
+)
+
+// colors used in vela cmd for printing
+var (
+	red    = color.New(color.FgRed)
+	green  = color.New(color.FgGreen)
+	yellow = color.New(color.FgYellow)
+	white  = color.New(color.Bold, color.FgWhite)
+)
+
+// emoji used in vela cmd for printing
+var (
+	emojiSucceed   = emoji.Sprint(":check_mark_button:")
+	emojiFail      = emoji.Sprint(":cross_mark:")
+	emojiLightBulb = emoji.Sprint(":light_bulb:")
+)
+
+// newUITable creates a new table with fixed MaxColWidth
+func newUITable() *uitable.Table {
+	t := uitable.New()
+	t.MaxColWidth = 60
+	t.Wrap = true
+	return t
+}
+
+func newTrackingSpinner(suffix string) *spinner.Spinner {
+	suffixColor := color.New(color.Bold, color.FgGreen)
+	return spinner.New(
+		spinner.CharSets[14],
+		100*time.Millisecond,
+		spinner.WithColor("green"),
+		spinner.WithHiddenCursor(true),
+		spinner.WithSuffix(suffixColor.Sprintf(" %s", suffix)))
+}
+
+func applySpinnerNewSuffix(s *spinner.Spinner, suffix string) {
+	suffixColor := color.New(color.Bold, color.FgGreen)
+	s.Suffix = suffixColor.Sprintf(" %s", suffix)
+}

--- a/pkg/commands/refresh.go
+++ b/pkg/commands/refresh.go
@@ -63,7 +63,8 @@ func RefreshDefinitions(ctx context.Context, c types.Args, ioStreams cmdutil.IOS
 // silent indicates whether output existing caps if no change occurs. If false, output all existing caps.
 func printRefreshReport(newCaps, oldCaps []types.Capability, io cmdutil.IOStreams, silent bool) {
 	report := refreshResultReport(newCaps, oldCaps)
-	table := uitable.New()
+	table := newUITable()
+	table.MaxColWidth = 80
 	table.AddRow("TYPE", "CATEGORY", "DESCRIPTION")
 
 	if len(report[added]) == 0 && len(report[updated]) == 0 && len(report[deleted]) == 0 {

--- a/pkg/commands/show.go
+++ b/pkg/commands/show.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 
 	"github.com/oam-dev/kubevela/apis/types"
@@ -55,7 +54,7 @@ func showApplication(cmd *cobra.Command, env *types.EnvMeta, appName string) err
 	}
 
 	cmd.Printf("About:\n\n")
-	table := uitable.New()
+	table := newUITable()
 	table.AddRow("  Name:", appName)
 	table.AddRow("  Created at:", app.CreateTime.String())
 	table.AddRow("  Updated at:", app.UpdateTime.String())
@@ -66,7 +65,7 @@ func showApplication(cmd *cobra.Command, env *types.EnvMeta, appName string) err
 	cmd.Printf("  Namespace:\t%s\n", env.Namespace)
 	cmd.Println()
 
-	table = uitable.New()
+	table = newUITable()
 	cmd.Printf("Services:\n\n")
 
 	for _, svcName := range targetServices {
@@ -96,12 +95,12 @@ func showComponent(cmd *cobra.Command, env *types.EnvMeta, compName, appName str
 			continue
 		}
 		wtype, data := app.GetWorkload(compName)
-		table := uitable.New()
+		table := newUITable()
 		table.AddRow("  - Name:", compName)
 		table.AddRow("    WorkloadType:", wtype)
 		cmd.Printf(table.String())
 		cmd.Printf("\n    Arguments:\n")
-		table = uitable.New()
+		table = newUITable()
 		for k, v := range data {
 			table.AddRow(fmt.Sprintf("      %s:        ", k), v)
 		}
@@ -115,7 +114,7 @@ func showComponent(cmd *cobra.Command, env *types.EnvMeta, compName, appName str
 		cmd.Printf("      Traits:\n")
 		for k, v := range traits {
 			cmd.Printf("        - %s:\n", k)
-			table = uitable.New()
+			table = newUITable()
 			for kk, vv := range v {
 				table.AddRow(fmt.Sprintf("            %s:", kk), vv)
 			}

--- a/pkg/commands/status.go
+++ b/pkg/commands/status.go
@@ -8,11 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/briandowns/spinner"
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/fatih/color"
-	"github.com/gosuri/uitable"
-	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -73,19 +70,6 @@ const (
 	ErrServiceNotFound   = "service %s not found in app"
 )
 
-var (
-	red    = color.New(color.FgRed)
-	green  = color.New(color.FgGreen)
-	yellow = color.New(color.FgYellow)
-	white  = color.New(color.Bold, color.FgWhite)
-)
-
-var (
-	emojiSucceed   = emoji.Sprint(":check_mark_button:")
-	emojiFail      = emoji.Sprint(":cross_mark:")
-	emojiLightBulb = emoji.Sprint(":light_bulb:")
-)
-
 const (
 	trackingInterval      time.Duration = 1 * time.Second
 	deployTimeout         time.Duration = 10 * time.Second
@@ -143,7 +127,7 @@ func printAppStatus(ctx context.Context, c client.Client, ioStreams cmdutil.IOSt
 	}
 
 	cmd.Printf("About:\n\n")
-	table := uitable.New()
+	table := newUITable()
 	table.AddRow("  Name:", appName)
 	table.AddRow("  Namespace:", namespace)
 	table.AddRow("  Created at:", app.CreateTime.String())
@@ -420,21 +404,6 @@ func getWorkloadStatusFromAppConfig(appConfig *v1alpha2.ApplicationConfiguration
 		}
 	}
 	return wlStatus, foundWlStatus
-}
-
-func newTrackingSpinner(suffix string) *spinner.Spinner {
-	suffixColor := color.New(color.Bold, color.FgGreen)
-	return spinner.New(
-		spinner.CharSets[14],
-		100*time.Millisecond,
-		spinner.WithColor("green"),
-		spinner.WithHiddenCursor(true),
-		spinner.WithSuffix(suffixColor.Sprintf(" %s", suffix)))
-}
-
-func applySpinnerNewSuffix(s *spinner.Spinner, suffix string) {
-	suffixColor := color.New(color.Bold, color.FgGreen)
-	s.Suffix = suffixColor.Sprintf(" %s", suffix)
 }
 
 func getHealthStatusColor(s HealthStatus) *color.Color {

--- a/pkg/commands/traits.go
+++ b/pkg/commands/traits.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 
 	"github.com/oam-dev/kubevela/apis/types"
@@ -46,7 +45,7 @@ func NewTraitsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 }
 
 func printTraitList(workloadName *string, ioStreams cmdutil.IOStreams) error {
-	table := uitable.New()
+	table := newUITable()
 	table.Wrap = true
 	traitDefinitionList, err := serverlib.ListTraitDefinitions(workloadName)
 	if err != nil {

--- a/pkg/commands/traits_test.go
+++ b/pkg/commands/traits_test.go
@@ -39,8 +39,7 @@ func Test_printTraitList(t *testing.T) {
 		},
 	}
 	newTable := func() *uitable.Table {
-		table := uitable.New()
-		table.MaxColWidth = 60
+		table := newUITable()
 		table.AddRow("NAME", "DEFINITION", "APPLIES TO")
 		return table
 	}

--- a/pkg/commands/workloads.go
+++ b/pkg/commands/workloads.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 
-	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 
 	"github.com/oam-dev/kubevela/apis/types"
@@ -46,7 +45,7 @@ func NewWorkloadsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 }
 
 func printWorkloadList(workloadList []types.Capability, ioStreams cmdutil.IOStreams) error {
-	table := uitable.New()
+	table := newUITable()
 	table.AddRow("NAME", "DESCRIPTION")
 	for _, r := range workloadList {
 		table.AddRow(r.Name, r.Description)


### PR DESCRIPTION
- Issue: too much content in one table cell makes the table mess.

Before:
![image](https://user-images.githubusercontent.com/5107364/101235104-de133980-3708-11eb-8d7c-6ca4c7dd2b28.png)
Fix: specify `MaxColWidth=80 and Wrap=true` to uitable 
After:
![image](https://user-images.githubusercontent.com/5107364/101235106-e4091a80-3708-11eb-85ed-a2c195ed1438.png)

- move funcs/vars used for printing into one go file.

Signed-off-by: roy wang <seiwy2010@gmail.com>