### PR TITLE
run CI check for all PR including docs/ and *md

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -5,9 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [master]
-    paths-ignore:
-    - 'docs/**'
-    - '**.md'
 defaults:
   run:
     working-directory: ./dashboard

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,9 +8,6 @@ on:
   workflow_dispatch: {}
   pull_request:
     branches: [master]
-    paths-ignore:
-    - 'docs/**'
-    - '**.md'
 
 env:
   # Common versions


### PR DESCRIPTION
I have made CI checks(e2e, unit tests, lint, diff check as required), but if the CI ignore running these checks, it will hang on and couldn't be merged. So I remove the ignore path, let all changes to run a CI.

![image](https://user-images.githubusercontent.com/2173670/103131075-3de27c00-46da-11eb-85f8-83f888393a61.png)


# Why I make the CI checks required?

Our community is growing and more maintainers will come in, branch protect will help us maintain a repo in high quality. 