### PR TITLE
Make the definitionRef field of traitDef optional

### DIFF
--- a/apis/core.oam.dev/v1alpha2/core_types.go
+++ b/apis/core.oam.dev/v1alpha2/core_types.go
@@ -97,7 +97,7 @@ type WorkloadDefinitionList struct {
 // A TraitDefinitionSpec defines the desired state of a TraitDefinition.
 type TraitDefinitionSpec struct {
 	// Reference to the CustomResourceDefinition that defines this trait kind.
-	Reference DefinitionReference `json:"definitionRef"`
+	Reference DefinitionReference `json:"definitionRef,omitempty"`
 
 	// Revision indicates whether a trait is aware of component revision
 	// +optional

--- a/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
@@ -66,8 +66,6 @@ spec:
               workloadRefPath:
                 description: WorkloadRefPath indicates where/if a trait accepts a workloadRef object
                 type: string
-            required:
-            - definitionRef
             type: object
         type: object
     served: true

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
@@ -65,8 +65,6 @@ spec:
             workloadRefPath:
               description: WorkloadRefPath indicates where/if a trait accepts a workloadRef object
               type: string
-          required:
-          - definitionRef
           type: object
       type: object
   version: v1alpha2


### PR DESCRIPTION
- [x] Support Definition Reference be Optional #749

Modified TraitDefinition CRD, and removed the definitionRef field from required list