### PR TITLE
Use ‘Ubuntu’ as default base image instead of 'Distroless' for debug convenience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,17 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on \
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-# Could use `--build-arg=BASE_DISTROLESS=gcr.io/distroless/static:nonroot` to overwrite
-ARG BASE_DISTROLESS
-FROM ${BASE_DISTROLESS:-gcr.io/distroless/static:nonroot}
+# Could use `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot` to overwrite
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE:-ubuntu:latest}
+# This is required by daemon connnecting with cri
+RUN ln -s /usr/bin/* /usr/sbin/ && apt-get update -y \
+  && apt-get install --no-install-recommends -y ca-certificates \
+  && apt-get clean && rm -rf /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
 
 WORKDIR /
 
 ARG TARGETARCH
 COPY --from=builder /workspace/manager-${TARGETARCH} /manager
-USER nonroot:nonroot
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on \
     go build -a -ldflags "-X github.com/oam-dev/kubevela/version.VelaVersion=${VERSION:-undefined} -X github.com/oam-dev/kubevela/version.GitRevision=${GITVERSION:-undefined}" \
     -o manager-${TARGETARCH} main.go
 
-# Use distroless as minimal base image to package the manager binary
+# Use ubuntu as base image for convenience.
+# You can replace distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # Could use `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot` to overwrite
 ARG BASE_IMAGE


### PR DESCRIPTION
fix #1177
Use ‘Ubuntu’ as default base image instead of 'Distroless' for debug convenience.

change log:
1. change args `BASE_DISTROLESS` to `BASE_IMAGE`
2. change default image from `gcr.io/distroless/static:nonroot` to `ubuntu:latest`
3. dockerfile reference to 
https://github.com/openkruise/kruise/blob/master/Dockerfile#L24-L28