### PR TITLE
Upload vela core chart to alibaba cloud oss for every release and master commit

### DIFF
--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -12,9 +12,8 @@ env:
   ACCESS_KEY: ${{ secrets.OSS_ACCESS_KEY }}
   ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
 
-
 jobs:
-  update:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -48,6 +47,6 @@ jobs:
       - name: Package helm charts
         run: |
           helm package charts/vela-core --destination .oss/
-          helm repo index .oss/
+          helm repo index --url https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core .oss/
       - name: sync local to cloud
         run: ./ossutil --config-file .ossutilconfig sync .oss/ oss://kubevelacharts/core

--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Get the version
@@ -36,8 +36,10 @@ jobs:
           version: v3.4.0
       - name: Tag helm chart image
         run:  |
-          sed -i 's/latest/${{ steps.get_version.outputs.VERSION }}/g' charts/vela-core/values.yaml
-          sed -i 's/0.1.0/${{ steps.get_version.outputs.VERSION }}/g' charts/vela-core/Chart.yaml
+          version=${{ steps.get_version.outputs.VERSION }}
+          number=${version#"v"}
+          sed -i "s/latest/$number/g" charts/vela-core/values.yaml
+          sed -i "s/0.1.0/$number/g" charts/vela-core/Chart.yaml
       - name: Install ossutil
         run: wget http://gosspublic.alicdn.com/ossutil/1.7.0/ossutil64 && chmod +x ossutil64 && mv ossutil64 ossutil
       - name: Configure Alibaba Cloud OSSUTIL

--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -42,12 +42,12 @@ jobs:
       - name: Install ossutil
         run: wget http://gosspublic.alicdn.com/ossutil/1.7.0/ossutil64 && chmod +x ossutil64 && mv ossutil64 ossutil
       - name: Configure Alibaba Cloud OSSUTIL
-        run: ./ossutil config -i ${ACCESS_KEY} -k ${ACCESS_KEY_SECRET} -e ${ENDPOINT} -c .ossutilconfig
+        run: ./ossutil --config-file .ossutilconfig config -i ${ACCESS_KEY} -k ${ACCESS_KEY_SECRET} -e ${ENDPOINT} -c .ossutilconfig
       - name: sync cloud to local
-        run: ./ossutil sync oss://kubevelacharts/core .oss/
+        run: ./ossutil --config-file .ossutilconfig sync oss://kubevelacharts/core .oss/
       - name: Package helm charts
         run: |
           helm package charts/vela-core --destination .oss/
           helm repo index .oss/
       - name: sync local to cloud
-        run: ./ossutil sync .oss/ oss://kubevelacharts/core
+        run: ./ossutil --config-file .ossutilconfig sync .oss/ oss://kubevelacharts/core

--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -49,4 +49,4 @@ jobs:
           helm package charts/vela-core --destination .oss/
           helm repo index --url https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core .oss/
       - name: sync local to cloud
-        run: ./ossutil --config-file .ossutilconfig sync .oss/ oss://kubevelacharts/core
+        run: ./ossutil --config-file .ossutilconfig sync .oss/ oss://kubevelacharts/core -f

--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -1,0 +1,53 @@
+name: Charts
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+
+env:
+  BUCKET: kubevelacharts
+  ENDPOINT: oss-cn-hangzhou.aliyuncs.com
+  ACCESS_KEY: ${{ secrets.OSS_ACCESS_KEY }}
+  ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Get the version
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          if [[ ${GITHUB_REF} == "refs/heads/master" ]]; then
+            VERSION=latest
+          fi
+          echo ::set-output name=VERSION::${VERSION}
+      - name: Get git revision
+        id: vars
+        shell: bash
+        run: |
+          echo "::set-output name=git_revision::$(git rev-parse --short HEAD)"
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+      - name: Tag helm chart image
+        run:  |
+          sed -i 's/latest/${{ steps.get_version.outputs.VERSION }}/g' charts/vela-core/values.yaml
+          sed -i 's/0.1.0/${{ steps.get_version.outputs.VERSION }}/g' charts/vela-core/Chart.yaml
+      - name: Install ossutil
+        run: wget http://gosspublic.alicdn.com/ossutil/1.7.0/ossutil64 && chmod +x ossutil64 && mv ossutil64 ossutil
+      - name: Configure Alibaba Cloud OSSUTIL
+        run: ./ossutil config -i ${ACCESS_KEY} -k ${ACCESS_KEY_SECRET} -e ${ENDPOINT} -c .ossutilconfig
+      - name: sync cloud to local
+        run: ./ossutil sync oss://kubevelacharts/core .oss/
+      - name: Package helm charts
+        run: |
+          helm package charts/vela-core --destination .oss/
+          helm repo index .oss/
+      - name: sync local to cloud
+        run: ./ossutil sync .oss/ oss://kubevelacharts/core


### PR DESCRIPTION
AccessKey was added as Github secret and it has only permission to write the specified oss bucket.

Users will be able to use it by:

1. Add repo

```
helm repo add kubevela https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core
```

2. Update repo

```
helm repo update
```

3. Search version

```
helm search repo kubevela
```

4. Install

```
helm install kubevela/vela-core
```
 