### PR TITLE
fix unstable integration test

### DIFF
--- a/test/integration/appconfig_test.go
+++ b/test/integration/appconfig_test.go
@@ -159,7 +159,13 @@ func TestAppConfigController(t *testing.T) {
 						},
 					}))
 
-				if err := c.Create(context.Background(), ac); err != nil {
+				if err := waitFor(context.Background(), 3*time.Second, func() (bool, error) {
+					// re-try because validating-webhook may fail for workloadDefinition is not found
+					if err := c.Create(context.Background(), ac); err != nil {
+						return false, err
+					}
+					return true, nil
+				}); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
With webhooks of AppConfig enabled when creating an AppConfig, it's necessary to make sure WorkloadDefintion/TraitDefintion/Component are created successfully, otherwise the validating-webhook would fail.

Signed-off-by: roywang <seiwy2010@gmail.com>