### PR TITLE
Use context.output instead of context.input to refer to the output object defined in the WorkloadDefinition

### DIFF
--- a/pkg/dsl/definition/template.go
+++ b/pkg/dsl/definition/template.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// OutputFieldName is the name of the struct contains the CR data
-	OutputFieldName = "output"
+	OutputFieldName = process.OutputFieldName
 	// OutputsFieldName is the name of the struct contains the map[string]CR data
 	OutputsFieldName = "outputs"
 	// PatchFieldName is the name of the struct contains the patch of CR data

--- a/pkg/dsl/process/handle.go
+++ b/pkg/dsl/process/handle.go
@@ -80,7 +80,7 @@ func (ctx *templateContext) BaseContextFile() string {
 	buff += fmt.Sprintf("appName: \"%s\"\n", ctx.appName)
 
 	if ctx.base != nil {
-		buff += fmt.Sprintf("input: %s\n", structMarshal(ctx.base.String()))
+		buff += fmt.Sprintf("output: %s\n", structMarshal(ctx.base.String()))
 	}
 
 	if len(ctx.configs) > 0 {

--- a/pkg/dsl/process/handle.go
+++ b/pkg/dsl/process/handle.go
@@ -9,6 +9,17 @@ import (
 	"github.com/oam-dev/kubevela/pkg/dsl/model"
 )
 
+const (
+	// OutputFieldName is the reference of context base object
+	OutputFieldName = "output"
+	// ConfigFieldName is the reference of context config
+	ConfigFieldName = "config"
+	// ContextName is the name of context
+	ContextName = "name"
+	// ContextAppName is the appName of context
+	ContextAppName = "appName"
+)
+
 // Context defines Rendering Context Interface
 type Context interface {
 	SetBase(base model.Instance)
@@ -76,16 +87,16 @@ func (ctx *templateContext) AppendAuxiliaries(auxiliaries ...Auxiliary) {
 // BaseContextFile return cue format string of templateContext
 func (ctx *templateContext) BaseContextFile() string {
 	var buff string
-	buff += fmt.Sprintf("name: \"%s\"\n", ctx.name)
-	buff += fmt.Sprintf("appName: \"%s\"\n", ctx.appName)
+	buff += fmt.Sprintf(ContextName+": \"%s\"\n", ctx.name)
+	buff += fmt.Sprintf(ContextAppName+": \"%s\"\n", ctx.appName)
 
 	if ctx.base != nil {
-		buff += fmt.Sprintf("output: %s\n", structMarshal(ctx.base.String()))
+		buff += fmt.Sprintf(OutputFieldName+": %s\n", structMarshal(ctx.base.String()))
 	}
 
 	if len(ctx.configs) > 0 {
 		bt, _ := json.Marshal(ctx.configs)
-		buff += "config: " + string(bt)
+		buff += ConfigFieldName + ": " + string(bt)
 	}
 
 	return fmt.Sprintf("context: %s", structMarshal(buff))
@@ -95,9 +106,9 @@ func (ctx *templateContext) BaseContextLabels() map[string]string {
 
 	return map[string]string{
 		// appName is oam.LabelAppName
-		"appName": ctx.appName,
+		ContextAppName: ctx.appName,
 		// name is oam.LabelAppComponent
-		"name": ctx.name,
+		ContextName: ctx.name,
 	}
 }
 

--- a/pkg/dsl/process/handle_test.go
+++ b/pkg/dsl/process/handle_test.go
@@ -41,7 +41,7 @@ image: "myserver"
 	myAppName, err := ctxInst.Lookup("context", "appName").String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "myapp", myAppName)
-	inputJs, err := ctxInst.Lookup("context", "input").MarshalJSON()
+	inputJs, err := ctxInst.Lookup("context", "output").MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, `{"image":"myserver"}`, string(inputJs))
 }

--- a/pkg/dsl/process/handle_test.go
+++ b/pkg/dsl/process/handle_test.go
@@ -34,14 +34,14 @@ image: "myserver"
 		return
 	}
 
-	gName, err := ctxInst.Lookup("context", "name").String()
+	gName, err := ctxInst.Lookup("context", ContextName).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "mycomp", gName)
 
-	myAppName, err := ctxInst.Lookup("context", "appName").String()
+	myAppName, err := ctxInst.Lookup("context", ContextAppName).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "myapp", myAppName)
-	inputJs, err := ctxInst.Lookup("context", "output").MarshalJSON()
+	inputJs, err := ctxInst.Lookup("context", OutputFieldName).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, `{"image":"myserver"}`, string(inputJs))
 }


### PR DESCRIPTION
use context.output instead of context.input to refer to the output object defined in the WorkloadDefinition


use case
```
apiVersion: core.oam.dev/v1alpha2
kind: WorkloadDefinition
metadata:
  name: worker
spec:
  definitionRef:
    name: deployments.apps
  extension:
    template: |
      output: {
      	apiVersion: "apps/v1"
      	kind:       "Deployment"
      	spec: {
      		selector: matchLabels: {
      			"app.oam.dev/component": context.name
      		}

      		template: {
      			spec: {
      				containers: [{
      					name:  context.name
                                         ports:[{containerPort: 443}]
      				}]
      			}
      		}
      	}
      }
---
apiVersion: core.oam.dev/v1alpha2
kind: TraitDefinition
metadata:
  name: service
spec:
  extension:
    template: |
      parameter: {
        exposePort: int
      }
      outputs: service: {
        apiVersion: "v1"
        kind: "Service"
        spec: {
          selector:
            app: context.name
          ports: [
            {
              port: paramter.exposePort
              // Previously used context.input
              targetPort: context.output.spec.template.spec.containers[0].ports[0].containerPort
            }
          ]
        }
      }
```