### PR TITLE
Fix make core-install error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,6 @@ core-install: manifests
 	kubectl apply -f charts/vela-core/crds/
 	kubectl apply -f charts/vela-core/templates/defwithtemplate/
 	kubectl apply -f charts/vela-core/templates/definitions/
-	kubectl apply -f charts/vela-core/templates/velaConfig.yaml
 	bin/vela workloads
 	@$(OK) install succeed
 


### PR DESCRIPTION
An error occurs when running make core-install: 

```
❯ make core-install
go generate ./pkg/... ./apis/...
./hack/vela-templates/gen_definitions.sh
~/code/github/oam-dev/kubevela/hack/vela-templates ~/code/github/oam-dev/kubevela
done
~/code/github/oam-dev/kubevela
kubectl apply -f hack/namespace.yaml
namespace/vela-system created
kubectl apply -f charts/vela-core/crds/
customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/issuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/orders.acme.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/applicationconfigurations.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/applicationdeployments.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/applications.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/components.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/containerizedworkloads.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/healthscopes.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/manualscalertraits.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/scopedefinitions.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/traitdefinitions.core.oam.dev created
customresourcedefinition.apiextensions.k8s.io/workloaddefinitions.core.oam.dev created
Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com configured
customresourcedefinition.apiextensions.k8s.io/autoscalers.standard.oam.dev created
customresourcedefinition.apiextensions.k8s.io/metricstraits.standard.oam.dev created
customresourcedefinition.apiextensions.k8s.io/podspecworkloads.standard.oam.dev created
customresourcedefinition.apiextensions.k8s.io/rollouttraits.standard.oam.dev created
customresourcedefinition.apiextensions.k8s.io/routes.standard.oam.dev created
kubectl apply -f charts/vela-core/templates/defwithtemplate/
traitdefinition.core.oam.dev/ingress created
traitdefinition.core.oam.dev/scaler created
workloaddefinition.core.oam.dev/task created
workloaddefinition.core.oam.dev/webservice created
workloaddefinition.core.oam.dev/worker created
kubectl apply -f charts/vela-core/templates/definitions/
workloaddefinition.core.oam.dev/containerizedworkloads.core.oam.dev created
scopedefinition.core.oam.dev/healthscopes.core.oam.dev created
kubectl apply -f charts/vela-core/templates/velaConfig.yaml
error: the path "charts/vela-core/templates/velaConfig.yaml" does not exist
make: *** [core-install] Error 1
```
Since this file was deleted, this command should be removed.