### PR TITLE
Add cloud service doc in official site

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -64,6 +64,11 @@ module.exports = {
               ]
             },
             {
+              'Defining Cloud Service': [
+                'platform-engineers/cloud-services',
+              ]
+            },
+            {
               'Hands-on Lab': [
                   'platform-engineers/debug-test-cue',
                   'platform-engineers/keda'


### PR DESCRIPTION
The old location of cloud resource is behind `Define Trait`.

```
 <!-- - [Defining Workload Type](/en/platform-engineers/workload-type.md) -->
    <!-- - [Defining Trait](/en/platform-engineers/trait.md) -->
    <!-- - [Defining Cloud Service](/en/platform-engineers/cloud-services.md) -->
```