### PR TITLE
fix the problem that the description field in the crd file is modified due to the Kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ else
 CUE=$(shell which cue)
 endif
 
-KUSTOMIZE_VERSION ?= 3.8.2
+KUSTOMIZE_VERSION ?= 4.0.5
 
 .PHONY: kustomize
 kustomize:


### PR DESCRIPTION
when executing `make manifests`, the kustomize will change description field in CRD, this pr wiil fix this problem.