### PR TITLE
fix kube-webhook-certgen to patch CRD conversation && remove cert-manager in CI e2e test && remove issuer create from CLI env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,8 @@ docker-push:
 e2e-setup:
 	helm install --create-namespace -n flux-system helm-flux http://oam.dev/catalog/helm-flux2-0.1.0.tgz
 	helm install kruise https://github.com/openkruise/kruise/releases/download/v0.7.0/kruise-chart.tgz
-	helm repo add jetstack https://charts.jetstack.io
 	helm repo update
-	helm upgrade --install --create-namespace --namespace cert-manager cert-manager jetstack/cert-manager --version v1.2.0  --set installCRDs=true --wait
-	helm upgrade --install --create-namespace --namespace vela-system --set image.pullPolicy=IfNotPresent --set admissionWebhooks.certManager.enabled=true --set image.repository=vela-core-test --set image.tag=$(GIT_COMMIT) --wait kubevela ./charts/vela-core
+	helm upgrade --install --create-namespace --namespace vela-system --set image.pullPolicy=IfNotPresent --set image.repository=vela-core-test --set image.tag=$(GIT_COMMIT) --wait kubevela ./charts/vela-core
 	ginkgo version
 	ginkgo -v -r e2e/setup
 	kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=vela-core,app.kubernetes.io/instance=kubevela -n vela-system --timeout=600s

--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -50,8 +50,6 @@ type EnvMeta struct {
 	Email     string `json:"email,omitempty"`
 	Domain    string `json:"domain,omitempty"`
 
-	// Below are not arguments, should be auto-generated
-	Issuer  string `json:"issuer"`
 	Current string `json:"current,omitempty"`
 }
 

--- a/charts/vela-core/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/vela-core/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -18,4 +18,11 @@ rules:
     verbs:
       - get
       - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - update
 {{- end }}

--- a/charts/vela-core/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/vela-core/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -32,6 +32,7 @@ spec:
             - --namespace={{ .Release.Namespace }}
             - --secret-name={{ template "kubevela.fullname" . }}-admission
             - --patch-failure-policy={{ .Values.admissionWebhooks.failurePolicy }}
+            - --crds=applications.core.oam.dev
       restartPolicy: OnFailure
       serviceAccountName: {{ template "kubevela.fullname" . }}-admission
       {{- with .Values.admissionWebhooks.patch.affinity }}

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -88,8 +88,8 @@ admissionWebhooks:
   patch:
     enabled: true
     image:
-      repository: jettech/kube-webhook-certgen
-      tag: v1.5.0
+      repository: wonderflow/kube-webhook-certgen
+      tag: v2.1
       pullPolicy: IfNotPresent
     affinity: {}
     tolerations: []

--- a/design/vela-core/route.md
+++ b/design/vela-core/route.md
@@ -1,8 +1,8 @@
 # Route Trait Design
 
-The main idea of route trait is to let users have an entrypoint to visit their App.
+The main idea of [route trait](https://github.com/oam-dev/catalog/tree/master/traits/routetrait) is to let users have an entrypoint to visit their App.
 
-In k8s world, if you want to do so, you have to understand K8s [Serivce](https://kubernetes.io/docs/concepts/services-networking/service/)
+In k8s world, if you want to do so, you have to understand K8s [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
 , [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/), [Ingress Controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
 It's not easy to get all of these things work well.
 

--- a/docs/en/developers/config-enviroments.md
+++ b/docs/en/developers/config-enviroments.md
@@ -2,7 +2,8 @@
 title:  Setting Up Deployment Environment
 ---
 
-A deployment environment is where you could configure the workspace, email for certificate issuer and domain for your applications globally. A typical set of deployment environment is `test`, `staging`, `prod`, etc.
+A deployment environment is where you could configure the workspace, email for contact and domain for your applications globally.
+A typical set of deployment environment is `test`, `staging`, `prod`, etc.
 
 ## Create environment
 

--- a/hack/crd/update.go
+++ b/hack/crd/update.go
@@ -64,16 +64,6 @@ func fixNewSchemaValidationCheck(crds []string) error {
 			}
 			ioutil.WriteFile(crd, []byte(strings.Join(newData, "\n")), 0644)
 		}
-		// fix issue https://github.com/oam-dev/kubevela/issues/993
-		if strings.HasSuffix(crd, "legacy/charts/vela-core-legacy/crds/standard.oam.dev_routes.yaml") {
-			for _, line := range strings.Split(string(data), "\n") {
-				if strings.Contains(line, "default: Issuer") {
-					continue
-				}
-				newData = append(newData, line)
-			}
-			ioutil.WriteFile(crd, []byte(strings.Join(newData, "\n")), 0644)
-		}
 	}
 	return nil
 }

--- a/references/cli/up_test.go
+++ b/references/cli/up_test.go
@@ -36,7 +36,6 @@ func TestUp(t *testing.T) {
 	env := types.EnvMeta{
 		Name:      "up",
 		Namespace: "env-up",
-		Issuer:    "up",
 	}
 	o := common.AppfileOptions{
 		IO:  ioStream,


### PR DESCRIPTION
remove cert-manager in CI, by default, the webhook is enabled  in chart, it will use `wonderflow/kube-webhook-certgen:v2.1` if cert-manager is not enabled.

Repo: https://github.com/wonderflow/kube-webhook-certgen



fix https://github.com/oam-dev/kubevela/issues/1361