### PR TITLE
Add latest release tag to be the prefix of latest version of Chart

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -92,17 +92,23 @@ jobs:
         id: latest_tag
       - name: Tag helm chart image
         run:  |
-          latest_tag=${{ steps.latest_tag.outputs.tag }}
-          tag=${GITHUB_REF#refs/tags/}
-          chart_version=${tag#"v"}
+          latest_repo_tag=${{ steps.latest_tag.outputs.tag }}
+          sub="."
+          major="$(cut -d"$sub" -f1 <<<"$latest_repo_tag")"
+          minor="$(cut -d"$sub" -f2 <<<"$latest_repo_tag")"
+          patch="0"
+          next_repo_tag="$major.$(($minor + 1)).$patch"
+          image_tag=${GITHUB_REF#refs/tags/}
+          chart_version=$latest_repo_tag
           if [[ ${GITHUB_REF} == "refs/heads/master" ]]; then
-            tag=latest
-            chart_version=${latest_tag#"v"}-latest
+            image_tag=latest
+            chart_version=${next_repo_tag}-rc-master
           fi
-          sed -i "s/latest/${tag}/g" $HELM_CHART/values.yaml
-          sed -i "s/latest/$tag/g" $LEGACY_HELM_CHART/values.yaml
-          sed -i "s/0.1.0/$chart_version/g" $HELM_CHART/Chart.yaml
-          sed -i "s/0.1.0/$chart_version/g" $LEGACY_HELM_CHART/Chart.yaml
+          sed -i "s/latest/${image_tag}/g" $HELM_CHART/values.yaml
+          sed -i "s/latest/image_tag/g" $LEGACY_HELM_CHART/values.yaml
+          chart_smever=${chart_version#"v"}
+          sed -i "s/0.1.0/$chart_smever/g" $HELM_CHART/Chart.yaml
+          sed -i "s/0.1.0/$chart_smever/g" $LEGACY_HELM_CHART/Chart.yaml
       - name: Install ossutil
         run: wget http://gosspublic.alicdn.com/ossutil/1.7.0/ossutil64 && chmod +x ossutil64 && mv ossutil64 ossutil
       - name: Configure Alibaba Cloud OSSUTIL

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -72,14 +72,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
-      - name: Get the version
-        id: get_version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == "refs/heads/master" ]]; then
-            VERSION=latest
-          fi
-          echo ::set-output name=VERSION::${VERSION}
       - name: Get git revision
         id: vars
         shell: bash
@@ -93,14 +85,24 @@ jobs:
         run: |
           rsync -r $LEGACY_HELM_CHART $HELM_CHARTS_DIR
           rsync -r $HELM_CHART/* $LEGACY_HELM_CHART --exclude=Chart.yaml --exclude=crds
+      - uses: oprypin/find-latest-tag@v1
+        with:
+          repository: oam-dev/kubevela
+          releases-only: true
+        id: latest_tag
       - name: Tag helm chart image
         run:  |
-          version=${{ steps.get_version.outputs.VERSION }}
-          sed -i "s/latest/$version/g" $HELM_CHART/values.yaml
-          sed -i "s/latest/$version/g" $LEGACY_HELM_CHART/values.yaml
-          number=${version#"v"}
-          sed -i "s/0.1.0/$number/g" $HELM_CHART/Chart.yaml
-          sed -i "s/0.1.0/$number/g" $LEGACY_HELM_CHART/Chart.yaml
+          latest_tag=${{ steps.latest_tag.outputs.tag }}
+          tag=${GITHUB_REF#refs/tags/}
+          chart_version=${tag#"v"}
+          if [[ ${GITHUB_REF} == "refs/heads/master" ]]; then
+            tag=latest
+            chart_version=${latest_tag#"v"}-latest
+          fi
+          sed -i "s/latest/${tag}/g" $HELM_CHART/values.yaml
+          sed -i "s/latest/$tag/g" $LEGACY_HELM_CHART/values.yaml
+          sed -i "s/0.1.0/$chart_version/g" $HELM_CHART/Chart.yaml
+          sed -i "s/0.1.0/$chart_version/g" $LEGACY_HELM_CHART/Chart.yaml
       - name: Install ossutil
         run: wget http://gosspublic.alicdn.com/ossutil/1.7.0/ossutil64 && chmod +x ossutil64 && mv ossutil64 ossutil
       - name: Configure Alibaba Cloud OSSUTIL

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -82,9 +82,6 @@ These steps will install KubeVela controller and its dependency.
     kubectl create namespace vela-system 
     ```
 
-    
-
-
 4. Install KubeVela
     ```shell script
     helm install -n vela-system kubevela kubevela/vela-core
@@ -104,9 +101,22 @@ These steps will install KubeVela controller and its dependency.
     helm install -n vela-system kubevela kubevela/vela-core --set installCertManager=true
     ```
    
-    If you want to try the latest master branch, try the following command:
+    If you want to try the latest master branch, add flag `--devel` in command `helm search` to choose a pre-release
+    version in format `<next_version>-rc-master` which means the next release candidate version build on `master` branch,
+    like `0.4.0-rc-master`.
+   
     ```shell script
-    helm install -n vela-system kubevela  https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core/vela-core-latest.tgz --set useWebhook=false
+    $ helm search repo kubevela/vela-core -l --devel
+    NAME                     	CHART VERSION        	APP VERSION          	DESCRIPTION
+    kubevela/vela-core       	0.4.0-rc-master         0.4.0-rc-master         A Helm chart for KubeVela core
+    kubevela/vela-core       	0.3.2  	                0.3.2                   A Helm chart for KubeVela core
+    kubevela/vela-core       	0.3.1        	        0.3.1               	A Helm chart for KubeVela core
+    ```
+   
+    And try the following command to install it.
+   
+    ```shell script
+    helm install -n vela-system kubevela kubevela/vela-core --version <next_version>-rc-master --set useWebhook=false
     ```
 
 ## 3. Get KubeVela CLI

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -21,7 +21,8 @@ Run the following command to install a KubeVela core legacy chart.
 $ helm install -n vela-system vela-core-legacy kubevela/vela-core-legacy
 ```
 
-If you'd like to install an older version of the legacy chart, use `helm search` to choose a proper chart version.
+If you'd like to install an older version of the legacy chart, use `helm search` to choose a proper chart version. Remember
+to add flag `--devel` if you prefer pre-release versions.
 ```
 $ helm search repo vela-core-legacy -l
   NAME                     	CHART VERSION	APP VERSION	DESCRIPTION


### PR DESCRIPTION
Currently the latest chart is vela-core:latest, which could
not be supported by Artifacthub, add latest tag and make the
lastest chart version as `vx.y.z-latest`