### PR TITLE
fix generate schema for helm values

### DIFF
--- a/pkg/appfile/helm/schema.go
+++ b/pkg/appfile/helm/schema.go
@@ -208,9 +208,13 @@ func handleItemsOfArrayType(t map[string]interface{}) {
 	}
 	if t["type"] == "array" {
 		if i, ok := t["items"].([]interface{}); ok {
-			itemSpec, _ := i[0].(map[string]interface{})
-			itemSpec["enum"] = nil
-			t["items"] = itemSpec
+			if len(i) > 0 {
+				if itemSpec, ok := i[0].(map[string]interface{}); ok {
+					handleItemsOfArrayType(itemSpec)
+					itemSpec["enum"] = nil
+					t["items"] = itemSpec
+				}
+			}
 		}
 	}
 }

--- a/pkg/appfile/helm/schema_test.go
+++ b/pkg/appfile/helm/schema_test.go
@@ -54,7 +54,7 @@ func TestGenerateSchemaFromValues(t *testing.T) {
 
 func TestGetChartValuesJSONSchema(t *testing.T) {
 	testHelm := testData("podinfo", "5.1.4", "http://oam.dev/catalog")
-	wantSchema, err := ioutil.ReadFile("./testdata/values.schema.json")
+	wantSchema, err := ioutil.ReadFile("./testdata/podinfo.values.schema.json")
 	if err != nil {
 		t.Error(err, "cannot load expected data")
 	}
@@ -240,6 +240,37 @@ func TestMakeSwaggerCompatible(t *testing.T) {
   ]
 }}`,
 			want: `{"objectArray":{"items":{"enum":null,"properties":{"f0":{"enum":["v0"],"type":"string"},"f1":{"enum":["v1"],"type":"string"},"f2":{"enum":["v2"],"type":"string"}},"required":["f0","f1","f2"],"type":"object"},"type":"array"}}`,
+		},
+		{
+			caseName: "object type array embeds object type array",
+			testdata: `{
+  "objectArray": {
+    "type": "array",
+    "items": [
+      {
+        "type": "array",
+        "items": [
+          {
+            "type": "object",
+            "required": [
+              "f0"
+            ],
+            "properties": {
+              "f0": {
+                "type": "string",
+                "enum": [
+                  "v0"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+`,
+			want: `{"objectArray":{"items":{"enum":null,"items":{"enum":null,"properties":{"f0":{"enum":["v0"],"type":"string"}},"required":["f0"],"type":"object"},"type":"array"},"type":"array"}}`,
 		},
 	}
 

--- a/pkg/appfile/helm/testdata/podinfo.values.schema.json
+++ b/pkg/appfile/helm/testdata/podinfo.values.schema.json
@@ -140,32 +140,17 @@
           "type": "boolean"
         },
         "hosts": {
-          "description": "kubernetes.io/ingress.class: nginx\nkubernetes.io/tls-acme: \"true\"",
-          "items": {
-            "properties": {
-              "host": {
-                "default": "chart-example.local",
-                "type": "string"
-              },
-              "paths": {
-                "items": {
-                  "properties": {
-                    "path": {
-                      "default": "/",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
-          },
+          "default": [],
           "type": "array"
+        },
+        "path": {
+          "default": "/*",
+          "description": "kubernetes.io/ingress.class: nginx\nkubernetes.io/tls-acme: \"true\"",
+          "type": "string"
         },
         "tls": {
           "default": [],
+          "description": "- podinfo.local",
           "type": "array"
         }
       },

--- a/pkg/appfile/helm/testdata/values.yaml
+++ b/pkg/appfile/helm/testdata/values.yaml
@@ -104,9 +104,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path: /*
-  hosts: []
-#    - podinfo.local
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
to fix #1369 
### Bug reason:
The values file contains such a snippet that, an array type property embedss an array type property in its items list.

```yaml
...
  hosts:
    - host: chart-example.local
      paths:
        - path: /
...
```

Signed-off-by: roy wang <seiwy2010@gmail.com>