### PR TITLE
Check whether parameter.command is nill for init-container trait

### DIFF
--- a/docs/en/cue/trait.md
+++ b/docs/en/cue/trait.md
@@ -552,7 +552,9 @@ spec:
       		initContainers: [{
       			name:    parameter.name
       			image:   parameter.image
-      			command: parameter.command
+      			if parameter.command != _|_ {
+      			  command: parameter.command
+      			}
       			// +patchKey=name
       			volumeMounts: [{
       				name:      parameter.mountName


### PR DESCRIPTION
Check whether parameter.command is nill before setting the value of
spec.template.spec.initContainers.command
Fix #1062