### PR TITLE
fix dockerfile of vela-core  to use 'CMD' instead of 'ENTRYPOINT'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ ARG TARGETARCH
 COPY --from=builder /workspace/manager-${TARGETARCH} /manager
 USER nonroot:nonroot
 
-ENTRYPOINT ["/manager"]
+CMD ["/manager","--metrics-addr=:8080","--enable-leader-election"]

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -104,7 +104,8 @@ spec:
         - name: {{ .Release.Name }}
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-          args:
+          command:
+            - "/manager"
             - "--metrics-addr=:8080"
             - "--enable-leader-election"
             {{ if .Values.admissionWebhooks.enabled }}

--- a/design/vela-core/migrate-from-oam-runtime.md
+++ b/design/vela-core/migrate-from-oam-runtime.md
@@ -64,7 +64,8 @@ metadata:
 ...
       containers:
         - name: oam
-          args:
+          command:
+            - "/manager"
             - "--metrics-addr=:8080"
             - "--enable-leader-election"
 +           - "--disable-caps=all"


### PR DESCRIPTION
refer to https://github.com/oam-dev/kubevela/issues/1177
change the dockerfile to use 'CMD' instead of 'ENTRYPOINT' and vela-core deployment to use `command` instead of `args`