### PR TITLE
fix cannot sync trait without definitionRef

### DIFF
--- a/pkg/commands/capability.go
+++ b/pkg/commands/capability.go
@@ -226,6 +226,7 @@ func NewCapCenterRemoveCommand(ioStreams cmdutil.IOStreams) *cobra.Command {
 
 func listCapCenters(ioStreams cmdutil.IOStreams) error {
 	table := newUITable()
+	table.MaxColWidth = 80
 	table.AddRow("NAME", "ADDRESS")
 	capabilityCenterList, err := serverlib.ListCapabilityCenters()
 	if err != nil {

--- a/pkg/plugins/capcenter.go
+++ b/pkg/plugins/capcenter.go
@@ -247,9 +247,9 @@ func (g *GithubCenter) SyncCapabilityFromCenter() error {
 			continue
 		}
 		//nolint:gosec
-		err = ioutil.WriteFile(filepath.Join(repoDir, tmp.CrdName+".yaml"), data, 0644)
+		err = ioutil.WriteFile(filepath.Join(repoDir, tmp.Name+".yaml"), data, 0644)
 		if err != nil {
-			fmt.Printf("write definition %s to %s err %v\n", tmp.CrdName+".yaml", repoDir, err)
+			fmt.Printf("write definition %s to %s err %v\n", tmp.Name+".yaml", repoDir, err)
 			continue
 		}
 		success++

--- a/pkg/serverlib/capability.go
+++ b/pkg/serverlib/capability.go
@@ -91,9 +91,9 @@ func InstallCapability(client client.Client, mapper discoverymapper.DiscoveryMap
 	switch tp.Type {
 	case types.TypeWorkload:
 		var wd v1alpha2.WorkloadDefinition
-		workloadData, err := ioutil.ReadFile(filepath.Clean(filepath.Join(repoDir, tp.CrdName+".yaml")))
+		workloadData, err := ioutil.ReadFile(filepath.Clean(filepath.Join(repoDir, tp.Name+".yaml")))
 		if err != nil {
-			return nil
+			return err
 		}
 		if err = yaml.Unmarshal(workloadData, &wd); err != nil {
 			return err
@@ -119,9 +119,9 @@ func InstallCapability(client client.Client, mapper discoverymapper.DiscoveryMap
 		}
 	case types.TypeTrait:
 		var td v1alpha2.TraitDefinition
-		traitdata, err := ioutil.ReadFile(filepath.Clean(filepath.Join(repoDir, tp.CrdName+".yaml")))
+		traitdata, err := ioutil.ReadFile(filepath.Clean(filepath.Join(repoDir, tp.Name+".yaml")))
 		if err != nil {
-			return nil
+			return err
 		}
 		if err = yaml.Unmarshal(traitdata, &td); err != nil {
 			return err
@@ -303,13 +303,17 @@ func uninstallCap(client client.Client, cap types.Capability, ioStreams cmdutil.
 	capdir, _ := system.GetCapabilityDir()
 	switch cap.Type {
 	case types.TypeTrait:
-		return os.Remove(filepath.Join(capdir, "traits", cap.Name))
+		if err := os.Remove(filepath.Join(capdir, "traits", cap.Name)); err != nil {
+			return err
+		}
 	case types.TypeWorkload:
-		return os.Remove(filepath.Join(capdir, "workloads", cap.Name))
+		if err := os.Remove(filepath.Join(capdir, "workloads", cap.Name)); err != nil {
+			return err
+		}
 	case types.TypeScope:
 		// TODO(wonderflow): add scope remove here.
 	}
-	ioStreams.Infof("%s removed successfully", cap.Name)
+	ioStreams.Infof("Successfully uninstalled capability %s", cap.Name)
 	return nil
 }
 


### PR DESCRIPTION
to fix #998 
solution: use trait cap name instead of trait's CRD name as file name saved locally

because unit tests in pkg `capability` are skipped by CI, I just run those tests locally.

Signed-off-by: roy wang <seiwy2010@gmail.com>