### PR TITLE
Refine error message for trait without `spec.extension.template`

### DIFF
--- a/pkg/commands/refresh.go
+++ b/pkg/commands/refresh.go
@@ -57,7 +57,7 @@ func RefreshDefinitions(ctx context.Context, c types.Args, ioStreams cmdutil.IOS
 	}
 	if len(templateErrors) > 0 {
 		for _, e := range templateErrors {
-			ioStreams.Infof("WARN: %v, you will unable to use this workload capability", e)
+			ioStreams.Infof("WARN: %v, you will unable to use this workload capability\n", e)
 		}
 	}
 	syncedTemplates = append(syncedTemplates, templates...)
@@ -69,7 +69,7 @@ func RefreshDefinitions(ctx context.Context, c types.Args, ioStreams cmdutil.IOS
 	}
 	if len(templateErrors) > 0 {
 		for _, e := range templateErrors {
-			ioStreams.Infof("WARN: %v, you will unable to use this trait capability", e)
+			ioStreams.Infof("WARN: %v, you will unable to use this trait capability\n", e)
 		}
 	}
 	syncedTemplates = append(syncedTemplates, templates...)

--- a/pkg/plugins/cluster.go
+++ b/pkg/plugins/cluster.go
@@ -96,7 +96,7 @@ func GetTraitsFromCluster(ctx context.Context, namespace string, c types.Args, s
 	for _, td := range traitDefs.Items {
 		tmp, err := HandleDefinition(td.Name, syncDir, td.Spec.Reference.Name, td.Annotations, td.Spec.Extension, types.TypeTrait, td.Spec.AppliesToWorkloads)
 		if err != nil {
-			templateErrors = append(templateErrors, errors.Wrapf(err, "handle trait template `%s` failed\n", td.Name))
+			templateErrors = append(templateErrors, errors.Wrapf(err, "handle trait template `%s` failed", td.Name))
 			continue
 		}
 		if tmp, err = validateCapabilities(tmp, dm, td.Name, td.Spec.Reference); err != nil {


### PR DESCRIPTION
Error message of trait without `spec.extension.template`
adheres with normal message when executing "vela workloads".

To fix #826