### PR TITLE
Fix the function and method names that does not conform to the naming convention

### DIFF
--- a/apis/core.oam.dev/v1alpha2/application_types_test.go
+++ b/apis/core.oam.dev/v1alpha2/application_types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestApplication_GetComponent(t *testing.T) {
+func TestApplicationGetComponent(t *testing.T) {
 	ac1 := ApplicationComponent{
 		Name:         "ac1",
 		WorkloadType: "type1",

--- a/pkg/builtin/http/http_test.go
+++ b/pkg/builtin/http/http_test.go
@@ -31,7 +31,7 @@ const Req = `
 }
 `
 
-func TestHTTPCmd_Run(t *testing.T) {
+func TestHTTPCmdRun(t *testing.T) {
 	s := NewMock()
 	defer s.Close()
 

--- a/pkg/controller/common/rollout/rollout_webhook_test.go
+++ b/pkg/controller/common/rollout/rollout_webhook_test.go
@@ -16,7 +16,7 @@ import (
 
 const mockUrl = "127.0.0.1:4848"
 
-func Test_MakeHTTPRequest(t *testing.T) {
+func TestMakeHTTPRequest(t *testing.T) {
 	ctx := context.TODO()
 	type mockHTTPParameter struct {
 		method     string


### PR DESCRIPTION
Fix the function and method names that does not conform to the naming convention