### PR TITLE
parent override child when annotation/labels conflicts && one revision will apply once only in force mode && AC.status CRD updated

### DIFF
--- a/apis/core.oam.dev/v1alpha2/core_types.go
+++ b/apis/core.oam.dev/v1alpha2/core_types.go
@@ -439,12 +439,15 @@ type WorkloadStatus struct {
 	// ComponentRevisionName of current component
 	ComponentRevisionName string `json:"componentRevisionName,omitempty"`
 
-	// ObservedGeneration indicates the generation observed by the appconfig controller.
+	// DependencyUnsatisfied notify does the workload has dependency unsatisfied
+	DependencyUnsatisfied bool `json:"dependencyUnsatisfied,omitempty"`
+
+	// AppliedGeneration indicates the generation observed by the appConfig controller.
 	// The same field is also recorded in the annotations of workloads.
 	// A workload is possible to be deleted from cluster after created.
 	// This field is useful to track the observed generation of workloads after they are
 	// deleted.
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	AppliedGeneration int64 `json:"appliedGeneration,omitempty"`
 
 	// Reference to a workload created by an ApplicationConfiguration.
 	Reference runtimev1alpha1.TypedReference `json:"workloadRef,omitempty"`

--- a/charts/vela-core/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationconfigurations.yaml
@@ -380,16 +380,19 @@ spec:
                 items:
                   description: A WorkloadStatus represents the status of a workload.
                   properties:
+                    appliedGeneration:
+                      description: AppliedGeneration indicates the generation observed by the appConfig controller. The same field is also recorded in the annotations of workloads. A workload is possible to be deleted from cluster after created. This field is useful to track the observed generation of workloads after they are deleted.
+                      format: int64
+                      type: integer
                     componentName:
                       description: ComponentName that produced this workload.
                       type: string
                     componentRevisionName:
                       description: ComponentRevisionName of current component
                       type: string
-                    observedGeneration:
-                      description: ObservedGeneration indicates the generation observed by the appconfig controller. The same field is also recorded in the annotations of workloads. A workload is possible to be deleted from cluster after created. This field is useful to track the observed generation of workloads after they are deleted.
-                      format: int64
-                      type: integer
+                    dependencyUnsatisfied:
+                      description: DependencyUnsatisfied notify does the workload has dependency unsatisfied
+                      type: boolean
                     scopes:
                       description: Scopes associated with this workload.
                       items:

--- a/design/vela-core/apply-once-only.md
+++ b/design/vela-core/apply-once-only.md
@@ -130,8 +130,13 @@ The same mechanism also works for Trait as well as Workload.
 
 ### Apply Once Only Force
 
-Based on the same mechanism as `apply-once-only`, `apply-once-only-force` allows to skip re-creating a workload or trait that has already been DELETED from the cluster if its spec is not changed. 
-It's regarded as a stronger case of `apply-once-only`.
+Based on the same mechanism as `apply-once-only`, `apply-once-only-force` has a more strict method for apply only once.
+
+It allows to skip re-creating a workload or trait that has already been DELETED from the cluster if its spec is not changed. 
+
+Besides the condition in `apply-once-only`, `apply-once-only-force` has one more condition:
+
+- if the component revision not changed, the workload will not be applied.
 
 ## Usage
 

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationconfigurations.yaml
@@ -380,16 +380,19 @@ spec:
               items:
                 description: A WorkloadStatus represents the status of a workload.
                 properties:
+                  appliedGeneration:
+                    description: AppliedGeneration indicates the generation observed by the appConfig controller. The same field is also recorded in the annotations of workloads. A workload is possible to be deleted from cluster after created. This field is useful to track the observed generation of workloads after they are deleted.
+                    format: int64
+                    type: integer
                   componentName:
                     description: ComponentName that produced this workload.
                     type: string
                   componentRevisionName:
                     description: ComponentRevisionName of current component
                     type: string
-                  observedGeneration:
-                    description: ObservedGeneration indicates the generation observed by the appconfig controller. The same field is also recorded in the annotations of workloads. A workload is possible to be deleted from cluster after created. This field is useful to track the observed generation of workloads after they are deleted.
-                    format: int64
-                    type: integer
+                  dependencyUnsatisfied:
+                    description: DependencyUnsatisfied notify does the workload has dependency unsatisfied
+                    type: boolean
                   scopes:
                     description: Scopes associated with this workload.
                     items:

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/apply_once_only_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/apply_once_only_test.go
@@ -661,13 +661,13 @@ var _ = Describe("Test apply (workloads/traits) once only", func() {
 				return updateAC.GetGeneration()
 			}, 3*time.Second, time.Second).Should(Equal(int64(2)))
 
-			By("Check workload is re-created by reconciliation")
+			By("Check workload was not created by reconciliation")
 			Eventually(func() error {
 				By("Reconcile")
 				reconcileRetry(reconciler, req)
 				recreatedCwObj = v1alpha2.ContainerizedWorkload{}
 				return k8sClient.Get(ctx, cwObjKey, &recreatedCwObj)
-			}, 5*time.Second, time.Second).Should(Succeed())
+			}, 5*time.Second, time.Second).Should(SatisfyAll(util.NotFoundMatcher{}))
 
 			By("Check trait is re-created by reconciliation")
 			recreatedFooObj = unstructured.Unstructured{}

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/component_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/component_test.go
@@ -138,7 +138,7 @@ func TestComponentHandler(t *testing.T) {
 	// check component's status saved in corresponding controllerRevision
 	assert.Equal(t, gotComp.Status.LatestRevision.Name, revisions.Items[0].Name)
 	assert.Equal(t, gotComp.Status.LatestRevision.Revision, revisions.Items[0].Revision)
-	// check component's status ObservedGeneration
+	// check component's status AppliedGeneration
 	assert.Equal(t, gotComp.Status.ObservedGeneration, comp.Generation)
 	q.Done(item)
 	// ============ Test Create Event End ===================

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/revision_enable_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/revision_enable_test.go
@@ -504,3 +504,323 @@ var _ = Describe("Test Component Revision Enabled with custom component revision
 		}, time.Second, 300*time.Millisecond).Should(BeNil())
 	})
 })
