### PR TITLE
API: make Component type|settings omitempty

### DIFF
--- a/apis/core.oam.dev/v1alpha2/application_types.go
+++ b/apis/core.oam.dev/v1alpha2/application_types.go
@@ -86,9 +86,9 @@ type ApplicationTrait struct {
 // ApplicationComponent describe the component of application
 type ApplicationComponent struct {
 	Name         string `json:"name"`
-	WorkloadType string `json:"type"`
+	WorkloadType string `json:"type,omitempty"`
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Settings runtime.RawExtension `json:"settings"`
+	Settings runtime.RawExtension `json:"settings,omitempty"`
 
 	// Traits define the trait of one component, the type must be array to keep the order.
 	Traits []ApplicationTrait `json:"traits,omitempty"`

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -66,8 +66,6 @@ spec:
                       type: string
                   required:
                   - name
-                  - settings
-                  - type
                   type: object
                 type: array
               rolloutPlan:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -66,8 +66,6 @@ spec:
                     type: string
                 required:
                 - name
-                - settings
-                - type
                 type: object
               type: array
             rolloutPlan:


### PR DESCRIPTION
I'm importing the oamcore ApplicationComponent type for overlay patch.

But the field is required even though there is no patch for it:
```
      components:
        - name: backend
          type: "" 
          settings:
            image: busybox
        - name: frontend
          type: ""
          settings: {} 
          traits:
            - name: sidecar
              properties:
                image: "fluentd"
```

With this change it would be simplified:

```
      components:
        - name: backend
          settings:
            image: busybox
        - name: frontend
          traits:
            - name: sidecar
              properties:
                image: "fluentd"
```