### PR TITLE
modify image pull policy

### DIFF
--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -11,7 +11,7 @@ disableCaps: "metrics"
 image:
   repository: oamdev/vela-core
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
To avoid using legacy `oamdev/vela-core: latest` image.
Signed-off-by: roy wang <seiwy2010@gmail.com>