+
+var _ = Describe("Component Revision Enabled with apply once only force", func() {
+	const (
+		namespace = "revision-and-apply-once-force"
+		appName   = "revision-apply-once"
+		compName  = "revision-apply-once-comp"
+	)
+	var (
+		ctx          = context.Background()
+		wr           v1.Deployment
+		component    v1alpha2.Component
+		appConfig    v1alpha2.ApplicationConfiguration
+		appConfigKey = client.ObjectKey{
+			Name:      appName,
+			Namespace: namespace,
+		}
+		req = reconcile.Request{NamespacedName: appConfigKey}
+		ns  = corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+	)
+
+	BeforeEach(func() {})
+
+	AfterEach(func() {
+		// delete the namespace with all its resources
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).
+			Should(SatisfyAny(BeNil(), &util.NotFoundMatcher{}))
+	})
+
+	It("revision enabled should create workload with revisionName and work upgrade with new revision successfully", func() {
+
+		getDeploy := func(image string) *v1.Deployment {
+			return &v1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+				},
+				Spec: v1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"app": compName,
+					}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+							"app": compName,
+						}},
+						Spec: corev1.PodSpec{Containers: []corev1.Container{{
+							Name:  "wordpress",
+							Image: image,
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "wordpress",
+									ContainerPort: 80,
+								},
+							},
+						},
+						}}},
+				},
+			}
+		}
+		component = v1alpha2.Component{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "Component",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      compName,
+				Namespace: namespace,
+			},
+			Spec: v1alpha2.ComponentSpec{
+				Workload: runtime.RawExtension{
+					Object: getDeploy("wordpress:4.6.1-apache"),
+				},
+			},
+		}
+		appConfig = v1alpha2.ApplicationConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appName,
+				Namespace: namespace,
+			},
+		}
+
+		By("Create namespace")
+		Eventually(
+			func() error {
+				return k8sClient.Create(ctx, &ns)
+			},
+			time.Second*3, time.Millisecond*300).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+		By("Create Component")
+		Expect(k8sClient.Create(ctx, &component)).Should(Succeed())
+		cmpV1 := &v1alpha2.Component{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: compName}, cmpV1)).Should(Succeed())
+
+		By("component handler will automatically create controller revision")
+		Expect(func() bool {
+			_, ok := componentHandler.createControllerRevision(cmpV1, cmpV1)
+			return ok
+		}()).Should(BeTrue())
+		var crList v1.ControllerRevisionList
+		By("Check controller revision created successfully")
+		Eventually(func() error {
+			labels := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					ControllerRevisionComponentLabel: compName,
+				},
+			}
+			selector, err := metav1.LabelSelectorAsSelector(labels)
+			if err != nil {
+				return err
+			}
+			err = k8sClient.List(ctx, &crList, &client.ListOptions{
+				LabelSelector: selector,
+			})
+			if err != nil {
+				return err
+			}
+			if len(crList.Items) != 1 {
+				return fmt.Errorf("want only 1 revision created but got %d", len(crList.Items))
+			}
+			return nil
+		}, time.Second, 300*time.Millisecond).Should(BeNil())
+
+		By("Create an ApplicationConfiguration")
+		appConfig = v1alpha2.ApplicationConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appName,
+				Namespace: namespace,
+			},
+			Spec: v1alpha2.ApplicationConfigurationSpec{Components: []v1alpha2.ApplicationConfigurationComponent{
+				{
+					RevisionName: compName + "-v1",
+					Traits: []v1alpha2.ComponentTrait{
+						{
+							Trait: runtime.RawExtension{Object: &unstructured.Unstructured{Object: map[string]interface{}{
+								"apiVersion": "example.com/v1",
+								"kind":       "Foo",
+								"metadata": map[string]interface{}{
+									"labels": map[string]interface{}{
+										"trait.oam.dev/type": "rollout-revision",
+									},
+								},
+								"spec": map[string]interface{}{
+									"key": "test1",
+								},
+							}}},
+						},
+					},
+				},
+			}},
+		}
+		By("Creat appConfig & check successfully")
+		Expect(k8sClient.Create(ctx, &appConfig)).Should(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(ctx, appConfigKey, &appConfig)
+		}, time.Second, 300*time.Millisecond).Should(BeNil())
+
+		By("Reconcile")
+		reconciler.applyOnceOnlyMode = "force"
+		reconcileRetry(reconciler, req)
+
+		By("Check workload created successfully")
+		var workloadKey1 = client.ObjectKey{Namespace: namespace, Name: compName + "-v1"}
+		Eventually(func() error {
+			reconcileRetry(reconciler, req)
+			return k8sClient.Get(ctx, workloadKey1, &wr)
+		}, 3*time.Second, 300*time.Millisecond).Should(BeNil())
+		By("Check workload should only have 1 generation")
+		Expect(wr.GetGeneration()).Should(BeEquivalentTo(1))
+
+		By("Delete the workload")
+		Expect(k8sClient.Delete(ctx, &wr)).Should(BeNil())
+
+		By("Check reconcile again and no error will happen")
+		reconcileRetry(reconciler, req)
+
+		By("Check workload will not created after reconcile because apply once force enabled")
+		Expect(k8sClient.Get(ctx, workloadKey1, &wr)).Should(SatisfyAll(util.NotFoundMatcher{}))
+		Expect(k8sClient.Get(ctx, appConfigKey, &appConfig)).Should(BeNil())
+		By("update the trait of ac")
+		appConfig.Spec.Components[0].Traits[0].Trait = runtime.RawExtension{Object: &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "Foo",
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					"trait.oam.dev/type": "rollout-revision",
+				},
+			},
+			"spec": map[string]interface{}{
+				"key": "test2",
+			},
+		}}}
+		Expect(k8sClient.Update(ctx, &appConfig)).Should(Succeed())
+
+		By("Reconcile and Check appconfig condition should not have error")
+		reconcileRetry(reconciler, req)
+		Eventually(func() string {
+			By("Reconcile again and should not have error")
+			reconcileRetry(reconciler, req)
+			err := k8sClient.Get(ctx, appConfigKey, &appConfig)
+			if err != nil {
+				return err.Error()
+			}
+			if len(appConfig.Status.Conditions) != 1 {
+				return "condition len should be 1 but now is " + strconv.Itoa(len(appConfig.Status.Conditions))
+			}
+			return string(appConfig.Status.Conditions[0].Reason)
+		}, 3*time.Second, 300*time.Millisecond).Should(BeEquivalentTo("ReconcileSuccess"))
+		time.Sleep(time.Second)
+		By("Check workload will not created even AC changed because apply once force working")
+		Expect(k8sClient.Get(ctx, workloadKey1, &wr)).Should(SatisfyAll(util.NotFoundMatcher{}))
+		By("Check the trait was updated as expected")
+		var tr unstructured.Unstructured
+		Eventually(func() error {
+			tr.SetAPIVersion("example.com/v1")
+			tr.SetKind("Foo")
+			var traitKey = client.ObjectKey{Namespace: namespace, Name: appConfig.Status.Workloads[0].Traits[0].Reference.Name}
+			return k8sClient.Get(ctx, traitKey, &tr)
+		}, time.Second, 300*time.Millisecond).Should(BeNil())
+		Expect(tr.Object["spec"]).Should(BeEquivalentTo(map[string]interface{}{"key": "test2"}))
+
+		By("===================================== Start to Upgrade revision of component =========================================")
+		cmpV2 := &v1alpha2.Component{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: compName}, cmpV2)).Should(Succeed())
+		cmpV2.Spec.Workload = runtime.RawExtension{
+			Object: getDeploy("wordpress:v2"),
+		}
+		By("Update Component")
+		Expect(k8sClient.Update(ctx, cmpV2)).Should(Succeed())
+		By("component handler will automatically create a ne controller revision")
+		Expect(func() bool { _, ok := componentHandler.createControllerRevision(cmpV2, cmpV2); return ok }()).Should(BeTrue())
+		By("Check controller revision created successfully")
+		Eventually(func() error {
+			labels := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					ControllerRevisionComponentLabel: compName,
+				},
+			}
+			selector, err := metav1.LabelSelectorAsSelector(labels)
+			if err != nil {
+				return err
+			}
+			err = k8sClient.List(ctx, &crList, &client.ListOptions{
+				LabelSelector: selector,
+			})
+			if err != nil {
+				return err
+			}
+			if len(crList.Items) != 2 {
+				return fmt.Errorf("there should be exactly 2 revision created but got %d", len(crList.Items))
+			}
+			return nil
+		}, time.Second, 300*time.Millisecond).Should(BeNil())
+
+		By("Update appConfig & check successfully")
+		appConfig.Spec.Components[0].RevisionName = compName + "-v2"
+		appConfig.Spec.Components[0].Traits[0].Trait = runtime.RawExtension{Object: &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "Foo",
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					"trait.oam.dev/type": "rollout-revision",
+				},
+			},
+			"spec": map[string]interface{}{
+				"key": "test3",
+			},
+		}}}
+		Expect(k8sClient.Update(ctx, &appConfig)).Should(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(ctx, appConfigKey, &appConfig)
+		}, time.Second, 300*time.Millisecond).Should(BeNil())
+		By("Reconcile for new revision")
+		reconcileRetry(reconciler, req)
+
+		By("Check new revision workload created successfully")
+		Eventually(func() error {
+			reconcileRetry(reconciler, req)
+			var workloadKey = client.ObjectKey{Namespace: namespace, Name: compName + "-v2"}
+			return k8sClient.Get(ctx, workloadKey, &wr)
+		}, time.Second, 300*time.Millisecond).Should(BeNil())
+		By("Check the new workload should only have 1 generation")
+		Expect(wr.GetGeneration()).Should(BeEquivalentTo(1))
+		Expect(wr.Spec.Template.Spec.Containers[0].Image).Should(BeEquivalentTo("wordpress:v2"))
+
+		By("Check the new workload should only have 1 generation")
+		Expect(wr.GetGeneration()).Should(BeEquivalentTo(1))
+
+		By("Check reconcile again and no error will happen")
+		reconcileRetry(reconciler, req)
+		By("Check appconfig condition should not have error")
+		Eventually(func() string {
+			By("Once more Reconcile and should not have error")
+			reconcileRetry(reconciler, req)
+			err := k8sClient.Get(ctx, appConfigKey, &appConfig)
+			if err != nil {
+				return err.Error()
+			}
+			if len(appConfig.Status.Conditions) != 1 {
+				return "condition len should be 1 but now is " + strconv.Itoa(len(appConfig.Status.Conditions))
+			}
+			return string(appConfig.Status.Conditions[0].Reason)
+		}, 3*time.Second, 300*time.Millisecond).Should(BeEquivalentTo("ReconcileSuccess"))
+		By("Check trait was updated as expected")
+		Eventually(func() error {
+			tr.SetAPIVersion("example.com/v1")
+			tr.SetKind("Foo")
+			var traitKey = client.ObjectKey{Namespace: namespace, Name: appConfig.Status.Workloads[0].Traits[0].Reference.Name}
+			return k8sClient.Get(ctx, traitKey, &tr)
+		}, time.Second, 300*time.Millisecond).Should(BeNil())
+		Expect(tr.Object["spec"]).Should(BeEquivalentTo(map[string]interface{}{"key": "test3"}))
+		reconciler.applyOnceOnlyMode = "off"
+	})
+
+})

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/suite_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/suite_test.go
@@ -44,7 +44,7 @@ var k8sClient client.Client
 var scheme = runtime.NewScheme()
 var crd crdv1.CustomResourceDefinition
 
