### PR TITLE
fix inconsistency for dev proxy config

### DIFF
--- a/dashboard/config/proxy.ts
+++ b/dashboard/config/proxy.ts
@@ -1,7 +1,7 @@
 export default {
   dev: {
     '/api/': {
-      target: 'http://localhost:38081/',
+      target: 'http://localhost:8081/',
       changeOrigin: true,
     },
   },


### PR DESCRIPTION
Make it work for `make start-dashboard`:

![20201217201738](https://user-images.githubusercontent.com/920884/102574141-eb370d80-40a4-11eb-9d66-e38abdcbe013.jpg)
