### PR TITLE
Expend column width for "vela workloads/traits"

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/autoscale.yaml
+++ b/charts/vela-core/templates/defwithtemplate/autoscale.yaml
@@ -4,7 +4,7 @@ kind: TraitDefinition
 metadata:
   name: autoscale
   annotations:
-    definition.oam.dev/description: "`Autoscale` is used to automatically scale workloads by resource utilization metrics or cron triggers."
+    definition.oam.dev/description: "Automatically scales workloads by resource utilization metrics or cron triggers."
 spec:
   appliesToWorkloads:
     - webservice

--- a/charts/vela-core/templates/defwithtemplate/manualscale.yaml
+++ b/charts/vela-core/templates/defwithtemplate/manualscale.yaml
@@ -3,7 +3,7 @@ apiVersion: core.oam.dev/v1alpha2
 kind: TraitDefinition
 metadata:
   annotations:
-    definition.oam.dev/description: "`Scaler` is used to configure replicas for your service."
+    definition.oam.dev/description: "Configures replicas for your service."
   name: scaler
 spec:
   appliesToWorkloads:

--- a/charts/vela-core/templates/defwithtemplate/metrics.yaml
+++ b/charts/vela-core/templates/defwithtemplate/metrics.yaml
@@ -4,7 +4,7 @@ kind: TraitDefinition
 metadata:
   name: metrics
   annotations:
-    definition.oam.dev/description: "`Metrics` is used to configure monitoring metrics for your service."
+    definition.oam.dev/description: "Configures monitoring metrics for your service."
 spec:
   appliesToWorkloads:
     - webservice

--- a/charts/vela-core/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-core/templates/defwithtemplate/rollout.yaml
@@ -4,7 +4,7 @@ kind: TraitDefinition
 metadata:
   name: rollout
   annotations:
-    definition.oam.dev/description: "`Rollout` is used to configure Canary deployment strategy for your application."
+    definition.oam.dev/description: "Configures Canary deployment strategy for your application."
 spec:
   appliesToWorkloads:
     - webservice

--- a/charts/vela-core/templates/defwithtemplate/route.yaml
+++ b/charts/vela-core/templates/defwithtemplate/route.yaml
@@ -4,7 +4,7 @@ kind: TraitDefinition
 metadata:
   name: route
   annotations:
-    definition.oam.dev/description: "`Route` is used to configure external access to your service."
+    definition.oam.dev/description: "Configures external access to your service."
 spec:
   appliesToWorkloads:
     - webservice

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -4,7 +4,7 @@ kind: WorkloadDefinition
 metadata:
   name: task
   annotations:
-    definition.oam.dev/description: "`Task` is a workload type to describe jobs that run code or a script to completion."
+    definition.oam.dev/description: "Describes jobs that run code or a script to completion."
 spec:
   definitionRef:
     name: jobs.batch

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -4,8 +4,8 @@ kind: WorkloadDefinition
 metadata:
   name: webservice
   annotations:
-    definition.oam.dev/description: "`Webservice` is a workload type to describe long-running, scalable, containerized services that have a stable network endpoint to receive external network traffic from customers.
-    If workload type is skipped for any service defined in Appfile, it will be defaulted to `Web Service` type."
+    definition.oam.dev/description: "Describes long-running, scalable, containerized services that have a stable network endpoint to receive external network traffic from customers.
+    If workload type is skipped for any service defined in Appfile, it will be defaulted to `webservice` type."
 spec:
   definitionRef:
     name: deployments.apps

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -4,7 +4,7 @@ kind: WorkloadDefinition
 metadata:
   name: worker
   annotations:
-    definition.oam.dev/description: "`Worker` is a workload type to describe long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic."
+    definition.oam.dev/description: "Describes long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic."
 spec:
   definitionRef:
     name: deployments.apps

--- a/docs/en/developers/references/traits/autoscale.md
+++ b/docs/en/developers/references/traits/autoscale.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`Autoscale` is used to automatically scale workloads by resource utilization metrics or cron triggers.
+Automatically scales workloads by resource utilization metrics or cron triggers.
 
 ## Specification
 

