### PR TITLE
Set KubeVela as verified publisher of ArtifactHub

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -12,6 +12,7 @@ env:
   ENDPOINT: oss-cn-hangzhou.aliyuncs.com
   ACCESS_KEY: ${{ secrets.OSS_ACCESS_KEY }}
   ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+  ARTIFACT_HUB_REPOSITORY_ID: ${{ secrets.ARTIFACT_HUB_REPOSITORY_ID }}
 
 jobs:
   publish-images:
@@ -95,6 +96,11 @@ jobs:
         run: ./ossutil --config-file .ossutilconfig config -i ${ACCESS_KEY} -k ${ACCESS_KEY_SECRET} -e ${ENDPOINT} -c .ossutilconfig
       - name: sync cloud to local
         run: ./ossutil --config-file .ossutilconfig sync oss://kubevelacharts/core .oss/
+      - name: add artifacthub stuff to the repo
+        run: |
+          rsync docs/en/install.md ./oss
+          sed -i '' "s/ARTIFACT_HUB_REPOSITORY_ID/$ARTIFACT_HUB_REPOSITORY_ID/g" hack/artifacthub/artifacthub-repo.yml
+          rsync hack/artifacthub/artifacthub-repo.yml ./oss
       - name: Package helm charts
         run: |
           helm package charts/vela-core --destination .oss/

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -98,7 +98,7 @@ jobs:
         run: ./ossutil --config-file .ossutilconfig sync oss://kubevelacharts/core .oss/
       - name: add artifacthub stuff to the repo
         run: |
-          rsync docs/en/install.md ./oss
+          rsync docs/en/install.md charts/vela-core/README.md
           sed -i '' "s/ARTIFACT_HUB_REPOSITORY_ID/$ARTIFACT_HUB_REPOSITORY_ID/g" hack/artifacthub/artifacthub-repo.yml
           rsync hack/artifacthub/artifacthub-repo.yml ./oss
       - name: Package helm charts

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Releases](https://img.shields.io/github/release/oam-dev/kubevela/all.svg?style=flat-square)](https://github.com/oam-dev/kubevela/releases)
 [![TODOs](https://img.shields.io/endpoint?url=https://api.tickgit.com/badge?repo=github.com/oam-dev/kubevela)](https://www.tickgit.com/browse?repo=github.com/oam-dev/kubevela)
 [![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Foam_dev)](https://twitter.com/oam_dev)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kubevela)](https://artifacthub.io/packages/search?repo=kubevela)
 
 ![alt](docs/resources/KubeVela-03.png)
 

--- a/hack/artifacthub/artifacthub-repo.yml
+++ b/hack/artifacthub/artifacthub-repo.yml
@@ -1,0 +1,19 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: ARTIFACT_HUB_REPOSITORY_ID
+owners:
+  - name: Lei Zhang (Harry)
+    email: resouer@gmail.com
+  - name: Jianbo Sun
+    email: jianbo.sjb@alibaba-inc.com
+  - name: Zheng Xi Zhou
+    email: zzxwill@gmail.com

--- a/hack/artifacthub/artifacthub-repo.yml
+++ b/hack/artifacthub/artifacthub-repo.yml
@@ -15,7 +15,9 @@ owners:
     email: resouer@gmail.com
   - name: Jianbo Sun
     email: wonderflow.sun@gmail.com
+  - name: Ryan Zhang
+    email: yangzhangrice@hotmail.com
+  - name: Hongchao Deng
+    email: hongchaodeng1@gmail.com
   - name: Zheng Xi Zhou
     email: zzxwill@gmail.com
-  - name: Ryan Zhang
-    email: yangzhangrice@hotmail.com 

--- a/hack/artifacthub/artifacthub-repo.yml
+++ b/hack/artifacthub/artifacthub-repo.yml
@@ -14,7 +14,7 @@ owners:
   - name: Lei Zhang (Harry)
     email: resouer@gmail.com
   - name: Jianbo Sun
-    email: jianbo.sjb@alibaba-inc.com
+    email: wonderflow.sun@gmail.com
   - name: Zheng Xi Zhou
     email: zzxwill@gmail.com
   - name: Ryan Zhang

--- a/hack/artifacthub/artifacthub-repo.yml
+++ b/hack/artifacthub/artifacthub-repo.yml
@@ -17,3 +17,5 @@ owners:
     email: jianbo.sjb@alibaba-inc.com
   - name: Zheng Xi Zhou
     email: zzxwill@gmail.com
+  - name: Ryan Zhang
+    email: yangzhangrice@hotmail.com 


### PR DESCRIPTION
Set KubeVela team as a verified publisher of Artifacthub,
Add README to the repo and add helm badge in github readme

fix #977