### PR TITLE
add podDisruptive to traitdefinition

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -112,22 +112,6 @@ type WorkloadGVK struct {
 	Kind       string `json:"kind"`
 }
 
-// DisruptiveProperty describes whether when a trait is applied to an Application,
-// it will cause the pod to restart due to changes in some fields.
-// +kubebuilder:validation:Enum=unknown;yes;no;
-type DisruptiveProperty string
-
-const (
-	// UnknownDisruptive means disruptive unknown.
-	UnknownDisruptive DisruptiveProperty = "unknown"
-
-	// Disruptive means will cause the pod to restart.
-	Disruptive DisruptiveProperty = "yes"
-
-	// NonDisruptive means will not cause the pod restart
-	NonDisruptive DisruptiveProperty = "no"
-)
-
 // A DefinitionReference refers to a CustomResourceDefinition by name.
 type DefinitionReference struct {
 	// Name of the referenced CustomResourceDefinition.

--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -112,6 +112,22 @@ type WorkloadGVK struct {
 	Kind       string `json:"kind"`
 }
 
+// DisruptiveProperty describes whether when a trait is applied to an Application,
+// it will cause the pod to restart due to changes in some fields
+// +kubebuilder:validation:Enum=unknown;yes;no;
+type DisruptiveProperty string
+
+const (
+	// UnknownDisruptive means disruptive unknown.
+	UnknownDisruptive DisruptiveProperty = "unknown"
+
+	// Disruptive means will cause the pod to restart.
+	Disruptive DisruptiveProperty = "yes"
+
+	// NonDisruptive means will not cause the pod restart
+	NonDisruptive DisruptiveProperty = "no"
+)
+
 // A DefinitionReference refers to a CustomResourceDefinition by name.
 type DefinitionReference struct {
 	// Name of the referenced CustomResourceDefinition.

--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -113,7 +113,7 @@ type WorkloadGVK struct {
 }
 
 // DisruptiveProperty describes whether when a trait is applied to an Application,
-// it will cause the pod to restart due to changes in some fields
+// it will cause the pod to restart due to changes in some fields.
 // +kubebuilder:validation:Enum=unknown;yes;no;
 type DisruptiveProperty string
 

--- a/apis/core.oam.dev/v1alpha2/core_types.go
+++ b/apis/core.oam.dev/v1alpha2/core_types.go
@@ -112,13 +112,9 @@ type TraitDefinitionSpec struct {
 	// +optional
 	WorkloadRefPath string `json:"workloadRefPath,omitempty"`
 
-	// PodDisruptive specifies whether using the trait will cause the pod to restart.
-	// Valid values are:
-	// - "unknown" (default): disruptive unknown
-	// - "yes": cause the pod to restart
-	// - "no": will not cause the pod restart
+	// PodDisruptive specifies whether using the trait will cause the pod to restart or not.
 	// +optional
-	PodDisruptive common.DisruptiveProperty `json:"podDisruptive,omitempty"`
+	PodDisruptive bool `json:"podDisruptive,omitempty"`
 
 	// AppliesToWorkloads specifies the list of workload kinds this trait
 	// applies to. Workload kinds are specified in kind.group/version format,

--- a/apis/core.oam.dev/v1alpha2/core_types.go
+++ b/apis/core.oam.dev/v1alpha2/core_types.go
@@ -112,6 +112,14 @@ type TraitDefinitionSpec struct {
 	// +optional
 	WorkloadRefPath string `json:"workloadRefPath,omitempty"`
 
+	// PodDisruptive specifies whether using the trait will cause the pod to restart
+	// Valid values are:
+	// - "unknown" (default): disruptive unknown
+	// - "yes": cause the pod to restart
+	// - "no": will not cause the pod restart
+	// +optional
+	PodDisruptive common.DisruptiveProperty `json:"podDisruptive,omitempty"`
+
 	// AppliesToWorkloads specifies the list of workload kinds this trait
 	// applies to. Workload kinds are specified in kind.group/version format,
 	// e.g. server.core.oam.dev/v1alpha2. Traits that omit this field apply to

--- a/apis/core.oam.dev/v1alpha2/core_types.go
+++ b/apis/core.oam.dev/v1alpha2/core_types.go
@@ -112,7 +112,7 @@ type TraitDefinitionSpec struct {
 	// +optional
 	WorkloadRefPath string `json:"workloadRefPath,omitempty"`
 
-	// PodDisruptive specifies whether using the trait will cause the pod to restart
+	// PodDisruptive specifies whether using the trait will cause the pod to restart.
 	// Valid values are:
 	// - "unknown" (default): disruptive unknown
 	// - "yes": cause the pod to restart

--- a/apis/core.oam.dev/v1beta1/core_types.go
+++ b/apis/core.oam.dev/v1beta1/core_types.go
@@ -112,13 +112,9 @@ type TraitDefinitionSpec struct {
 	// +optional
 	WorkloadRefPath string `json:"workloadRefPath,omitempty"`
 
-	// PodDisruptive specifies whether using the trait will cause the pod to restart.
-	// Valid values are:
-	// - "unknown" (default): disruptive unknown
-	// - "yes": cause the pod to restart
-	// - "no": will not cause the pod restart
+	// PodDisruptive specifies whether using the trait will cause the pod to restart or not.
 	// +optional
-	PodDisruptive common.DisruptiveProperty `json:"podDisruptive,omitempty"`
+	PodDisruptive bool `json:"podDisruptive,omitempty"`
 
 	// AppliesToWorkloads specifies the list of workload kinds this trait
 	// applies to. Workload kinds are specified in kind.group/version format,

--- a/apis/core.oam.dev/v1beta1/core_types.go
+++ b/apis/core.oam.dev/v1beta1/core_types.go
@@ -112,6 +112,14 @@ type TraitDefinitionSpec struct {
 	// +optional
 	WorkloadRefPath string `json:"workloadRefPath,omitempty"`
 
+	// PodDisruptive specifies whether using the trait will cause the pod to restart
+	// Valid values are:
+	// - "unknown" (default): disruptive unknown
+	// - "yes": cause the pod to restart
+	// - "no": will not cause the pod restart
+	// +optional
+	PodDisruptive common.DisruptiveProperty `json:"podDisruptive,omitempty"`
+
 	// AppliesToWorkloads specifies the list of workload kinds this trait
 	// applies to. Workload kinds are specified in kind.group/version format,
 	// e.g. server.core.oam.dev/v1alpha2. Traits that omit this field apply to

--- a/apis/core.oam.dev/v1beta1/core_types.go
+++ b/apis/core.oam.dev/v1beta1/core_types.go
@@ -112,7 +112,7 @@ type TraitDefinitionSpec struct {
 	// +optional
 	WorkloadRefPath string `json:"workloadRefPath,omitempty"`
 
-	// PodDisruptive specifies whether using the trait will cause the pod to restart
+	// PodDisruptive specifies whether using the trait will cause the pod to restart.
 	// Valid values are:
 	// - "unknown" (default): disruptive unknown
 	// - "yes": cause the pod to restart

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -758,12 +758,8 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         podDisruptive:
-                          description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
-                          enum:
-                          - unknown
-                          - "yes"
-                          - "no"
-                          type: string
+                          description: PodDisruptive specifies whether using the trait will cause the pod to restart or not.
+                          type: boolean
                         revisionEnabled:
                           description: Revision indicates whether a trait is aware of component revision
                           type: boolean
@@ -1814,12 +1810,8 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         podDisruptive:
-                          description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
-                          enum:
-                          - unknown
-                          - "yes"
-                          - "no"
-                          type: string
+                          description: PodDisruptive specifies whether using the trait will cause the pod to restart or not.
+                          type: boolean
                         revisionEnabled:
                           description: Revision indicates whether a trait is aware of component revision
                           type: boolean

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -758,7 +758,7 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         podDisruptive:
-                          description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                          description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
                           enum:
                           - unknown
                           - "yes"
@@ -1814,7 +1814,7 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         podDisruptive:
-                          description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                          description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
                           enum:
                           - unknown
                           - "yes"

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -757,6 +757,13 @@ spec:
                           description: Extension is used for extension needs by OAM platform builders
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+                        podDisruptive:
+                          description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                          enum:
+                          - unknown
+                          - "yes"
+                          - "no"
+                          type: string
                         revisionEnabled:
                           description: Revision indicates whether a trait is aware of component revision
                           type: boolean
@@ -1806,6 +1813,13 @@ spec:
                           description: Extension is used for extension needs by OAM platform builders
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+                        podDisruptive:
+                          description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                          enum:
+                          - unknown
+                          - "yes"
+                          - "no"
+                          type: string
                         revisionEnabled:
                           description: Revision indicates whether a trait is aware of component revision
                           type: boolean

--- a/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
@@ -72,7 +72,7 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               podDisruptive:
-                description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
                 enum:
                 - unknown
                 - "yes"
@@ -259,7 +259,7 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               podDisruptive:
-                description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
                 enum:
                 - unknown
                 - "yes"

--- a/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
@@ -72,12 +72,8 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               podDisruptive:
-                description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
-                enum:
-                - unknown
-                - "yes"
-                - "no"
-                type: string
+                description: PodDisruptive specifies whether using the trait will cause the pod to restart or not.
+                type: boolean
               revisionEnabled:
                 description: Revision indicates whether a trait is aware of component revision
                 type: boolean
@@ -259,12 +255,8 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               podDisruptive:
-                description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
-                enum:
-                - unknown
-                - "yes"
-                - "no"
-                type: string
+                description: PodDisruptive specifies whether using the trait will cause the pod to restart or not.
+                type: boolean
               revisionEnabled:
                 description: Revision indicates whether a trait is aware of component revision
                 type: boolean

--- a/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
@@ -71,6 +71,13 @@ spec:
                 description: Extension is used for extension needs by OAM platform builders
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              podDisruptive:
+                description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                enum:
+                - unknown
+                - "yes"
+                - "no"
+                type: string
               revisionEnabled:
                 description: Revision indicates whether a trait is aware of component revision
                 type: boolean
@@ -251,6 +258,13 @@ spec:
                 description: Extension is used for extension needs by OAM platform builders
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              podDisruptive:
+                description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                enum:
+                - unknown
+                - "yes"
+                - "no"
+                type: string
               revisionEnabled:
                 description: Revision indicates whether a trait is aware of component revision
                 type: boolean

--- a/charts/vela-core/templates/defwithtemplate/ingress.yaml
+++ b/charts/vela-core/templates/defwithtemplate/ingress.yaml
@@ -21,6 +21,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: "no"
   schematic:
     cue:
       template: |

--- a/charts/vela-core/templates/defwithtemplate/ingress.yaml
+++ b/charts/vela-core/templates/defwithtemplate/ingress.yaml
@@ -21,7 +21,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
-  podDisruptive: "no"
+  podDisruptive: false
   schematic:
     cue:
       template: |

--- a/charts/vela-core/templates/defwithtemplate/manualscale.yaml
+++ b/charts/vela-core/templates/defwithtemplate/manualscale.yaml
@@ -13,6 +13,7 @@ spec:
   definitionRef:
     name: manualscalertraits.core.oam.dev
   workloadRefPath: spec.workloadRef
+  podDisruptive: "yes"
   schematic:
     cue:
       template: |

--- a/charts/vela-core/templates/defwithtemplate/manualscale.yaml
+++ b/charts/vela-core/templates/defwithtemplate/manualscale.yaml
@@ -13,7 +13,7 @@ spec:
   definitionRef:
     name: manualscalertraits.core.oam.dev
   workloadRefPath: spec.workloadRef
-  podDisruptive: "yes"
+  podDisruptive: true
   schematic:
     cue:
       template: |

--- a/docs/en/cue/patch-trait.md
+++ b/docs/en/cue/patch-trait.md
@@ -21,6 +21,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: true
   schematic:
     cue:
       template: |
@@ -54,7 +55,12 @@ spec:
         }
 ```
 
-The patch trait above assumes the target component instance have `spec.template.spec.affinity` field. Hence we need to use `appliesToWorkloads` to enforce the trait only applies to those workload types have this field.
+The patch trait above assumes the target component instance have `spec.template.spec.affinity` field.
+Hence, we need to use `appliesToWorkloads` to enforce the trait only applies to those workload types have this field.
+
+Another important field is `podDisruptive`, this patch trait will patch to the pod template field,
+so changes on any field of this trait will cause the pod to restart, We should add `podDisruptive` and make it to be true
+to tell users that applying this trait will cause the pod to restart.
 
 
 Now the users could declare they want to add node affinity rules to the component instance as below:
@@ -112,6 +118,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: true
   schematic:
     cue:
       template: |
@@ -141,6 +148,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: true
   schematic:
     cue:
       template: |
@@ -185,6 +193,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: true
   schematic:
     cue:
       template: |
@@ -235,6 +244,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: false
   schematic:
     cue:
       template: |
@@ -258,7 +268,7 @@ spec:
 
 Inject system environments into Pod is also very common use case.
 
-> This case rely on strategy merge patch, so don't forget add `+patchKey=name` as below:
+> This case relies on strategy merge patch, so don't forget add `+patchKey=name` as below:
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1
@@ -271,6 +281,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: true
   schematic:
     cue:
       template: |
@@ -312,6 +323,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: true
   schematic:
     cue:
       template: |
@@ -358,6 +370,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: true
   schematic:
     cue:
       template: |

--- a/docs/en/cue/trait.md
+++ b/docs/en/cue/trait.md
@@ -68,6 +68,7 @@ kind: TraitDefinition
 metadata:
   name: ingress
 spec:
+  podDisruptive: false
   schematic:
     cue:
       template: |
@@ -140,8 +141,5 @@ spec:
             http:
               "/api": 8080
 ```
-
-When we deploy/upgrade an Application, some field of trait changed will cause the pod to restart, We should add `podDisruptive`
-to tell user whether applying this trait will cause the pod to restart.
 
 CUE based trait definitions can also enable many other advanced scenarios such as patching and data passing. They will be explained in detail in the following documentations.

--- a/docs/en/cue/trait.md
+++ b/docs/en/cue/trait.md
@@ -141,4 +141,7 @@ spec:
               "/api": 8080
 ```
 
+When we deploy/upgrade an Application, some field of trait changed will cause the pod to restart, We should add `podDisruptive`
+to tell user whether applying this trait will cause the pod to restart.
+
 CUE based trait definitions can also enable many other advanced scenarios such as patching and data passing. They will be explained in detail in the following documentations.

--- a/docs/en/platform-engineers/definition-and-templates.md
+++ b/docs/en/platform-engineers/definition-and-templates.md
@@ -75,7 +75,8 @@ spec:
     - webservice
   conflictsWith: 
     - service
-  workloadRefPath: spec.wrokloadRef 
+  workloadRefPath: spec.wrokloadRef
+  podDisruptive: no
 ```
 
 Let's explain them in detail.
@@ -120,6 +121,13 @@ This field defines the field path of the trait which is used to store the refere
 If this field is set, KubeVela core will automatically fill the workload reference into target field of the trait. Then the trait controller can get the workload reference from the trait latter. So this field usually accompanies with the traits whose controllers relying on the workload reference at runtime. 
 
 Please check [scaler](https://github.com/oam-dev/kubevela/blob/master/charts/vela-core/templates/defwithtemplate/manualscale.yaml) trait as a demonstration of how to set this field.
+
+##### `.spec.podDisruptive`
+
+This field defines that adding/updating the trait will disruptive the pod or not.
+In this example, the answer is `no`, so it will not affect the pod when the trait is added or updated.
+If the field is `yes`, then it will cause the pod to disruptive and restart when the trait is added or updated.
+By default, the value is `unknown` which means this character is undefined in this trait.
 
 ### Capability Encapsulation and Abstraction
 

--- a/docs/en/platform-engineers/definition-and-templates.md
+++ b/docs/en/platform-engineers/definition-and-templates.md
@@ -76,7 +76,7 @@ spec:
   conflictsWith: 
     - service
   workloadRefPath: spec.wrokloadRef
-  podDisruptive: no
+  podDisruptive: false
 ```
 
 Let's explain them in detail.
@@ -116,7 +116,7 @@ If this field is omitted, it means this trait is NOT conflicting with any traits
 ##### `.spec.workloadRefPath`
 
 This field defines the field path of the trait which is used to store the reference of the workload to which the trait is applied.
-- It accepts a string as value, e.g., `spec.workloadRef`.  
+- It accepts a string as value, e.g., `spec.workloadRef`.
 
 If this field is set, KubeVela core will automatically fill the workload reference into target field of the trait. Then the trait controller can get the workload reference from the trait latter. So this field usually accompanies with the traits whose controllers relying on the workload reference at runtime. 
 
@@ -125,9 +125,10 @@ Please check [scaler](https://github.com/oam-dev/kubevela/blob/master/charts/vel
 ##### `.spec.podDisruptive`
 
 This field defines that adding/updating the trait will disruptive the pod or not.
-In this example, the answer is `no`, so it will not affect the pod when the trait is added or updated.
-If the field is `yes`, then it will cause the pod to disruptive and restart when the trait is added or updated.
-By default, the value is `unknown` which means this character is undefined in this trait.
+In this example, the answer is not, so the field is `false`, it will not affect the pod when the trait is added or updated.
+If the field is `true`, then it will cause the pod to disruptive and restart when the trait is added or updated.
+By default, the value is `false` which means this trait will not affect.
+Please take care of this field, it's really important and useful for serious large scale production usage scenarios.
 
 ### Capability Encapsulation and Abstraction
 

--- a/docs/examples/app-with-status/template.yaml
+++ b/docs/examples/app-with-status/template.yaml
@@ -80,6 +80,7 @@ spec:
       message: "type: "+ context.outputs.service.spec.type +",\t clusterIP:"+ context.outputs.service.spec.clusterIP+",\t ports:"+ "\(context.outputs.service.spec.ports[0].port)"+",\t domain"+context.outputs.ingress.spec.rules[0].host
     healthPolicy: |
       isHealth: len(context.outputs.service.spec.clusterIP) > 0
+  podDisruptive: "no"
   schematic:
     cue:
       template: |

--- a/docs/examples/app-with-status/template.yaml
+++ b/docs/examples/app-with-status/template.yaml
@@ -80,7 +80,7 @@ spec:
       message: "type: "+ context.outputs.service.spec.type +",\t clusterIP:"+ context.outputs.service.spec.clusterIP+",\t ports:"+ "\(context.outputs.service.spec.ports[0].port)"+",\t domain"+context.outputs.ingress.spec.rules[0].host
     healthPolicy: |
       isHealth: len(context.outputs.service.spec.clusterIP) > 0
-  podDisruptive: "no"
+  podDisruptive: false
   schematic:
     cue:
       template: |

--- a/docs/examples/dry-run/definitions/myingress.yaml
+++ b/docs/examples/dry-run/definitions/myingress.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   appliesToWorkloads:
     - "*"
-  podDisruptive: "no"
+  podDisruptive: false
   schematic:
     cue:
       template: |

--- a/docs/examples/dry-run/definitions/myingress.yaml
+++ b/docs/examples/dry-run/definitions/myingress.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   appliesToWorkloads:
     - "*"
+  podDisruptive: "no"
   schematic:
     cue:
       template: |

--- a/docs/examples/helm-module/virtual-group-td.yaml
+++ b/docs/examples/helm-module/virtual-group-td.yaml
@@ -9,7 +9,7 @@ spec:
     - webservice
     - worker
     - deployments.apps
-  podDisruptive: "yes"
+  podDisruptive: true
   extension:
     template: |-
       patch: {

--- a/docs/examples/helm-module/virtual-group-td.yaml
+++ b/docs/examples/helm-module/virtual-group-td.yaml
@@ -9,6 +9,7 @@ spec:
     - webservice
     - worker
     - deployments.apps
+  podDisruptive: "yes"
   extension:
     template: |-
       patch: {

--- a/docs/examples/kube-module/virtual-group-td.yaml
+++ b/docs/examples/kube-module/virtual-group-td.yaml
@@ -9,7 +9,7 @@ spec:
     - webservice
     - worker
     - deployments.apps
-  podDisruptive: "yes"
+  podDisruptive: true
   extension:
     template: |-
       patch: {

--- a/docs/examples/kube-module/virtual-group-td.yaml
+++ b/docs/examples/kube-module/virtual-group-td.yaml
@@ -9,6 +9,7 @@ spec:
     - webservice
     - worker
     - deployments.apps
+  podDisruptive: "yes"
   extension:
     template: |-
       patch: {

--- a/docs/examples/registry/autoscale.yaml
+++ b/docs/examples/registry/autoscale.yaml
@@ -12,6 +12,7 @@ spec:
   workloadRefPath: spec.workloadRef
   definitionRef:
     name: autoscalers.standard.oam.dev
+  podDisruptive: "yes"
   extension:
     install:
       helm:

--- a/docs/examples/registry/autoscale.yaml
+++ b/docs/examples/registry/autoscale.yaml
@@ -12,7 +12,7 @@ spec:
   workloadRefPath: spec.workloadRef
   definitionRef:
     name: autoscalers.standard.oam.dev
-  podDisruptive: "yes"
+  podDisruptive: true
   extension:
     install:
       helm:

--- a/docs/examples/registry/for-loop.yaml
+++ b/docs/examples/registry/for-loop.yaml
@@ -4,7 +4,7 @@ metadata:
   name: expose
   namespace: vela-system
 spec:
-  podDisruptive: "no"
+  podDisruptive: false
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/for-loop.yaml
+++ b/docs/examples/registry/for-loop.yaml
@@ -4,6 +4,7 @@ metadata:
   name: expose
   namespace: vela-system
 spec:
+  podDisruptive: "no"
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/hpa.yaml
+++ b/docs/examples/registry/hpa.yaml
@@ -8,7 +8,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
-  podDisruptive: "yes"
+  podDisruptive: true
   schematic:
     cue:
       template: |

--- a/docs/examples/registry/hpa.yaml
+++ b/docs/examples/registry/hpa.yaml
@@ -8,6 +8,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: "yes"
   schematic:
     cue:
       template: |

--- a/docs/examples/registry/initcontainer.yaml
+++ b/docs/examples/registry/initcontainer.yaml
@@ -9,6 +9,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: "yes"
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/initcontainer.yaml
+++ b/docs/examples/registry/initcontainer.yaml
@@ -9,7 +9,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
-  podDisruptive: "yes"
+  podDisruptive: true
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/kautoscale.yaml
+++ b/docs/examples/registry/kautoscale.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   appliesToWorkloads:
     - webservice # this should be some knative like workload
-  podDisruptive: "yes"
+  podDisruptive: true
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/kautoscale.yaml
+++ b/docs/examples/registry/kautoscale.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   appliesToWorkloads:
     - webservice # this should be some knative like workload
+  podDisruptive: "yes"
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/node-affinity.yaml
+++ b/docs/examples/registry/node-affinity.yaml
@@ -9,6 +9,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: "yes"
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/node-affinity.yaml
+++ b/docs/examples/registry/node-affinity.yaml
@@ -9,7 +9,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
-  podDisruptive: "yes"
+  podDisruptive: true
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/patch-replica.yaml
+++ b/docs/examples/registry/patch-replica.yaml
@@ -9,6 +9,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: "yes"
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/patch-replica.yaml
+++ b/docs/examples/registry/patch-replica.yaml
@@ -9,7 +9,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
-  podDisruptive: "yes"
+  podDisruptive: true
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/rollout.yaml
+++ b/docs/examples/registry/rollout.yaml
@@ -12,6 +12,7 @@ spec:
     name: canaries.flagger.app
   workloadRefPath: spec.targetRef
   revisionEnabled: true
+  podDisruptive: "yes"
   extension:
     install:
       helm:

--- a/docs/examples/registry/rollout.yaml
+++ b/docs/examples/registry/rollout.yaml
@@ -12,7 +12,7 @@ spec:
     name: canaries.flagger.app
   workloadRefPath: spec.targetRef
   revisionEnabled: true
-  podDisruptive: "yes"
+  podDisruptive: true
   extension:
     install:
       helm:

--- a/docs/examples/registry/route.yaml
+++ b/docs/examples/registry/route.yaml
@@ -11,6 +11,7 @@ spec:
   workloadRefPath: spec.workloadRef
   definitionRef:
     name: routes.standard.oam.dev
+  podDisruptive: "no"
   extension:
     install:
       helm:

--- a/docs/examples/registry/route.yaml
+++ b/docs/examples/registry/route.yaml
@@ -11,7 +11,7 @@ spec:
   workloadRefPath: spec.workloadRef
   definitionRef:
     name: routes.standard.oam.dev
-  podDisruptive: "no"
+  podDisruptive: false
   extension:
     install:
       helm:

--- a/docs/examples/registry/sidecar.yaml
+++ b/docs/examples/registry/sidecar.yaml
@@ -8,7 +8,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
-  podDisruptive: "yes"
+  podDisruptive: true
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/sidecar.yaml
+++ b/docs/examples/registry/sidecar.yaml
@@ -8,6 +8,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: "yes"
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/virtualgroup.yaml
+++ b/docs/examples/registry/virtualgroup.yaml
@@ -9,6 +9,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: "no"
   schematic:
     cue:
       template: |-

--- a/docs/examples/registry/virtualgroup.yaml
+++ b/docs/examples/registry/virtualgroup.yaml
@@ -9,7 +9,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
-  podDisruptive: "no"
+  podDisruptive: false
   schematic:
     cue:
       template: |-

--- a/hack/vela-templates/definitions/ingress.yaml
+++ b/hack/vela-templates/definitions/ingress.yaml
@@ -20,7 +20,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
-  podDisruptive: "no"
+  podDisruptive: false
   schematic:
     cue:
       template: |

--- a/hack/vela-templates/definitions/ingress.yaml
+++ b/hack/vela-templates/definitions/ingress.yaml
@@ -20,6 +20,7 @@ spec:
   appliesToWorkloads:
     - webservice
     - worker
+  podDisruptive: "no"
   schematic:
     cue:
       template: |

--- a/hack/vela-templates/definitions/manualscale.yaml
+++ b/hack/vela-templates/definitions/manualscale.yaml
@@ -12,6 +12,7 @@ spec:
   definitionRef:
     name: manualscalertraits.core.oam.dev
   workloadRefPath: spec.workloadRef
+  podDisruptive: "yes"
   schematic:
     cue:
       template: |

--- a/hack/vela-templates/definitions/manualscale.yaml
+++ b/hack/vela-templates/definitions/manualscale.yaml
@@ -12,7 +12,7 @@ spec:
   definitionRef:
     name: manualscalertraits.core.oam.dev
   workloadRefPath: spec.workloadRef
-  podDisruptive: "yes"
+  podDisruptive: true
   schematic:
     cue:
       template: |

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -753,12 +753,8 @@ spec:
                         type: object
                         
                       podDisruptive:
-                        description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
-                        enum:
-                        - unknown
-                        - "yes"
-                        - "no"
-                        type: string
+                        description: PodDisruptive specifies whether using the trait will cause the pod to restart or not.
+                        type: boolean
                       revisionEnabled:
                         description: Revision indicates whether a trait is aware of component revision
                         type: boolean

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -753,7 +753,7 @@ spec:
                         type: object
                         
                       podDisruptive:
-                        description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                        description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
                         enum:
                         - unknown
                         - "yes"

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -752,6 +752,13 @@ spec:
                         description: Extension is used for extension needs by OAM platform builders
                         type: object
                         
+                      podDisruptive:
+                        description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+                        enum:
+                        - unknown
+                        - "yes"
+                        - "no"
+                        type: string
                       revisionEnabled:
                         description: Revision indicates whether a trait is aware of component revision
                         type: boolean

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
@@ -71,6 +71,13 @@ spec:
               description: Extension is used for extension needs by OAM platform builders
               type: object
               
+            podDisruptive:
+              description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+              enum:
+              - unknown
+              - "yes"
+              - "no"
+              type: string
             revisionEnabled:
               description: Revision indicates whether a trait is aware of component revision
               type: boolean

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
@@ -72,7 +72,7 @@ spec:
               type: object
               
             podDisruptive:
-              description: 'PodDisruptive specifies whether using the trait will cause the pod to restart Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
+              description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
               enum:
               - unknown
               - "yes"

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
@@ -72,12 +72,8 @@ spec:
               type: object
               
             podDisruptive:
-              description: 'PodDisruptive specifies whether using the trait will cause the pod to restart. Valid values are: - "unknown" (default): disruptive unknown - "yes": cause the pod to restart - "no": will not cause the pod restart'
-              enum:
-              - unknown
-              - "yes"
-              - "no"
-              type: string
+              description: PodDisruptive specifies whether using the trait will cause the pod to restart or not.
+              type: boolean
             revisionEnabled:
               description: Revision indicates whether a trait is aware of component revision
               type: boolean

--- a/references/cli/traits.go
+++ b/references/cli/traits.go
@@ -63,9 +63,13 @@ func printTraitList(userNamespace string, c common2.Args, ioStreams cmdutil.IOSt
 	if err != nil {
 		return err
 	}
-	table.AddRow("NAME", "NAMESPACE", "APPLIES-TO", "CONFLICTS-WITH", "DESCRIPTION")
+	table.AddRow("NAME", "NAMESPACE", "APPLIES-TO", "CONFLICTS-WITH", "POD-DISRUPTIVE", "DESCRIPTION")
 	for _, t := range traitDefinitionList {
-		table.AddRow(t.Name, t.Namespace, strings.Join(t.Spec.AppliesToWorkloads, ","), strings.Join(t.Spec.ConflictsWith, ","), plugins.GetDescription(t.Annotations))
+		var podDisruptive = t.Spec.PodDisruptive
+		if t.Spec.PodDisruptive == "" {
+			podDisruptive = "unknown"
+		}
+		table.AddRow(t.Name, t.Namespace, strings.Join(t.Spec.AppliesToWorkloads, ","), strings.Join(t.Spec.ConflictsWith, ","), podDisruptive, plugins.GetDescription(t.Annotations))
 	}
 	ioStreams.Info(table.String())
 	return nil

--- a/references/cli/traits.go
+++ b/references/cli/traits.go
@@ -65,11 +65,7 @@ func printTraitList(userNamespace string, c common2.Args, ioStreams cmdutil.IOSt
 	}
 	table.AddRow("NAME", "NAMESPACE", "APPLIES-TO", "CONFLICTS-WITH", "POD-DISRUPTIVE", "DESCRIPTION")
 	for _, t := range traitDefinitionList {
-		var podDisruptive = t.Spec.PodDisruptive
-		if t.Spec.PodDisruptive == "" {
-			podDisruptive = "unknown"
-		}
-		table.AddRow(t.Name, t.Namespace, strings.Join(t.Spec.AppliesToWorkloads, ","), strings.Join(t.Spec.ConflictsWith, ","), podDisruptive, plugins.GetDescription(t.Annotations))
+		table.AddRow(t.Name, t.Namespace, strings.Join(t.Spec.AppliesToWorkloads, ","), strings.Join(t.Spec.ConflictsWith, ","), t.Spec.PodDisruptive, plugins.GetDescription(t.Annotations))
 	}
 	ioStreams.Info(table.String())
 	return nil


### PR DESCRIPTION
fix #1123

Now when we deploy/upgrade an Application, only change some fields of trait , we don't know whether the underlying pod will restart or not, we should let the TraitDefinition tell. So we add a podDisruptive field  to TraitDefinition.

- [X] add podDisruptive field into traitdefinition.
- [X] display in cli
- [x] add docs
- [x] check all traits in kubevela and registry