### PR TITLE
Add "description" field for each workload from ListWorkloads API

### DIFF
--- a/pkg/server/apis/types.go
+++ b/pkg/server/apis/types.go
@@ -47,9 +47,9 @@ type WorkloadRunBody struct {
 
 // WorkloadMeta store workload metadata for dashboard restful API server
 type WorkloadMeta struct {
-	Name       string            `json:"name"`
-	Parameters []types.Parameter `json:"parameters,omitempty"`
-	AppliesTo  []string          `json:"appliesTo,omitempty"`
+	Name        string            `json:"name"`
+	Parameters  []types.Parameter `json:"parameters,omitempty"`
+	Description string            `json:"description,omitempty"`
 }
 
 // TraitBody used to present trait which is to be attached and, of which parameters are set

--- a/pkg/server/workloadHandler.go
+++ b/pkg/server/workloadHandler.go
@@ -87,9 +87,9 @@ func (s *APIServer) ListWorkload(c *gin.Context) {
 	}
 	for _, w := range workloads {
 		workloadDefinitionList = append(workloadDefinitionList, apis.WorkloadMeta{
-			Name:       w.Name,
-			Parameters: w.Parameters,
-			AppliesTo:  w.AppliesTo,
+			Name:        w.Name,
+			Parameters:  w.Parameters,
+			Description: w.Description,
 		})
 	}
 	util.AssembleResponse(c, workloadDefinitionList, err)


### PR DESCRIPTION
Workload item doesn't have descriptin property, added it to help display
the description in capability list on Dashboard

Fix #821 