### PR TITLE
fix CI check-diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ KUSTOMIZE_VERSION ?= 3.8.2
 
 .PHONY: kustomize
 kustomize:
-ifeq (, $(shell which kustomize))
+ifeq (, $(shell kustomize version | grep $(KUSTOMIZE_VERSION)))
 	@{ \
 	set -e ;\
 	echo 'installing kustomize-v$(KUSTOMIZE_VERSION)' ;\

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -34,14 +34,10 @@ spec:
         description: Application is the Schema for the applications API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -57,18 +53,14 @@ spec:
                     scopes:
                       additionalProperties:
                         type: string
-                      description: scopes in ApplicationComponent defines the component-level
-                        scopes the format is <scope-type:scope-instance-name> pairs,
-                        the key represents type of `ScopeDefinition` while the value
-                        represent the name of scope instance.
+                      description: scopes in ApplicationComponent defines the component-level scopes the format is <scope-type:scope-instance-name> pairs, the key represents type of `ScopeDefinition` while the value represent the name of scope instance.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     settings:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     traits:
-                      description: Traits define the trait of one component, the type
-                        must be array to keep the order.
+                      description: Traits define the trait of one component, the type must be array to keep the order.
                       items:
                         description: ApplicationTrait defines the trait of application
                         properties:
@@ -89,24 +81,16 @@ spec:
                   type: object
                 type: array
               rolloutPlan:
-                description: RolloutPlan is the details on how to rollout the resources
-                  The controller simply replace the old resources with the new one
-                  if there is no rollout plan involved
+                description: RolloutPlan is the details on how to rollout the resources The controller simply replace the old resources with the new one if there is no rollout plan involved
                 properties:
                   batchPartition:
-                    description: All pods in the batches up to the batchPartition
-                      (included) will have the target resource specification while
-                      the rest still have the source resource This is designed for
-                      the operators to manually rollout Default is the the number
-                      of batches which will rollout all the batches
+                    description: All pods in the batches up to the batchPartition (included) will have the target resource specification while the rest still have the source resource This is designed for the operators to manually rollout Default is the the number of batches which will rollout all the batches
                     format: int32
                     type: integer
                   canaryMetric:
-                    description: CanaryMetric provides a way for the rollout process
-                      to automatically check certain metrics before complete the process
+                    description: CanaryMetric provides a way for the rollout process to automatically check certain metrics before complete the process
                     items:
-                      description: CanaryMetric holds the reference to metrics used
-                        for canary analysis
+                      description: CanaryMetric holds the reference to metrics used for canary analysis
                       properties:
                         interval:
                           description: Interval represents the windows size
@@ -162,26 +146,17 @@ spec:
                     description: Paused the rollout, default is false
                     type: boolean
                   rolloutBatches:
-                    description: The exact distribution among batches. its size has
-                      to be exactly the same as the NumBatches (if set) The total
-                      number cannot exceed the targetSize or the size of the source
-                      resource We will IGNORE the last batch's replica field if it's
-                      a percentage since round errors can lead to inaccurate sum We
-                      highly recommend to leave the last batch's replica field empty
+                    description: The exact distribution among batches. its size has to be exactly the same as the NumBatches (if set) The total number cannot exceed the targetSize or the size of the source resource We will IGNORE the last batch's replica field if it's a percentage since round errors can lead to inaccurate sum We highly recommend to leave the last batch's replica field empty
                     items:
-                      description: RolloutBatch is used to describe how the each batch
-                        rollout should be
+                      description: RolloutBatch is used to describe how the each batch rollout should be
                       properties:
                         batchRolloutWebhooks:
-                          description: RolloutWebhooks provides a way for the batch
-                            rollout to interact with an external process
+                          description: RolloutWebhooks provides a way for the batch rollout to interact with an external process
                           items:
-                            description: RolloutWebhook holds the reference to external
-                              checks used for canary analysis
+                            description: RolloutWebhook holds the reference to external checks used for canary analysis
                             properties:
                               expectedStatus:
-                                description: ExpectedStatus contains all the expected
-                                  http status code that we will accept as success
+                                description: ExpectedStatus contains all the expected http status code that we will accept as success
                                 items:
                                   type: integer
                                 type: array
@@ -191,8 +166,7 @@ spec:
                                 description: Metadata (key-value pairs) for this webhook
                                 type: object
                               method:
-                                description: Method the HTTP call method, default
-                                  is POST
+                                description: Method the HTTP call method, default is POST
                                 type: string
                               name:
                                 description: Name of this webhook
@@ -210,12 +184,9 @@ spec:
                             type: object
                           type: array
                         canaryMetric:
-                          description: CanaryMetric provides a way for the batch rollout
-                            process to automatically check certain metrics before
-                            moving to the next batch
+                          description: CanaryMetric provides a way for the batch rollout process to automatically check certain metrics before moving to the next batch
                           items:
-                            description: CanaryMetric holds the reference to metrics
-                              used for canary analysis
+                            description: CanaryMetric holds the reference to metrics used for canary analysis
                             properties:
                               interval:
                                 description: Interval represents the windows size
@@ -240,8 +211,7 @@ spec:
                                 description: Name of the metric
                                 type: string
                               templateRef:
-                                description: TemplateRef references a metric template
-                                  object
+                                description: TemplateRef references a metric template object
                                 properties:
                                   apiVersion:
                                     description: APIVersion of the referenced object.
@@ -265,23 +235,17 @@ spec:
                             type: object
                           type: array
                         instanceInterval:
-                          description: The wait time, in seconds, between instances
-                            upgrades, default = 0
+                          description: The wait time, in seconds, between instances upgrades, default = 0
                           format: int32
                           type: integer
                         maxUnavailable:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: MaxUnavailable is the max allowed number of
-                            pods that is unavailable during the upgrade. We will mark
-                            the batch as ready as long as there are less or equal
-                            number of pods unavailable than this number. default =
-                            0
+                          description: MaxUnavailable is the max allowed number of pods that is unavailable during the upgrade. We will mark the batch as ready as long as there are less or equal number of pods unavailable than this number. default = 0
                           x-kubernetes-int-or-string: true
                         podList:
-                          description: The list of Pods to get upgraded it is mutually
-                            exclusive with the Replicas field
+                          description: The list of Pods to get upgraded it is mutually exclusive with the Replicas field
                           items:
                             type: string
                           type: array
@@ -289,28 +253,20 @@ spec:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Replicas is the number of pods to upgrade
-                            in this batch it can be an absolute number (ex: 5) or
-                            a percentage of total pods we will ignore the percentage
-                            of the last batch to just fill the gap it is mutually
-                            exclusive with the PodList field'
+                          description: 'Replicas is the number of pods to upgrade in this batch it can be an absolute number (ex: 5) or a percentage of total pods we will ignore the percentage of the last batch to just fill the gap it is mutually exclusive with the PodList field'
                           x-kubernetes-int-or-string: true
                       type: object
                     type: array
                   rolloutStrategy:
-                    description: RolloutStrategy defines strategies for the rollout
-                      plan The default is IncreaseFirstRolloutStrategyType
+                    description: RolloutStrategy defines strategies for the rollout plan The default is IncreaseFirstRolloutStrategyType
                     type: string
                   rolloutWebhooks:
-                    description: RolloutWebhooks provide a way for the rollout to
-                      interact with an external process
+                    description: RolloutWebhooks provide a way for the rollout to interact with an external process
                     items:
-                      description: RolloutWebhook holds the reference to external
-                        checks used for canary analysis
+                      description: RolloutWebhook holds the reference to external checks used for canary analysis
                       properties:
                         expectedStatus:
-                          description: ExpectedStatus contains all the expected http
-                            status code that we will accept as success
+                          description: ExpectedStatus contains all the expected http status code that we will accept as success
                           items:
                             type: integer
                           type: array
@@ -338,8 +294,7 @@ spec:
                       type: object
                     type: array
                   targetSize:
-                    description: The size of the target resource. The default is the
-                      same as the size of the source resource.
+                    description: The size of the target resource. The default is the same as the size of the source resource.
                     format: int32
                     type: integer
                 type: object
@@ -350,16 +305,12 @@ spec:
             description: AppStatus defines the observed state of Application
             properties:
               batchRollingState:
-                description: BatchRollingState only meaningful when the Status is
-                  rolling
+                description: BatchRollingState only meaningful when the Status is rolling
                 type: string
               components:
-                description: Components record the related Components created by Application
-                  Controller
+                description: Components record the related Components created by Application Controller
                 items:
-                  description: A TypedReference refers to an object by Name, Kind,
-                    and APIVersion. It is commonly used to reference cluster-scoped
-                    objects or objects where the namespace is already known.
+                  description: A TypedReference refers to an object by Name, Kind, and APIVersion. It is commonly used to reference cluster-scoped objects or objects where the namespace is already known.
                   properties:
                     apiVersion:
                       description: APIVersion of the referenced object.
@@ -385,25 +336,20 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from
-                        one status to another.
+                      description: A Reason for this condition's last transition from one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True,
-                        False, or Unknown?
+                      description: Status of this condition; is it currently True, False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -413,15 +359,11 @@ spec:
                   type: object
                 type: array
               currentBatch:
-                description: The current batch the rollout is working on/blocked it
-                  starts from 0
+                description: The current batch the rollout is working on/blocked it starts from 0
                 format: int32
                 type: integer
               lastAppliedPodTemplateIdentifier:
-                description: lastAppliedPodTemplateIdentifier is a string that uniquely
-                  represent the last pod template each workload type could use different
-                  ways to identify that so we cannot compare between resources We
-                  update this field only after a successful rollout
+                description: lastAppliedPodTemplateIdentifier is a string that uniquely represent the last pod template each workload type could use different ways to identify that so we cannot compare between resources We update this field only after a successful rollout
                 type: string
               latestRevision:
                 description: LatestRevision of the application configuration it generates
@@ -432,8 +374,7 @@ spec:
                     format: int64
                     type: integer
                   revisionHash:
-                    description: RevisionHash record the hash value of the spec of
-                      ApplicationRevision object.
+                    description: RevisionHash record the hash value of the spec of ApplicationRevision object.
                     type: string
                 required:
                 - name
@@ -443,16 +384,13 @@ spec:
                 description: RollingState is the Rollout State
                 type: string
               rolloutTargetSize:
-                description: RolloutTargetTotalSize is the size of the target resources.
-                  This is determined once the initial spec verification and does not
-                  change until the rollout is restarted
+                description: RolloutTargetTotalSize is the size of the target resources. This is determined once the initial spec verification and does not change until the rollout is restarted
                 format: int32
                 type: integer
               services:
                 description: Services record the status of the application services
                 items:
-                  description: ApplicationComponentStatus record the health status
-                    of App component
+                  description: ApplicationComponentStatus record the health status of App component
                   properties:
                     healthy:
                       type: boolean
@@ -462,8 +400,7 @@ spec:
                       type: string
                     traits:
                       items:
-                        description: ApplicationTraitStatus records the trait health
-                          status
+                        description: ApplicationTraitStatus records the trait health status
                         properties:
                           healthy:
                             type: boolean
@@ -482,22 +419,17 @@ spec:
                   type: object
                 type: array
               status:
-                description: ApplicationPhase is a label for the condition of a application
-                  at the current time
+                description: ApplicationPhase is a label for the condition of a application at the current time
                 type: string
               targetGeneration:
-                description: NewPodTemplateIdentifier is a string that uniquely represent
-                  the new pod template each workload type could use different ways
-                  to identify that so we cannot compare between resources
+                description: NewPodTemplateIdentifier is a string that uniquely represent the new pod template each workload type could use different ways to identify that so we cannot compare between resources
                 type: string
               upgradedReadyReplicas:
-                description: UpgradedReadyReplicas is the number of Pods upgraded
-                  by the rollout controller that have a Ready Condition.
+                description: UpgradedReadyReplicas is the number of Pods upgraded by the rollout controller that have a Ready Condition.
                 format: int32
                 type: integer
               upgradedReplicas:
-                description: UpgradedReplicas is the number of Pods upgraded by the
-                  rollout controller
+                description: UpgradedReplicas is the number of Pods upgraded by the rollout controller
                 format: int32
                 type: integer
             required:
@@ -517,14 +449,10 @@ spec:
         description: Application is the Schema for the applications API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -543,15 +471,11 @@ spec:
                     scopes:
                       additionalProperties:
                         type: string
-                      description: scopes in ApplicationComponent defines the component-level
-                        scopes the format is <scope-type:scope-instance-name> pairs,
-                        the key represents type of `ScopeDefinition` while the value
-                        represent the name of scope instance.
+                      description: scopes in ApplicationComponent defines the component-level scopes the format is <scope-type:scope-instance-name> pairs, the key represents type of `ScopeDefinition` while the value represent the name of scope instance.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     traits:
-                      description: Traits define the trait of one component, the type
-                        must be array to keep the order.
+                      description: Traits define the trait of one component, the type must be array to keep the order.
                       items:
                         description: ApplicationTrait defines the trait of application
                         properties:
@@ -572,24 +496,16 @@ spec:
                   type: object
                 type: array
               rolloutPlan:
-                description: RolloutPlan is the details on how to rollout the resources
-                  The controller simply replace the old resources with the new one
-                  if there is no rollout plan involved
+                description: RolloutPlan is the details on how to rollout the resources The controller simply replace the old resources with the new one if there is no rollout plan involved
                 properties:
                   batchPartition:
-                    description: All pods in the batches up to the batchPartition
-                      (included) will have the target resource specification while
-                      the rest still have the source resource This is designed for
-                      the operators to manually rollout Default is the the number
-                      of batches which will rollout all the batches
+                    description: All pods in the batches up to the batchPartition (included) will have the target resource specification while the rest still have the source resource This is designed for the operators to manually rollout Default is the the number of batches which will rollout all the batches
                     format: int32
                     type: integer
                   canaryMetric:
-                    description: CanaryMetric provides a way for the rollout process
-                      to automatically check certain metrics before complete the process
+                    description: CanaryMetric provides a way for the rollout process to automatically check certain metrics before complete the process
                     items:
-                      description: CanaryMetric holds the reference to metrics used
-                        for canary analysis
+                      description: CanaryMetric holds the reference to metrics used for canary analysis
                       properties:
                         interval:
                           description: Interval represents the windows size
@@ -645,26 +561,17 @@ spec:
                     description: Paused the rollout, default is false
                     type: boolean
                   rolloutBatches:
-                    description: The exact distribution among batches. its size has
-                      to be exactly the same as the NumBatches (if set) The total
-                      number cannot exceed the targetSize or the size of the source
-                      resource We will IGNORE the last batch's replica field if it's
-                      a percentage since round errors can lead to inaccurate sum We
-                      highly recommend to leave the last batch's replica field empty
+                    description: The exact distribution among batches. its size has to be exactly the same as the NumBatches (if set) The total number cannot exceed the targetSize or the size of the source resource We will IGNORE the last batch's replica field if it's a percentage since round errors can lead to inaccurate sum We highly recommend to leave the last batch's replica field empty
                     items:
-                      description: RolloutBatch is used to describe how the each batch
-                        rollout should be
+                      description: RolloutBatch is used to describe how the each batch rollout should be
                       properties:
                         batchRolloutWebhooks:
-                          description: RolloutWebhooks provides a way for the batch
-                            rollout to interact with an external process
+                          description: RolloutWebhooks provides a way for the batch rollout to interact with an external process
                           items:
-                            description: RolloutWebhook holds the reference to external
-                              checks used for canary analysis
+                            description: RolloutWebhook holds the reference to external checks used for canary analysis
                             properties:
                               expectedStatus:
-                                description: ExpectedStatus contains all the expected
-                                  http status code that we will accept as success
+                                description: ExpectedStatus contains all the expected http status code that we will accept as success
                                 items:
                                   type: integer
                                 type: array
@@ -674,8 +581,7 @@ spec:
                                 description: Metadata (key-value pairs) for this webhook
                                 type: object
                               method:
-                                description: Method the HTTP call method, default
-                                  is POST
+                                description: Method the HTTP call method, default is POST
                                 type: string
                               name:
                                 description: Name of this webhook
@@ -693,12 +599,9 @@ spec:
                             type: object
                           type: array
                         canaryMetric:
-                          description: CanaryMetric provides a way for the batch rollout
-                            process to automatically check certain metrics before
-                            moving to the next batch
+                          description: CanaryMetric provides a way for the batch rollout process to automatically check certain metrics before moving to the next batch
                           items:
-                            description: CanaryMetric holds the reference to metrics
-                              used for canary analysis
+                            description: CanaryMetric holds the reference to metrics used for canary analysis
                             properties:
                               interval:
                                 description: Interval represents the windows size
@@ -723,8 +626,7 @@ spec:
                                 description: Name of the metric
                                 type: string
                               templateRef:
-                                description: TemplateRef references a metric template
-                                  object
+                                description: TemplateRef references a metric template object
                                 properties:
                                   apiVersion:
                                     description: APIVersion of the referenced object.
@@ -748,23 +650,17 @@ spec:
                             type: object
                           type: array
                         instanceInterval:
-                          description: The wait time, in seconds, between instances
-                            upgrades, default = 0
+                          description: The wait time, in seconds, between instances upgrades, default = 0
                           format: int32
                           type: integer
                         maxUnavailable:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: MaxUnavailable is the max allowed number of
-                            pods that is unavailable during the upgrade. We will mark
-                            the batch as ready as long as there are less or equal
-                            number of pods unavailable than this number. default =
-                            0
+                          description: MaxUnavailable is the max allowed number of pods that is unavailable during the upgrade. We will mark the batch as ready as long as there are less or equal number of pods unavailable than this number. default = 0
                           x-kubernetes-int-or-string: true
                         podList:
-                          description: The list of Pods to get upgraded it is mutually
-                            exclusive with the Replicas field
+                          description: The list of Pods to get upgraded it is mutually exclusive with the Replicas field
                           items:
                             type: string
                           type: array
@@ -772,28 +668,20 @@ spec:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Replicas is the number of pods to upgrade
-                            in this batch it can be an absolute number (ex: 5) or
-                            a percentage of total pods we will ignore the percentage
-                            of the last batch to just fill the gap it is mutually
-                            exclusive with the PodList field'
+                          description: 'Replicas is the number of pods to upgrade in this batch it can be an absolute number (ex: 5) or a percentage of total pods we will ignore the percentage of the last batch to just fill the gap it is mutually exclusive with the PodList field'
                           x-kubernetes-int-or-string: true
                       type: object
                     type: array
                   rolloutStrategy:
-                    description: RolloutStrategy defines strategies for the rollout
-                      plan The default is IncreaseFirstRolloutStrategyType
+                    description: RolloutStrategy defines strategies for the rollout plan The default is IncreaseFirstRolloutStrategyType
                     type: string
                   rolloutWebhooks:
-                    description: RolloutWebhooks provide a way for the rollout to
-                      interact with an external process
+                    description: RolloutWebhooks provide a way for the rollout to interact with an external process
                     items:
-                      description: RolloutWebhook holds the reference to external
-                        checks used for canary analysis
+                      description: RolloutWebhook holds the reference to external checks used for canary analysis
                       properties:
                         expectedStatus:
-                          description: ExpectedStatus contains all the expected http
-                            status code that we will accept as success
+                          description: ExpectedStatus contains all the expected http status code that we will accept as success
                           items:
                             type: integer
                           type: array
@@ -821,8 +709,7 @@ spec:
                       type: object
                     type: array
                   targetSize:
-                    description: The size of the target resource. The default is the
-                      same as the size of the source resource.
+                    description: The size of the target resource. The default is the same as the size of the source resource.
                     format: int32
                     type: integer
                 type: object
@@ -833,16 +720,12 @@ spec:
             description: AppStatus defines the observed state of Application
             properties:
               batchRollingState:
-                description: BatchRollingState only meaningful when the Status is
-                  rolling
+                description: BatchRollingState only meaningful when the Status is rolling
                 type: string
               components:
-                description: Components record the related Components created by Application
-                  Controller
+                description: Components record the related Components created by Application Controller
                 items:
-                  description: A TypedReference refers to an object by Name, Kind,
-                    and APIVersion. It is commonly used to reference cluster-scoped
-                    objects or objects where the namespace is already known.
+                  description: A TypedReference refers to an object by Name, Kind, and APIVersion. It is commonly used to reference cluster-scoped objects or objects where the namespace is already known.
                   properties:
                     apiVersion:
                       description: APIVersion of the referenced object.
@@ -868,25 +751,20 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition
-                        transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's
-                        last transition from one status to another, if any.
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from
-                        one status to another.
+                      description: A Reason for this condition's last transition from one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True,
-                        False, or Unknown?
+                      description: Status of this condition; is it currently True, False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition
-                        type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -896,15 +774,11 @@ spec:
                   type: object
                 type: array
               currentBatch:
-                description: The current batch the rollout is working on/blocked it
-                  starts from 0
+                description: The current batch the rollout is working on/blocked it starts from 0
                 format: int32
                 type: integer
               lastAppliedPodTemplateIdentifier:
-                description: lastAppliedPodTemplateIdentifier is a string that uniquely
-                  represent the last pod template each workload type could use different
-                  ways to identify that so we cannot compare between resources We
-                  update this field only after a successful rollout
+                description: lastAppliedPodTemplateIdentifier is a string that uniquely represent the last pod template each workload type could use different ways to identify that so we cannot compare between resources We update this field only after a successful rollout
                 type: string
               latestRevision:
                 description: LatestRevision of the application configuration it generates
@@ -915,8 +789,7 @@ spec:
                     format: int64
                     type: integer
                   revisionHash:
-                    description: RevisionHash record the hash value of the spec of
-                      ApplicationRevision object.
+                    description: RevisionHash record the hash value of the spec of ApplicationRevision object.
                     type: string
                 required:
                 - name
@@ -926,16 +799,13 @@ spec:
                 description: RollingState is the Rollout State
                 type: string
               rolloutTargetSize:
-                description: RolloutTargetTotalSize is the size of the target resources.
-                  This is determined once the initial spec verification and does not
-                  change until the rollout is restarted
+                description: RolloutTargetTotalSize is the size of the target resources. This is determined once the initial spec verification and does not change until the rollout is restarted
                 format: int32
                 type: integer
               services:
                 description: Services record the status of the application services
                 items:
-                  description: ApplicationComponentStatus record the health status
-                    of App component
+                  description: ApplicationComponentStatus record the health status of App component
                   properties:
                     healthy:
                       type: boolean
@@ -945,8 +815,7 @@ spec:
                       type: string
                     traits:
                       items:
-                        description: ApplicationTraitStatus records the trait health
-                          status
+                        description: ApplicationTraitStatus records the trait health status
                         properties:
                           healthy:
                             type: boolean
@@ -965,22 +834,17 @@ spec:
                   type: object
                 type: array
               status:
-                description: ApplicationPhase is a label for the condition of a application
-                  at the current time
+                description: ApplicationPhase is a label for the condition of a application at the current time
                 type: string
               targetGeneration:
-                description: NewPodTemplateIdentifier is a string that uniquely represent
-                  the new pod template each workload type could use different ways
-                  to identify that so we cannot compare between resources
+                description: NewPodTemplateIdentifier is a string that uniquely represent the new pod template each workload type could use different ways to identify that so we cannot compare between resources
                 type: string
               upgradedReadyReplicas:
-                description: UpgradedReadyReplicas is the number of Pods upgraded
-                  by the rollout controller that have a Ready Condition.
+                description: UpgradedReadyReplicas is the number of Pods upgraded by the rollout controller that have a Ready Condition.
                 format: int32
                 type: integer
               upgradedReplicas:
-                description: UpgradedReplicas is the number of Pods upgraded by the
-                  rollout controller
+                description: UpgradedReplicas is the number of Pods upgraded by the rollout controller
                 format: int32
                 type: integer
             required:


### PR DESCRIPTION
In CI image "ubuntu-20.04", kustomize v4.0.5 is pre-installed. So current makefile skips installing v3.8.2
> {Version:kustomize/v4.0.5 GitCommit:9e8e7a7fe99ec9fbf801463e8607928322fc5245 BuildDate:2021-03-08T20:53:03Z GoOs:linux GoArch:amd64}

And diff from v3.8.2, customize v4 has the problem that break too long sentences. 
That will fail any PR containing changes on crds/application.yml while author's local kustomize is truly v3.8.2.

to fix #1311 

Signed-off-by: roywang <seiwy2010@gmail.com>