### PR TITLE
feature: add healthcheck policy for workload and trait by cue template

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -108,6 +108,14 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	app.Status.SetConditions(readyCondition("Applied"))
 
+	applog.Info("check application health status")
+	// check application health status
+	if err := handler.healthCheck(appfile); err != nil {
+		app.Status.SetConditions(errorCondition("HealthCheck", err))
+		return handler.Err(err)
+	}
+
+	app.Status.SetConditions(readyCondition("HealthCheck"))
 	app.Status.Phase = v1alpha2.ApplicationRunning
 	// Gather status of components
 	var refComps []v1alpha1.TypedReference

--- a/pkg/controller/core.oam.dev/v1alpha2/application/template/template_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/template/template_test.go
@@ -79,7 +79,7 @@ spec:
 	m := manager{
 		mock,
 	}
-	temp, err := m.LoadTemplate("worker", types.TypeWorkload)
+	temp, _, err := m.LoadTemplate("worker", types.TypeWorkload)
 	if err != nil {
 		t.Error(err)
 		return

--- a/pkg/dsl/definition/template.go
+++ b/pkg/dsl/definition/template.go
@@ -1,6 +1,7 @@
 package definition
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -9,21 +10,35 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/build"
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/pkg/dsl/model"
 	"github.com/oam-dev/kubevela/pkg/dsl/process"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+var (
+	metadataAccessor = meta.NewAccessor()
 )
 
 // Template defines Definition's Render interface
 type Template interface {
 	Params(params interface{}) Template
 	Complete(ctx process.Context) error
+	Output(ctx process.Context, client client.Client, name string) Template
+	HealthCheck() error
 }
 
 type def struct {
 	name   string
 	templ  string
+	health string
 	params interface{}
+	output map[string]interface{}
 }
 
 type workloadDef struct {
@@ -31,12 +46,14 @@ type workloadDef struct {
 }
 
 // NewWDTemplater create Workload Definition templater
-func NewWDTemplater(name, templ string) Template {
+func NewWDTemplater(name, templ, health string) Template {
 	return &workloadDef{
 		def: def{
 			name:   name,
 			templ:  templ,
+			health: health,
 			params: nil,
+			output: nil,
 		},
 	}
 }
@@ -78,16 +95,65 @@ func (wd *workloadDef) Complete(ctx process.Context) error {
 	return nil
 }
 
+// Output fetch the workload cr and set result to context
+func (wd *workloadDef) Output(ctx process.Context, client client.Client, name string) Template {
+	base, _ := ctx.Output()
+	componentWorkload, err := base.Unstructured()
+	if err != nil {
+		return wd
+	}
+	workloadCr, err := getObj(client, componentWorkload, name)
+	if err != nil {
+		return wd
+	}
+	wd.output = workloadCr
+	return wd
+}
+
+// HealthCheck address health check for workload
+func (wd *workloadDef) HealthCheck() error {
+	if wd.health == "" {
+		return nil
+	}
+	bi := build.NewContext().NewInstance("", nil)
+	if err := bi.AddFile("-", wd.health); err != nil {
+		return err
+	}
+	if wd.output != nil {
+		bt, _ := json.Marshal(wd.output)
+		if err := bi.AddFile("output", fmt.Sprintf("output: %s", string(bt))); err != nil {
+			return err
+		}
+	} else {
+		return errors.WithMessagef(errors.New("there is no workload output cr for health check"), "workload %s health check", wd.name)
+	}
+	insts := cue.Build([]*build.Instance{bi})
+	for _, inst := range insts {
+		if err := inst.Value().Err(); err != nil {
+			return errors.WithMessagef(err, "workload %s check", wd.name)
+		}
+		isHealthVal := inst.Lookup("isHealth")
+		if isHealthVal.Exists() {
+			healthRs := isHealthVal.Eval()
+			if isHealth, err := healthRs.Bool(); err != nil || !isHealth {
+				return errors.WithMessage(err, "the workload is unhealthy")
+			}
+		}
+	}
+	return nil
+}
+
 type traitDef struct {
 	def
 }
 
 // NewTDTemplater create Trait Definition templater
-func NewTDTemplater(name, templ string) Template {
+func NewTDTemplater(name, templ, health string) Template {
 	return &traitDef{
 		def: def{
-			name:  name,
-			templ: templ,
+			name:   name,
+			templ:  templ,
+			health: health,
 		},
 	}
 }
@@ -169,4 +235,83 @@ func (td *traitDef) Complete(ctx process.Context) error {
 
 	}
 	return nil
+}
+
+// Output fetch the trait cr and set result to context
+func (td *traitDef) Output(ctx process.Context, client client.Client, name string) Template {
+	_, assists := ctx.Output()
+	for _, assist := range assists {
+		if assist.Type != td.name {
+			continue
+		}
+		traitRef, err := assist.Ins.Unstructured()
+		if err != nil {
+			return td
+		}
+		traitCr, err := getObj(client, traitRef, name)
+		if err != nil {
+			return td
+		}
+		td.output = traitCr
+		return td
+	}
+	return td
+}
+
+// HealthCheck address health check for trait
+func (td *traitDef) HealthCheck() error {
+	if td.health == "" {
+		return nil
+	}
+	bi := build.NewContext().NewInstance("", nil)
+	if err := bi.AddFile("-", td.health); err != nil {
+		return err
+	}
+	if td.output != nil {
+		bt, _ := json.Marshal(td.output)
+		if err := bi.AddFile("output", fmt.Sprintf("output: %s", string(bt))); err != nil {
+			return err
+		}
+	} else {
+		return errors.WithMessagef(errors.New("there is no trait output cr for health check"), "trait %s health check", td.name)
+	}
+	insts := cue.Build([]*build.Instance{bi})
+	for _, inst := range insts {
+		if err := inst.Value().Err(); err != nil {
+			return errors.WithMessagef(err, "trait %s check", td.name)
+		}
+		isHealthVal := inst.Lookup("isHealth")
+		if isHealthVal.Exists() {
+			if isHealth, err := isHealthVal.Bool(); err != nil || !isHealth {
+				return errors.WithMessage(err, "the trait is unhealthy")
+			}
+		}
+	}
+	return nil
+}
+
+func getObj(cli client.Client, obj runtime.Object, name string) (map[string]interface{}, error) {
+	var kind, apiVersion string
+	var err error
+	kind, err = metadataAccessor.Kind(obj)
+	if err != nil {
+		return nil, fmt.Errorf("cannot access object kind")
+	}
+	apiVersion, err = metadataAccessor.APIVersion(obj)
+	if err != nil {
+		return nil, fmt.Errorf("cannot access object kind")
+	}
+	unList := &unstructured.UnstructuredList{}
+	unList.SetKind(kind)
+	unList.SetAPIVersion(apiVersion)
+	if err := cli.List(context.Background(), unList, client.MatchingLabels{oam.LabelAppName: name}); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(unList.Items) == 0 {
+		return nil, nil
+	}
+	return unList.Items[0].Object, nil
 }

--- a/pkg/dsl/definition/template_test.go
+++ b/pkg/dsl/definition/template_test.go
@@ -39,7 +39,7 @@ parameter: {
 
 	for _, v := range testCases {
 		ctx := process.NewContext("test")
-		wt := NewWDTemplater("-", v.templ)
+		wt := NewWDTemplater("-", v.templ, "")
 		if err := wt.Params(v.params).Complete(ctx); err != nil {
 			t.Error(err)
 			return
@@ -74,7 +74,7 @@ parameter: {
 }
 `
 	ctx := process.NewContext("test")
-	wt := NewWDTemplater("-", baseTemplate)
+	wt := NewWDTemplater("-", baseTemplate, "")
 	if err := wt.Params(map[string]interface{}{
 		"replicas": 2,
 	}).Complete(ctx); err != nil {
@@ -107,7 +107,7 @@ parameter: {
 	}
 
 	for _, v := range tds {
-		td := NewTDTemplater("-", v.templ)
+		td := NewTDTemplater("-", v.templ, "")
 		if err := td.Params(v.params).Complete(ctx); err != nil {
 			t.Error(err)
 			return


### PR DESCRIPTION
- [x] Support Custom Health Check Logic for Appliction by Cue Template

Vela is used for application release, and how to evaluate the success of an application release? Not only Vela creates workloads and traits, but more importantly, Vela should check the health of workloads and traits. HealthScope is hardcoded for the health check logic of various resources. Here providers a custom health check plan.

### Health Check Policy

After the K8s resource is created, the relevant data will be written back to the status of CR. Whether the release is successful is actually a series of judgments and filter conditions combination, called health policy. Vela should combine with the data in CR and the policy to determine whether a resource object meets the conditions. For example, when the values of replicas and readyReplicas in the status of Deployment CR are equal, the release is successful.

Developers could customize the health check policy in the definition, which has high scalability.
``` yaml
apiVersion: core.oam.dev/v1alpha2
kind: WorkloadDefinition
metadata:
  name: worker
  annotations:
    definition.oam.dev/description: "Long-running scalable backend worker without network endpoint"
spec:
  definitionRef:
    name: deployments.apps
  extension:
    healthPolicy: |
      isHealth: output.status.replicas == output.status.readyReplicas
    template
      ... 
```
* **healthPolicy** is the customized policy by developer 
* **output** represents the CR
### Example
* Workload(deployment) health policy
```yaml
apiVersion: core.oam.dev/v1alpha2
kind: WorkloadDefinition
metadata:
  name: worker
  annotations:
    definition.oam.dev/description: "Long-running scalable backend worker without network endpoint"
spec:
  definitionRef:
    name: deployments.apps
  extension:
    healthPolicy: |
      isHealth: output.status.replicas == output.status.readyReplicas
    template: |
      output: {
      	apiVersion: "apps/v1"
      	kind:       "Deployment"
      	spec: {
      		selector: matchLabels: {
      			"app.oam.dev/component": context.name
      		}
      		template: {
      			metadata: labels: {
      				"app.oam.dev/component": context.name
      			}
      			spec: {
      				containers: [{
      					name:  context.name
      					image: parameter.image

      					if parameter["cmd"] != _|_ {
      						command: parameter.cmd
      					}
      				}]
      			}
      		}

      		selector:
      			matchLabels:
      				"app.oam.dev/component": context.name
      	}
      }

      parameter: {
      	// +usage=Which image would you like to use for your service
      	// +short=i
      	image: string

      	cmd?: [...string]
      }`
```
* Trait(ManualScalerTrait) health policy
It is assumed that the trait will return whether the release is successful through the **phase** of status
```yaml
apiVersion: core.oam.dev/v1alpha2
kind: TraitDefinition
metadata:
  annotations:
    definition.oam.dev/description: "Manually scale the app"
  name: scaler
spec:
  appliesToWorkloads:
    - webservice
    - worker
  definitionRef:
    name: manualscalertraits.core.oam.dev
  workloadRefPath: spec.workloadRef
  extension:
    healthPolicy: |
      isHealth: output.status.phase == "ready"
    template: |-
      output: {
      	apiVersion: "core.oam.dev/v1alpha2"
      	kind:       "ManualScalerTrait"
      	spec: {
      		replicaCount: parameter.replicas
      	}
      }
      parameter: {
      	//+short=r
      	replicas: *1 | int
      }
```