### PR TITLE
Adapted for brew installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ build: fmt vet lint
 	@$(OK) build succeed
 
 vela-cli:
+	go run hack/chart/generate.go
 	go build -o bin/vela -ldflags ${LDFLAGS} cmd/vela/main.go
 
 npm-build:


### PR DESCRIPTION
`brew install kubevel` use `make vela-cli` install kubevela, the command `go run hack/chart/generate.go` needs to be added, otherwise the `vela install` command will not run