### PR TITLE
Fixed the problem that the rds crd name is incorrect

### DIFF
--- a/docs/en/platform-engineers/cloud-services.md
+++ b/docs/en/platform-engineers/cloud-services.md
@@ -25,7 +25,7 @@ metadata:
     definition.oam.dev/description: "RDS on Ali Cloud"
 spec:
   definitionRef:
-    name: rds.apps
+    name: rdsinstances.database.alibaba.crossplane.io
   extension:
     template: |
       output: {

--- a/docs/examples/kubecondemo/script/def_db.yaml
+++ b/docs/examples/kubecondemo/script/def_db.yaml
@@ -6,7 +6,7 @@ metadata:
     definition.oam.dev/description: "RDS on Ali Cloud"
 spec:
   definitionRef:
-    name: rds.apps
+    name: rdsinstances.database.alibaba.crossplane.io
   extension:
     template: |
       output: {


### PR DESCRIPTION
When you use crossplane to apply for an rds instance, the rds crd name in the example does not correspond to the name created by crossplane, resulting in a vela workloads error: rds was not ready.

fix #748