-func TestReconcilder(t *testing.T) {
+func TestReconcilerSuit(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -301,12 +301,13 @@ func PassLabel(parentObj oam.Object, childObj labelAnnotationObject) {
 	childObj.SetLabels(MergeMapOverrideWithDst(parentObj.GetLabels(), childObj.GetLabels()))
 }
 
-// PassLabelAndAnnotation passes through labels and annotation objectMeta from the parent to the child object
+// PassLabelAndAnnotation passes through labels and annotation objectMeta from the parent to the child object,
+// when annotation or labels has conflicts, the parentObj will override the childObj.
 func PassLabelAndAnnotation(parentObj oam.Object, childObj labelAnnotationObject) {
 	// pass app-config labels
-	childObj.SetLabels(MergeMapOverrideWithDst(parentObj.GetLabels(), childObj.GetLabels()))
+	childObj.SetLabels(MergeMapOverrideWithDst(childObj.GetLabels(), parentObj.GetLabels()))
 	// pass app-config annotation
-	childObj.SetAnnotations(MergeMapOverrideWithDst(parentObj.GetAnnotations(), childObj.GetAnnotations()))
+	childObj.SetAnnotations(MergeMapOverrideWithDst(childObj.GetAnnotations(), parentObj.GetAnnotations()))
 }
 
 // GetDefinitionName return the Definition name of any resources

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -1192,7 +1192,7 @@ func TestPassThroughObjMeta(t *testing.T) {
 
 	gotAnnotation = u.GetAnnotations()
 	wantAnnotation = map[string]string{
-		"key1": "exist value1",
+		"key1": "value1",
 		"key2": "value2",
 		"key3": "value3",
 	}
@@ -1200,7 +1200,7 @@ func TestPassThroughObjMeta(t *testing.T) {
 
 	gotLabels := u.GetLabels()
 	wantLabels := map[string]string{
-		"core.oam.dev/ns":          "kube-system",
+		"core.oam.dev/ns":          "oam-system",
 		"core.oam.dev/kube-native": "deployment",
 		"core.oam.dev/controller":  "oam-kubernetes-runtime",
 	}


### PR DESCRIPTION
1) AC will override its component/workload; 
2) AC will override its trait; 
3) workload will override child resources

![image](https://user-images.githubusercontent.com/2173670/109250089-f6848300-7823-11eb-9f5b-a972d951bc7e.png)

---

4) apply once only will check component revision
5) refactor CRD status of AppConfig to make workload has Dependency and appliedGeneration
