### PR TITLE
remove redundant image push operation

### DIFF
--- a/pkg/builtin/build/build.go
+++ b/pkg/builtin/build/build.go
@@ -106,7 +106,7 @@ func (b *Build) buildImage(io cmdutil.IOStreams, image string) error {
 		io.Errorf("BuildImage wait for command execution error:%s", err.Error())
 		return err
 	}
-	return b.pushImage(io, image)
+	return nil
 }
 
 func (b *Build) pushImage(io cmdutil.IOStreams, image string) error {


### PR DESCRIPTION
since image push operation is done here(https://github.com/oam-dev/kubevela/blob/a761e75c01b9305fe616f32d2646131ab6986fe4/pkg/builtin/build/build.go#L39)

it seems redudant to push image in image build function