### PR TITLE
Use "context.outputs" to reference auxiliary objects defined in the definition template

### DIFF
--- a/docs/en/cue/trait.md
+++ b/docs/en/cue/trait.md
@@ -349,6 +349,9 @@ spec:
 
 The trait can use the data of workload output and outputs to fill itself.
 
+There are two keywords `output` and `outputs` in the rendering context.
+You can use `context.output` refer to the output-object, and use `context.outputs.<xx>` refer to the outputs-object.
+
 Below is an example
 1. the main workload object(Deployment) in this example will render into the context.output before rendering traits.
 2. the context.outputs.<xx> will keep all these rendered trait data and can be used in the traits after them.

--- a/docs/en/cue/trait.md
+++ b/docs/en/cue/trait.md
@@ -345,6 +345,123 @@ spec:
     }
 ```
 
+## Simple data passing
+
+The trait can use the data of workload output and outputs to fill itself.
+
+Below is an example
+1. the main workload object(Deployment) in this example will render into the context.output before rendering traits.
+2. the context.outputs.<xx> will keep all these rendered trait data and can be used in the traits after them.
+```yaml
+apiVersion: core.oam.dev/v1alpha2
+kind: WorkloadDefinition
+metadata:
+  name: worker
+spec:
+  definitionRef:
+    name: deployments.apps
+  extension:
+    template: |
+      output: {
+        apiVersion: "apps/v1"
+        kind:       "Deployment"
+        spec: {
+            selector: matchLabels: {
+                "app.oam.dev/component": context.name
+            }
+    
+            template: {
+                metadata: labels: {
+                    "app.oam.dev/component": context.name
+                }
+                spec: {
+                    containers: [{
+                        name:  context.name
+                        image: parameter.image
+                                         ports:[{containerPort: parameter.port}]
+                        envFrom: [{
+                            configMapRef: name: context.name + "game-config"
+                        }]
+                        if parameter["cmd"] != _|_ {
+                            command: parameter.cmd
+                        }
+                    }]
+                }
+            }
+        }
+      }
+
+      outputs: gameconfig: {
+            apiVersion: "v1"
+            kind:       "ConfigMap"
+            metadata: {
+                name: context.name + "game-config"
+            }
+            data: {
+                enemies: parameter.enemies
+                lives:   parameter.lives
+            }
+      }
+
+      parameter: {
+      	// +usage=Which image would you like to use for your service
+      	// +short=i
+      	image: string
+      	// +usage=Commands to run in the container
+      	cmd?: [...string]
+      	lives:   string
+      	enemies: string
+        port: int
+      }
+
+---
+apiVersion: core.oam.dev/v1alpha2
+kind: TraitDefinition
+metadata:
+  name: ingress
+spec:
+  extension:
+    template: |
+      parameter: {
+        domain: string
+        path: string
+        exposePort: int
+      }
+      // trait template can have multiple outputs in one trait
+      outputs: service: {
+        apiVersion: "v1"
+        kind: "Service"
+        spec: {
+          selector:
+            app: context.name
+          ports: [{
+              port: parameter.exposePort
+              targetPort: context.output.spec.template.spec.containers[0].ports[0].containerPort
+            }]
+        }
+      }
+      outputs: ingress: {
+          apiVersion: "networking.k8s.io/v1beta1"
+          kind: "Ingress"
+          metadata:
+            name: context.name
+            labels: config: context.outputs.gameconfig.data.enemies
+          spec: {
+            rules: [{
+              host: parameter.domain
+              http: {
+                paths: [{
+                    path: parameter.path
+                    backend: {
+                      serviceName: context.name
+                      servicePort: parameter.exposePort
+                    }
+                }]
+              }
+            }]
+          }
+      }
+```
 
 ## More Use Cases for Patch Trait
 

--- a/docs/en/cue/trait.md
+++ b/docs/en/cue/trait.md
@@ -350,7 +350,8 @@ spec:
 The trait can use the data of workload output and outputs to fill itself.
 
 There are two keywords `output` and `outputs` in the rendering context.
-You can use `context.output` refer to the output-object, and use `context.outputs.<xx>` refer to the outputs-object.
+You can use `context.output` refer to the workload object, and use `context.outputs.<xx>` refer to the trait object.
+please make sure the trait resource name is unique, or the former data will be covered by the latter one.
 
 Below is an example
 1. the main workload object(Deployment) in this example will render into the context.output before rendering traits.

--- a/pkg/dsl/definition/template.go
+++ b/pkg/dsl/definition/template.go
@@ -22,7 +22,7 @@ const (
 	// OutputFieldName is the name of the struct contains the CR data
 	OutputFieldName = process.OutputFieldName
 	// OutputsFieldName is the name of the struct contains the map[string]CR data
-	OutputsFieldName = "outputs"
+	OutputsFieldName = process.OutputsFieldName
 	// PatchFieldName is the name of the struct contains the patch of CR data
 	PatchFieldName = "patch"
 	// CustomMessage defines the custom message in definition template

--- a/pkg/dsl/process/handle.go
+++ b/pkg/dsl/process/handle.go
@@ -12,6 +12,8 @@ import (
 const (
 	// OutputFieldName is the reference of context base object
 	OutputFieldName = "output"
+	// OutputsFieldName is the reference of context Auxiliaries
+	OutputsFieldName = "outputs"
 	// ConfigFieldName is the reference of context config
 	ConfigFieldName = "config"
 	// ContextName is the name of context
@@ -92,6 +94,18 @@ func (ctx *templateContext) BaseContextFile() string {
 
 	if ctx.base != nil {
 		buff += fmt.Sprintf(OutputFieldName+": %s\n", structMarshal(ctx.base.String()))
+	}
+
+	if len(ctx.auxiliaries) > 0 {
+		var auxLines []string
+		for _, auxiliary := range ctx.auxiliaries {
+			if auxiliary.IsOutputs {
+				auxLines = append(auxLines, fmt.Sprintf("%s: %s", auxiliary.Name, structMarshal(auxiliary.Ins.String())))
+			}
+		}
+		if len(auxLines) > 0 {
+			buff += fmt.Sprintf(OutputsFieldName+": {%s}\n", strings.Join(auxLines, "\n"))
+		}
 	}
 
 	if len(ctx.configs) > 0 {

--- a/pkg/dsl/process/handle_test.go
+++ b/pkg/dsl/process/handle_test.go
@@ -26,8 +26,33 @@ image: "myserver"
 		return
 	}
 
+	serviceTemplate := `
+	apiVersion: "v1"
+    kind:       "ConfigMap"
+`
+
+	svcInst, err := r.Compile("-", serviceTemplate)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	svcIns, err := model.NewOther(svcInst.Value())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	svcAux := Auxiliary{
+		Ins:       svcIns,
+		Name:      "service",
+		IsOutputs: true,
+	}
+
 	ctx := NewContext("mycomp", "myapp")
 	ctx.SetBase(base)
+	ctx.AppendAuxiliaries(svcAux)
+
 	ctxInst, err := r.Compile("-", ctx.BaseContextFile())
 	if err != nil {
 		t.Error(err)
@@ -41,7 +66,12 @@ image: "myserver"
 	myAppName, err := ctxInst.Lookup("context", ContextAppName).String()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "myapp", myAppName)
+
 	inputJs, err := ctxInst.Lookup("context", OutputFieldName).MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, `{"image":"myserver"}`, string(inputJs))
+
+	outputsJs, err := ctxInst.Lookup("context", OutputsFieldName, "service").MarshalJSON()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\"}", string(outputsJs))
 }


### PR DESCRIPTION
use "context.outputs" to reference auxiliary objects defined in the definition template
reference issue: [context.output refer to workload output  object](https://github.com/oam-dev/kubevela/pull/1076)

Implement  refer to objects defined in the definition template also achieves the purpose of
 [support simple data passing from workload to trait](https://github.com/oam-dev/kubevela/issues/1026)

fix https://github.com/oam-dev/kubevela/issues/1026