### PR TITLE
fix #1140 delete image after e2e test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -116,6 +116,10 @@ jobs:
       - name: Run e2e tests
         run: make e2e-test
 
+      - name: Cleanup image
+        if: ${{ always() }}
+        run: make image-cleanup
+
   staticcheck:
     runs-on: ubuntu-20.04
 

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,12 @@ e2e-cleanup:
 	# Clean up
 	rm -rf ~/.vela
 
+image-cleanup:
+# Delete Docker image
+ifneq ($(shell docker images -q vela-core-test:$(GIT_COMMIT)),)
+	docker image rm -f vela-core-test:$(GIT_COMMIT)
+endif
+
 # load docker image to the kind cluster
 kind-load:
 	docker build -t vela-core-test:$(GIT_COMMIT) .


### PR DESCRIPTION
add step **cleanup** to delete image after step **e2e-test** , the **cleanup** step will always executes(even if the previous step fails).

fix #1140