--- a/docs/en/developers/references/traits/metrics.md
+++ b/docs/en/developers/references/traits/metrics.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`Metrics` is used to configure monitoring metrics for your service.
+Configures monitoring metrics for your service.
 
 ## Specification
 

--- a/docs/en/developers/references/traits/rollout.md
+++ b/docs/en/developers/references/traits/rollout.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`Rollout` is used to configure Canary deployment strategy for your application.
+Configures Canary deployment strategy for your application.
 
 ## Specification
 

--- a/docs/en/developers/references/traits/route.md
+++ b/docs/en/developers/references/traits/route.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`Route` is used to configure external access to your service.
+Configures external access to your service.
 
 ## Specification
 
@@ -37,4 +37,3 @@ Name | Description | Type | Required | Default
 ------------ | ------------- | ------------- | ------------- | ------------- 
  path |  | string | true |  
  rewriteTarget |  | string | true | empty 
- 

--- a/docs/en/developers/references/traits/scaler.md
+++ b/docs/en/developers/references/traits/scaler.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`Scaler` is used to configure replicas for your service.
+Configures replicas for your service.
 
 ## Specification
 

--- a/docs/en/developers/references/workload-types/task.md
+++ b/docs/en/developers/references/workload-types/task.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`Task` is a workload type to describe jobs that run code or a script to completion.
+Describes jobs that run code or a script to completion.
 
 ## Specification
 

--- a/docs/en/developers/references/workload-types/webservice.md
+++ b/docs/en/developers/references/workload-types/webservice.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`Webservice` is a workload type to describe long-running, scalable, containerized services that have a stable network endpoint to receive external network traffic from customers. If workload type is skipped for any service defined in Appfile, it will be defaulted to `Web Service` type.
+Describes long-running, scalable, containerized services that have a stable network endpoint to receive external network traffic from customers. If workload type is skipped for any service defined in Appfile, it will be defaulted to `webservice` type.
 
 ## Specification
 
@@ -61,4 +61,3 @@ Name | Description | Type | Required | Default
 ------------ | ------------- | ------------- | ------------- | ------------- 
  name | The name of the secret in the pod's namespace to select from | string | true |  
  key | The key of the secret to select from. Must be a valid secret key | string | true |  
-

--- a/docs/en/developers/references/workload-types/worker.md
+++ b/docs/en/developers/references/workload-types/worker.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`Worker` is a workload type to describe long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic.
+Describes long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic.
 
 ## Specification
 

--- a/hack/references/generate.go
+++ b/hack/references/generate.go
@@ -60,6 +60,10 @@ func main() {
 			fmt.Printf("failed to open file %s: %s", filePath, err)
 			os.Exit(1)
 		}
