### PR TITLE
fix vela system dryrun command cannot get namespaced definition

### DIFF
--- a/pkg/commands/dryrun.go
+++ b/pkg/commands/dryrun.go
@@ -54,7 +54,13 @@ func NewDryRunCommand(c types.Args, ioStreams cmdutil.IOStreams) *cobra.Command 
 
 			parser := appfile.NewApplicationParser(newClient, dm)
 
-			ctx := oamutil.SetNnamespaceInCtx(context.Background(), app.Namespace)
+			velaEnv, err := GetEnv(cmd)
+			if err != nil {
+				return err
+			}
+
+			ctx := oamutil.SetNnamespaceInCtx(context.Background(), velaEnv.Namespace)
+
 			appFile, err := parser.GenerateAppFile(ctx, app.Name, app)
 			if err != nil {
 				return errors.WithMessage(err, "generate appFile")


### PR DESCRIPTION
quick fix vela system dryrun command cannot get namespaced definition, use env namespace for application namespace