+		if err = os.Truncate(filePath, 0); err != nil {
+			fmt.Printf("failed to truncate file %s: %s", filePath, err)
+			os.Exit(1)
+		}
 		capName := c.Name
 		ref := ReferenceMarkdown{
 			CapabilityName: capName,

--- a/hack/vela-templates/definitions/autoscale.yaml
+++ b/hack/vela-templates/definitions/autoscale.yaml
@@ -3,7 +3,7 @@ kind: TraitDefinition
 metadata:
   name: autoscale
   annotations:
-    definition.oam.dev/description: "`Autoscale` is used to automatically scale workloads by resource utilization metrics or cron triggers."
+    definition.oam.dev/description: "Automatically scales workloads by resource utilization metrics or cron triggers."
 spec:
   appliesToWorkloads:
     - webservice

--- a/hack/vela-templates/definitions/manualscale.yaml
+++ b/hack/vela-templates/definitions/manualscale.yaml
@@ -2,7 +2,7 @@ apiVersion: core.oam.dev/v1alpha2
 kind: TraitDefinition
 metadata:
   annotations:
-    definition.oam.dev/description: "`Scaler` is used to configure replicas for your service."
+    definition.oam.dev/description: "Configures replicas for your service."
   name: scaler
 spec:
   appliesToWorkloads:

--- a/hack/vela-templates/definitions/metrics.yaml
+++ b/hack/vela-templates/definitions/metrics.yaml
@@ -3,7 +3,7 @@ kind: TraitDefinition
 metadata:
   name: metrics
   annotations:
-    definition.oam.dev/description: "`Metrics` is used to configure monitoring metrics for your service."
+    definition.oam.dev/description: "Configures monitoring metrics for your service."
 spec:
   appliesToWorkloads:
     - webservice

--- a/hack/vela-templates/definitions/rollout.yaml
+++ b/hack/vela-templates/definitions/rollout.yaml
@@ -3,7 +3,7 @@ kind: TraitDefinition
 metadata:
   name: rollout
   annotations:
-    definition.oam.dev/description: "`Rollout` is used to configure Canary deployment strategy for your application."
+    definition.oam.dev/description: "Configures Canary deployment strategy for your application."
 spec:
   appliesToWorkloads:
     - webservice

--- a/hack/vela-templates/definitions/route.yaml
+++ b/hack/vela-templates/definitions/route.yaml
@@ -3,7 +3,7 @@ kind: TraitDefinition
 metadata:
   name: route
   annotations:
-    definition.oam.dev/description: "`Route` is used to configure external access to your service."
+    definition.oam.dev/description: "Configures external access to your service."
 spec:
   appliesToWorkloads:
     - webservice

--- a/hack/vela-templates/definitions/task.yaml
+++ b/hack/vela-templates/definitions/task.yaml
@@ -3,7 +3,7 @@ kind: WorkloadDefinition
 metadata:
   name: task
   annotations:
-    definition.oam.dev/description: "`Task` is a workload type to describe jobs that run code or a script to completion."
+    definition.oam.dev/description: "Describes jobs that run code or a script to completion."
 spec:
   definitionRef:
     name: jobs.batch

--- a/hack/vela-templates/definitions/webservice.yaml
+++ b/hack/vela-templates/definitions/webservice.yaml
@@ -3,8 +3,8 @@ kind: WorkloadDefinition
 metadata:
   name: webservice
   annotations:
-    definition.oam.dev/description: "`Webservice` is a workload type to describe long-running, scalable, containerized services that have a stable network endpoint to receive external network traffic from customers.
-    If workload type is skipped for any service defined in Appfile, it will be defaulted to `Web Service` type."
+    definition.oam.dev/description: "Describes long-running, scalable, containerized services that have a stable network endpoint to receive external network traffic from customers.
+    If workload type is skipped for any service defined in Appfile, it will be defaulted to `webservice` type."
 spec:
   definitionRef:
     name: deployments.apps

--- a/hack/vela-templates/definitions/worker.yaml
+++ b/hack/vela-templates/definitions/worker.yaml
@@ -3,7 +3,7 @@ kind: WorkloadDefinition
 metadata:
   name: worker
   annotations:
-    definition.oam.dev/description: "`Worker` is a workload type to describe long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic."
+    definition.oam.dev/description: "Describes long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic."
 spec:
   definitionRef:
     name: deployments.apps

--- a/pkg/commands/traits.go
+++ b/pkg/commands/traits.go
@@ -47,6 +47,7 @@ func NewTraitsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 
 func printTraitList(workloadName *string, ioStreams cmdutil.IOStreams) error {
 	table := newUITable()
+	table.MaxColWidth = 120
 	table.Wrap = true
 	traitDefinitionList, err := serverlib.ListTraitDefinitions(workloadName)
 	if err != nil {

--- a/pkg/commands/workloads.go
+++ b/pkg/commands/workloads.go
@@ -47,6 +47,7 @@ func NewWorkloadsCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 
 func printWorkloadList(workloadList []types.Capability, ioStreams cmdutil.IOStreams) error {
 	table := newUITable()
+	table.MaxColWidth = 120
 	table.AddRow("NAME", "DESCRIPTION")
 	for _, r := range workloadList {
 		table.AddRow(r.Name, r.Description)


### PR DESCRIPTION
Expended column width for `vela workloads/traits` and also
shortened the description for all workloads and traits.
Fixed a tiny issue in hack/reference/generate.go

To fix issue #827