### PR TITLE
fix crd: add additional print column and short Name for CRD

### DIFF
--- a/apis/core.oam.dev/v1alpha2/application_types.go
+++ b/apis/core.oam.dev/v1alpha2/application_types.go
@@ -90,6 +90,13 @@ type ApplicationSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories={oam}
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="COMPONENT",type=string,JSONPath=`.spec.components[*].name`
+// +kubebuilder:printcolumn:name="TYPE",type=string,JSONPath=`.spec.components[*].type`
+// +kubebuilder:printcolumn:name="TRAIT",type=string,JSONPath=`.spec.components[*].traits[*].name`
+// +kubebuilder:printcolumn:name="PHASE",type=string,JSONPath=`.status.status`
+// +kubebuilder:printcolumn:name="HEALTHY",type=boolean,JSONPath=`.status.services[*].healthy`
+// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].message`
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1alpha2/application_types.go
+++ b/apis/core.oam.dev/v1alpha2/application_types.go
@@ -92,10 +92,9 @@ type ApplicationSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="COMPONENT",type=string,JSONPath=`.spec.components[*].name`
 // +kubebuilder:printcolumn:name="TYPE",type=string,JSONPath=`.spec.components[*].type`
-// +kubebuilder:printcolumn:name="TRAIT",type=string,JSONPath=`.spec.components[*].traits[*].name`
 // +kubebuilder:printcolumn:name="PHASE",type=string,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="HEALTHY",type=boolean,JSONPath=`.status.services[*].healthy`
-// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].traits[*].message`
+// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].message`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core.oam.dev/v1alpha2/application_types.go
+++ b/apis/core.oam.dev/v1alpha2/application_types.go
@@ -88,14 +88,14 @@ type ApplicationSpec struct {
 
 // Application is the Schema for the applications API
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories={oam}
+// +kubebuilder:resource:categories={oam},shortName=apps
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="COMPONENT",type=string,JSONPath=`.spec.components[*].name`
 // +kubebuilder:printcolumn:name="TYPE",type=string,JSONPath=`.spec.components[*].type`
 // +kubebuilder:printcolumn:name="TRAIT",type=string,JSONPath=`.spec.components[*].traits[*].name`
 // +kubebuilder:printcolumn:name="PHASE",type=string,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="HEALTHY",type=boolean,JSONPath=`.status.services[*].healthy`
-// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].message`
+// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].traits[*].message`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core.oam.dev/v1alpha2/applicationrevision_types.go
+++ b/apis/core.oam.dev/v1alpha2/applicationrevision_types.go
@@ -55,7 +55,8 @@ type ApplicationRevisionSpec struct {
 
 // ApplicationRevision is the Schema for the ApplicationRevision API
 // +kubebuilder:object:root=true
-// +kubebuilder:shortName=apprev,resource:categories={oam}
+// +kubebuilder:resource:categories={oam},shortName=apprev;revisions
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type ApplicationRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1alpha2/approllout_types.go
+++ b/apis/core.oam.dev/v1alpha2/approllout_types.go
@@ -66,8 +66,8 @@ type AppRolloutStatus struct {
 // +kubebuilder:printcolumn:name="TARGET",type=string,JSONPath=`.status.rolloutStatus.rolloutTargetSize`
 // +kubebuilder:printcolumn:name="UPGRADED",type=string,JSONPath=`.status.rolloutStatus.upgradedReplicas`
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.rolloutStatus.upgradedReadyReplicas`
-// +kubebuilder:printcolumn:name="BATCH_ROLLING_STATE",type=string,JSONPath=`.status.rolloutStatus.batchRollingState`
-// +kubebuilder:printcolumn:name="ROLLING_STATE",type=string,JSONPath=`.status.rolloutStatus.rollingState`
+// +kubebuilder:printcolumn:name="BATCH-STATE",type=string,JSONPath=`.status.rolloutStatus.batchRollingState`
+// +kubebuilder:printcolumn:name="ROLLING-STATE",type=string,JSONPath=`.status.rolloutStatus.rollingState`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type AppRollout struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core.oam.dev/v1alpha2/approllout_types.go
+++ b/apis/core.oam.dev/v1alpha2/approllout_types.go
@@ -61,7 +61,7 @@ type AppRolloutStatus struct {
 
 // AppRollout is the Schema for the AppRollout API
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories={oam}
+// +kubebuilder:resource:categories={oam},shortName=approllout;rollout
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="TARGET",type=string,JSONPath=`.status.rolloutStatus.rolloutTargetSize`
 // +kubebuilder:printcolumn:name="UPGRADED",type=string,JSONPath=`.status.rolloutStatus.upgradedReplicas`

--- a/apis/core.oam.dev/v1alpha2/approllout_types.go
+++ b/apis/core.oam.dev/v1alpha2/approllout_types.go
@@ -63,6 +63,12 @@ type AppRolloutStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories={oam}
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="TARGET",type=string,JSONPath=`.status.rolloutStatus.rolloutTargetSize`
+// +kubebuilder:printcolumn:name="UPGRADED",type=string,JSONPath=`.status.rolloutStatus.upgradedReplicas`
+// +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.rolloutStatus.upgradedReadyReplicas`
+// +kubebuilder:printcolumn:name="BATCH_ROLLING_STATE",type=string,JSONPath=`.status.rolloutStatus.batchRollingState`
+// +kubebuilder:printcolumn:name="ROLLING_STATE",type=string,JSONPath=`.status.rolloutStatus.rollingState`
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type AppRollout struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1alpha2/componentdefinition_types.go
+++ b/apis/core.oam.dev/v1alpha2/componentdefinition_types.go
@@ -69,7 +69,7 @@ type ComponentDefinitionStatus struct {
 // ComponentDefinition is the Schema for the componentdefinitions API
 // +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=comp
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="WORKLOAD_KIND",type=string,JSONPath=".spec.workload.definition.kind"
+// +kubebuilder:printcolumn:name="WORKLOAD-KIND",type=string,JSONPath=".spec.workload.definition.kind"
 // +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type ComponentDefinition struct {

--- a/apis/core.oam.dev/v1alpha2/componentdefinition_types.go
+++ b/apis/core.oam.dev/v1alpha2/componentdefinition_types.go
@@ -67,8 +67,11 @@ type ComponentDefinitionStatus struct {
 // +kubebuilder:object:root=true
 
 // ComponentDefinition is the Schema for the componentdefinitions API
-// +kubebuilder:resource:scope=Namespaced,categories={oam}
+// +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=comp
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="WORKLOAD_KIND",type=string,JSONPath=".spec.workload.definition.kind"
+// +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type ComponentDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1alpha2/core_types.go
+++ b/apis/core.oam.dev/v1alpha2/core_types.go
@@ -69,8 +69,9 @@ type WorkloadDefinitionStatus struct {
 // valid OAM workload kind by referencing its CustomResourceDefinition. The CRD
 // is used to validate the schema of the workload when it is embedded in an OAM
 // Component.
-// +kubebuilder:printcolumn:JSONPath=".spec.definitionRef.name",name=DEFINITION-NAME,type=string
-// +kubebuilder:resource:scope=Namespaced,categories={oam}
+// +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=workload
+// +kubebuilder:printcolumn:name="DEFINITION-NAME",type=string,JSONPath=".spec.definitionRef.name"
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type WorkloadDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -158,9 +159,11 @@ type TraitDefinitionStatus struct {
 // OAM trait kind by referencing its CustomResourceDefinition. The CRD is used
 // to validate the schema of the trait when it is embedded in an OAM
 // ApplicationConfiguration.
-// +kubebuilder:printcolumn:JSONPath=".spec.definitionRef.name",name=DEFINITION-NAME,type=string
-// +kubebuilder:resource:scope=Namespaced,categories={oam}
+// +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=trait
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="APPLIES-TO",type=string,JSONPath=".spec.appliesToWorkloads"
+// +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type TraitDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1beta1/appdeployment_types.go
+++ b/apis/core.oam.dev/v1beta1/appdeployment_types.go
@@ -178,7 +178,7 @@ type AppDeploymentStatus struct {
 
 // AppDeployment is the Schema for the AppDeployment API
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories={oam}
+// +kubebuilder:resource:categories={oam},shortName=appdeploy
 // +kubebuilder:subresource:status
 type AppDeployment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core.oam.dev/v1beta1/application_types.go
+++ b/apis/core.oam.dev/v1beta1/application_types.go
@@ -67,12 +67,13 @@ type ApplicationSpec struct {
 // Application is the Schema for the applications API
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories={oam},shortName=apps
 // +kubebuilder:printcolumn:name="COMPONENT",type=string,JSONPath=`.spec.components[*].name`
 // +kubebuilder:printcolumn:name="TYPE",type=string,JSONPath=`.spec.components[*].type`
 // +kubebuilder:printcolumn:name="TRAIT",type=string,JSONPath=`.spec.components[*].traits[*].type`
 // +kubebuilder:printcolumn:name="PHASE",type=string,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="HEALTHY",type=boolean,JSONPath=`.status.services[*].healthy`
-// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].message`
+// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].traits[*].message`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core.oam.dev/v1beta1/application_types.go
+++ b/apis/core.oam.dev/v1beta1/application_types.go
@@ -70,10 +70,9 @@ type ApplicationSpec struct {
 // +kubebuilder:resource:categories={oam},shortName=apps
 // +kubebuilder:printcolumn:name="COMPONENT",type=string,JSONPath=`.spec.components[*].name`
 // +kubebuilder:printcolumn:name="TYPE",type=string,JSONPath=`.spec.components[*].type`
-// +kubebuilder:printcolumn:name="TRAIT",type=string,JSONPath=`.spec.components[*].traits[*].type`
 // +kubebuilder:printcolumn:name="PHASE",type=string,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="HEALTHY",type=boolean,JSONPath=`.status.services[*].healthy`
-// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].traits[*].message`
+// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].message`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core.oam.dev/v1beta1/application_types.go
+++ b/apis/core.oam.dev/v1beta1/application_types.go
@@ -67,6 +67,13 @@ type ApplicationSpec struct {
 // Application is the Schema for the applications API
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="COMPONENT",type=string,JSONPath=`.spec.components[*].name`
+// +kubebuilder:printcolumn:name="TYPE",type=string,JSONPath=`.spec.components[*].type`
+// +kubebuilder:printcolumn:name="TRAIT",type=string,JSONPath=`.spec.components[*].traits[*].type`
+// +kubebuilder:printcolumn:name="PHASE",type=string,JSONPath=`.status.status`
+// +kubebuilder:printcolumn:name="HEALTHY",type=boolean,JSONPath=`.status.services[*].healthy`
+// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.services[*].message`
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1beta1/applicationrevision_types.go
+++ b/apis/core.oam.dev/v1beta1/applicationrevision_types.go
@@ -56,6 +56,8 @@ type ApplicationRevisionSpec struct {
 
 // ApplicationRevision is the Schema for the ApplicationRevision API
 // +kubebuilder:storageversion
+// +kubebuilder:resource:categories={oam},shortName=apprev;revisions
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type ApplicationRevision struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1beta1/approllout_types.go
+++ b/apis/core.oam.dev/v1beta1/approllout_types.go
@@ -63,14 +63,14 @@ type AppRolloutStatus struct {
 
 // AppRollout is the Schema for the AppRollout API
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories={oam}
+// +kubebuilder:resource:categories={oam},shortName=approllout;rollout
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="TARGET",type=string,JSONPath=`.status.rolloutStatus.rolloutTargetSize`
-// +kubebuilder:printcolumn:name="UPGRADED",type=string,JSONPath=`.status.rolloutStatus.upgradedReplicas`
-// +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.rolloutStatus.upgradedReadyReplicas`
-// +kubebuilder:printcolumn:name="BATCH_ROLLING_STATE",type=string,JSONPath=`.status.rolloutStatus.batchRollingState`
-// +kubebuilder:printcolumn:name="ROLLING_STATE",type=string,JSONPath=`.status.rolloutStatus.rollingState`
+// +kubebuilder:printcolumn:name="TARGET",type=string,JSONPath=`.status.rolloutTargetSize`
+// +kubebuilder:printcolumn:name="UPGRADED",type=string,JSONPath=`.status.upgradedReplicas`
+// +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.upgradedReadyReplicas`
+// +kubebuilder:printcolumn:name="BATCH_ROLLING_STATE",type=string,JSONPath=`.status.batchRollingState`
+// +kubebuilder:printcolumn:name="ROLLING_STATE",type=string,JSONPath=`.status.rollingState`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type AppRollout struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core.oam.dev/v1beta1/approllout_types.go
+++ b/apis/core.oam.dev/v1beta1/approllout_types.go
@@ -66,6 +66,12 @@ type AppRolloutStatus struct {
 // +kubebuilder:resource:categories={oam}
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="TARGET",type=string,JSONPath=`.status.rolloutStatus.rolloutTargetSize`
+// +kubebuilder:printcolumn:name="UPGRADED",type=string,JSONPath=`.status.rolloutStatus.upgradedReplicas`
+// +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.rolloutStatus.upgradedReadyReplicas`
+// +kubebuilder:printcolumn:name="BATCH_ROLLING_STATE",type=string,JSONPath=`.status.rolloutStatus.batchRollingState`
+// +kubebuilder:printcolumn:name="ROLLING_STATE",type=string,JSONPath=`.status.rolloutStatus.rollingState`
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type AppRollout struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1beta1/approllout_types.go
+++ b/apis/core.oam.dev/v1beta1/approllout_types.go
@@ -69,8 +69,8 @@ type AppRolloutStatus struct {
 // +kubebuilder:printcolumn:name="TARGET",type=string,JSONPath=`.status.rolloutTargetSize`
 // +kubebuilder:printcolumn:name="UPGRADED",type=string,JSONPath=`.status.upgradedReplicas`
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.upgradedReadyReplicas`
-// +kubebuilder:printcolumn:name="BATCH_ROLLING_STATE",type=string,JSONPath=`.status.batchRollingState`
-// +kubebuilder:printcolumn:name="ROLLING_STATE",type=string,JSONPath=`.status.rollingState`
+// +kubebuilder:printcolumn:name="BATCH-STATE",type=string,JSONPath=`.status.batchRollingState`
+// +kubebuilder:printcolumn:name="ROLLING-STATE",type=string,JSONPath=`.status.rollingState`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type AppRollout struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/core.oam.dev/v1beta1/componentdefinition_types.go
+++ b/apis/core.oam.dev/v1beta1/componentdefinition_types.go
@@ -67,9 +67,12 @@ type ComponentDefinitionStatus struct {
 // +kubebuilder:object:root=true
 
 // ComponentDefinition is the Schema for the componentdefinitions API
-// +kubebuilder:resource:scope=Namespaced,categories={oam}
+// +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=comp
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="WORKLOAD_KIND",type=string,JSONPath=".spec.workload.definition.kind"
+// +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type ComponentDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1beta1/componentdefinition_types.go
+++ b/apis/core.oam.dev/v1beta1/componentdefinition_types.go
@@ -70,7 +70,7 @@ type ComponentDefinitionStatus struct {
 // +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=comp
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="WORKLOAD_KIND",type=string,JSONPath=".spec.workload.definition.kind"
+// +kubebuilder:printcolumn:name="WORKLOAD-KIND",type=string,JSONPath=".spec.workload.definition.kind"
 // +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type ComponentDefinition struct {

--- a/apis/core.oam.dev/v1beta1/core_types.go
+++ b/apis/core.oam.dev/v1beta1/core_types.go
@@ -67,9 +67,11 @@ type WorkloadDefinitionStatus struct {
 // valid OAM workload kind by referencing its CustomResourceDefinition. The CRD
 // is used to validate the schema of the workload when it is embedded in an OAM
 // Component.
-// +kubebuilder:printcolumn:JSONPath=".spec.definitionRef.name",name=DEFINITION-NAME,type=string
-// +kubebuilder:resource:scope=Namespaced,categories={oam}
+// +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=workload
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="DEFINITION-NAME",type=string,JSONPath=".spec.definitionRef.name"
+// +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type WorkloadDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -157,10 +159,12 @@ type TraitDefinitionStatus struct {
 // OAM trait kind by referencing its CustomResourceDefinition. The CRD is used
 // to validate the schema of the trait when it is embedded in an OAM
 // ApplicationConfiguration.
-// +kubebuilder:printcolumn:JSONPath=".spec.definitionRef.name",name=DEFINITION-NAME,type=string
-// +kubebuilder:resource:scope=Namespaced,categories={oam}
+// +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=trait
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="APPLIES-TO",type=string,JSONPath=".spec.appliesToWorkloads"
+// +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type TraitDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/vela-core/crds/core.oam.dev_appdeployments.yaml
+++ b/charts/vela-core/crds/core.oam.dev_appdeployments.yaml
@@ -14,6 +14,8 @@ spec:
     kind: AppDeployment
     listKind: AppDeploymentList
     plural: appdeployments
+    shortNames:
+    - appdeploy
     singular: appdeployment
   scope: Namespaced
   versions:

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -9,13 +9,22 @@ metadata:
 spec:
   group: core.oam.dev
   names:
+    categories:
+    - oam
     kind: ApplicationRevision
     listKind: ApplicationRevisionList
     plural: applicationrevisions
+    shortNames:
+    - apprev
+    - revisions
     singular: applicationrevision
   scope: Namespaced
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: ApplicationRevision is the Schema for the ApplicationRevision API
@@ -1058,7 +1067,12 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1beta1
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ApplicationRevision is the Schema for the ApplicationRevision API
@@ -2102,6 +2116,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -28,7 +28,29 @@ spec:
     singular: application
   scope: Namespaced
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.components[*].name
+      name: COMPONENT
+      type: string
+    - jsonPath: .spec.components[*].type
+      name: TYPE
+      type: string
+    - jsonPath: .spec.components[*].traits[*].name
+      name: TRAIT
+      type: string
+    - jsonPath: .status.status
+      name: PHASE
+      type: string
+    - jsonPath: .status.services[*].healthy
+      name: HEALTHY
+      type: boolean
+    - jsonPath: .status.services[*].message
+      name: STATUS
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: Application is the Schema for the applications API
@@ -463,7 +485,29 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.components[*].name
+      name: COMPONENT
+      type: string
+    - jsonPath: .spec.components[*].type
+      name: TYPE
+      type: string
+    - jsonPath: .spec.components[*].traits[*].type
+      name: TRAIT
+      type: string
+    - jsonPath: .status.status
+      name: PHASE
+      type: string
+    - jsonPath: .status.services[*].healthy
+      name: HEALTHY
+      type: boolean
+    - jsonPath: .status.services[*].message
+      name: STATUS
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Application is the Schema for the applications API

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -25,6 +25,8 @@ spec:
     kind: Application
     listKind: ApplicationList
     plural: applications
+    shortNames:
+    - apps
     singular: application
   scope: Namespaced
   versions:
@@ -44,7 +46,7 @@ spec:
     - jsonPath: .status.services[*].healthy
       name: HEALTHY
       type: boolean
-    - jsonPath: .status.services[*].message
+    - jsonPath: .status.services[*].traits[*].message
       name: STATUS
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -501,7 +503,7 @@ spec:
     - jsonPath: .status.services[*].healthy
       name: HEALTHY
       type: boolean
-    - jsonPath: .status.services[*].message
+    - jsonPath: .status.services[*].traits[*].message
       name: STATUS
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -37,16 +37,13 @@ spec:
     - jsonPath: .spec.components[*].type
       name: TYPE
       type: string
-    - jsonPath: .spec.components[*].traits[*].name
-      name: TRAIT
-      type: string
     - jsonPath: .status.status
       name: PHASE
       type: string
     - jsonPath: .status.services[*].healthy
       name: HEALTHY
       type: boolean
-    - jsonPath: .status.services[*].traits[*].message
+    - jsonPath: .status.services[*].message
       name: STATUS
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -494,16 +491,13 @@ spec:
     - jsonPath: .spec.components[*].type
       name: TYPE
       type: string
-    - jsonPath: .spec.components[*].traits[*].type
-      name: TRAIT
-      type: string
     - jsonPath: .status.status
       name: PHASE
       type: string
     - jsonPath: .status.services[*].healthy
       name: HEALTHY
       type: boolean
-    - jsonPath: .status.services[*].traits[*].message
+    - jsonPath: .status.services[*].message
       name: STATUS
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/charts/vela-core/crds/core.oam.dev_approllouts.yaml
+++ b/charts/vela-core/crds/core.oam.dev_approllouts.yaml
@@ -17,7 +17,26 @@ spec:
     singular: approllout
   scope: Namespaced
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .status.rolloutStatus.rolloutTargetSize
+      name: TARGET
+      type: string
+    - jsonPath: .status.rolloutStatus.upgradedReplicas
+      name: UPGRADED
+      type: string
+    - jsonPath: .status.rolloutStatus.upgradedReadyReplicas
+      name: READY
+      type: string
+    - jsonPath: .status.rolloutStatus.batchRollingState
+      name: BATCH_ROLLING_STATE
+      type: string
+    - jsonPath: .status.rolloutStatus.rollingState
+      name: ROLLING_STATE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: AppRollout is the Schema for the AppRollout API
@@ -346,7 +365,26 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.rolloutStatus.rolloutTargetSize
+      name: TARGET
+      type: string
+    - jsonPath: .status.rolloutStatus.upgradedReplicas
+      name: UPGRADED
+      type: string
+    - jsonPath: .status.rolloutStatus.upgradedReadyReplicas
+      name: READY
+      type: string
+    - jsonPath: .status.rolloutStatus.batchRollingState
+      name: BATCH_ROLLING_STATE
+      type: string
+    - jsonPath: .status.rolloutStatus.rollingState
+      name: ROLLING_STATE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: AppRollout is the Schema for the AppRollout API

--- a/charts/vela-core/crds/core.oam.dev_approllouts.yaml
+++ b/charts/vela-core/crds/core.oam.dev_approllouts.yaml
@@ -31,10 +31,10 @@ spec:
       name: READY
       type: string
     - jsonPath: .status.rolloutStatus.batchRollingState
-      name: BATCH_ROLLING_STATE
+      name: BATCH-STATE
       type: string
     - jsonPath: .status.rolloutStatus.rollingState
-      name: ROLLING_STATE
+      name: ROLLING-STATE
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
@@ -379,10 +379,10 @@ spec:
       name: READY
       type: string
     - jsonPath: .status.batchRollingState
-      name: BATCH_ROLLING_STATE
+      name: BATCH-STATE
       type: string
     - jsonPath: .status.rollingState
-      name: ROLLING_STATE
+      name: ROLLING-STATE
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE

--- a/charts/vela-core/crds/core.oam.dev_approllouts.yaml
+++ b/charts/vela-core/crds/core.oam.dev_approllouts.yaml
@@ -14,6 +14,9 @@ spec:
     kind: AppRollout
     listKind: AppRolloutList
     plural: approllouts
+    shortNames:
+    - approllout
+    - rollout
     singular: approllout
   scope: Namespaced
   versions:
@@ -366,19 +369,19 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - jsonPath: .status.rolloutStatus.rolloutTargetSize
+    - jsonPath: .status.rolloutTargetSize
       name: TARGET
       type: string
-    - jsonPath: .status.rolloutStatus.upgradedReplicas
+    - jsonPath: .status.upgradedReplicas
       name: UPGRADED
       type: string
-    - jsonPath: .status.rolloutStatus.upgradedReadyReplicas
+    - jsonPath: .status.upgradedReadyReplicas
       name: READY
       type: string
-    - jsonPath: .status.rolloutStatus.batchRollingState
+    - jsonPath: .status.batchRollingState
       name: BATCH_ROLLING_STATE
       type: string
-    - jsonPath: .status.rolloutStatus.rollingState
+    - jsonPath: .status.rollingState
       name: ROLLING_STATE
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/charts/vela-core/crds/core.oam.dev_componentdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_componentdefinitions.yaml
@@ -21,7 +21,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.workload.definition.kind
-      name: WORKLOAD_KIND
+      name: WORKLOAD-KIND
       type: string
     - jsonPath: .metadata.annotations.definition\.oam\.dev/description
       name: DESCRIPTION
@@ -220,7 +220,7 @@ spec:
       status: {}
   - additionalPrinterColumns:
     - jsonPath: .spec.workload.definition.kind
-      name: WORKLOAD_KIND
+      name: WORKLOAD-KIND
       type: string
     - jsonPath: .metadata.annotations.definition\.oam\.dev/description
       name: DESCRIPTION

--- a/charts/vela-core/crds/core.oam.dev_componentdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_componentdefinitions.yaml
@@ -14,10 +14,22 @@ spec:
     kind: ComponentDefinition
     listKind: ComponentDefinitionList
     plural: componentdefinitions
+    shortNames:
+    - comp
     singular: componentdefinition
   scope: Namespaced
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.workload.definition.kind
+      name: WORKLOAD_KIND
+      type: string
+    - jsonPath: .metadata.annotations.definition\.oam\.dev/description
+      name: DESCRIPTION
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: ComponentDefinition is the Schema for the componentdefinitions API
@@ -206,7 +218,17 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.workload.definition.kind
+      name: WORKLOAD_KIND
+      type: string
+    - jsonPath: .metadata.annotations.definition\.oam\.dev/description
+      name: DESCRIPTION
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ComponentDefinition is the Schema for the componentdefinitions API

--- a/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
@@ -14,13 +14,21 @@ spec:
     kind: TraitDefinition
     listKind: TraitDefinitionList
     plural: traitdefinitions
+    shortNames:
+    - trait
     singular: traitdefinition
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.definitionRef.name
-      name: DEFINITION-NAME
+    - jsonPath: .spec.appliesToWorkloads
+      name: APPLIES-TO
       type: string
+    - jsonPath: .metadata.annotations.definition\.oam\.dev/description
+      name: DESCRIPTION
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -192,9 +200,15 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - jsonPath: .spec.definitionRef.name
-      name: DEFINITION-NAME
+    - jsonPath: .spec.appliesToWorkloads
+      name: APPLIES-TO
       type: string
+    - jsonPath: .metadata.annotations.definition\.oam\.dev/description
+      name: DESCRIPTION
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/charts/vela-core/crds/core.oam.dev_workloaddefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_workloaddefinitions.yaml
@@ -14,6 +14,8 @@ spec:
     kind: WorkloadDefinition
     listKind: WorkloadDefinitionList
     plural: workloaddefinitions
+    shortNames:
+    - workload
     singular: workloaddefinition
   scope: Namespaced
   versions:
@@ -21,6 +23,9 @@ spec:
     - jsonPath: .spec.definitionRef.name
       name: DEFINITION-NAME
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -204,6 +209,12 @@ spec:
     - jsonPath: .spec.definitionRef.name
       name: DEFINITION-NAME
       type: string
+    - jsonPath: .metadata.annotations.definition\.oam\.dev/description
+      name: DESCRIPTION
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_appdeployments.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_appdeployments.yaml
@@ -14,6 +14,8 @@ spec:
     kind: AppDeployment
     listKind: AppDeploymentList
     plural: appdeployments
+    shortNames:
+    - appdeploy
     singular: appdeployment
   scope: Namespaced
   subresources:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -9,9 +9,14 @@ metadata:
 spec:
   group: core.oam.dev
   names:
+    categories:
+    - oam
     kind: ApplicationRevision
     listKind: ApplicationRevisionList
     plural: applicationrevisions
+    shortNames:
+    - apprev
+    - revisions
     singular: applicationrevision
   scope: Namespaced
   validation:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -23,7 +23,7 @@ spec:
   - JSONPath: .status.services[*].healthy
     name: HEALTHY
     type: boolean
-  - JSONPath: .status.services[*].message
+  - JSONPath: .status.services[*].traits[*].message
     name: STATUS
     type: string
   - JSONPath: .metadata.creationTimestamp
@@ -36,6 +36,8 @@ spec:
     kind: Application
     listKind: ApplicationList
     plural: applications
+    shortNames:
+    - apps
     singular: application
   scope: Namespaced
   validation:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -7,6 +7,28 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
   name: applications.core.oam.dev
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.components[*].name
+    name: COMPONENT
+    type: string
+  - JSONPath: .spec.components[*].type
+    name: TYPE
+    type: string
+  - JSONPath: .spec.components[*].traits[*].type
+    name: TRAIT
+    type: string
+  - JSONPath: .status.status
+    name: PHASE
+    type: string
+  - JSONPath: .status.services[*].healthy
+    name: HEALTHY
+    type: boolean
+  - JSONPath: .status.services[*].message
+    name: STATUS
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: core.oam.dev
   names:
     categories:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -7,28 +7,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
   name: applications.core.oam.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.components[*].name
-    name: COMPONENT
-    type: string
-  - JSONPath: .spec.components[*].type
-    name: TYPE
-    type: string
-  - JSONPath: .spec.components[*].traits[*].type
-    name: TRAIT
-    type: string
-  - JSONPath: .status.status
-    name: PHASE
-    type: string
-  - JSONPath: .status.services[*].healthy
-    name: HEALTHY
-    type: boolean
-  - JSONPath: .status.services[*].traits[*].message
-    name: STATUS
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: core.oam.dev
   names:
     categories:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_approllouts.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_approllouts.yaml
@@ -18,10 +18,10 @@ spec:
     name: READY
     type: string
   - JSONPath: .status.batchRollingState
-    name: BATCH_ROLLING_STATE
+    name: BATCH-STATE
     type: string
   - JSONPath: .status.rollingState
-    name: ROLLING_STATE
+    name: ROLLING-STATE
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: AGE

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_approllouts.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_approllouts.yaml
@@ -7,6 +7,25 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
   name: approllouts.core.oam.dev
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.rolloutTargetSize
+    name: TARGET
+    type: string
+  - JSONPath: .status.upgradedReplicas
+    name: UPGRADED
+    type: string
+  - JSONPath: .status.upgradedReadyReplicas
+    name: READY
+    type: string
+  - JSONPath: .status.batchRollingState
+    name: BATCH_ROLLING_STATE
+    type: string
+  - JSONPath: .status.rollingState
+    name: ROLLING_STATE
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: core.oam.dev
   names:
     categories:
@@ -14,6 +33,9 @@ spec:
     kind: AppRollout
     listKind: AppRolloutList
     plural: approllouts
+    shortNames:
+    - approllout
+    - rollout
     singular: approllout
   scope: Namespaced
   validation:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_componentdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_componentdefinitions.yaml
@@ -7,6 +7,16 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
   name: componentdefinitions.core.oam.dev
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.workload.definition.kind
+    name: WORKLOAD_KIND
+    type: string
+  - JSONPath: .metadata.annotations.definition\.oam\.dev/description
+    name: DESCRIPTION
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: core.oam.dev
   names:
     categories:
@@ -14,6 +24,8 @@ spec:
     kind: ComponentDefinition
     listKind: ComponentDefinitionList
     plural: componentdefinitions
+    shortNames:
+    - comp
     singular: componentdefinition
   scope: Namespaced
   subresources:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_componentdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_componentdefinitions.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.workload.definition.kind
-    name: WORKLOAD_KIND
+    name: WORKLOAD-KIND
     type: string
   - JSONPath: .metadata.annotations.definition\.oam\.dev/description
     name: DESCRIPTION

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
@@ -8,9 +8,15 @@ metadata:
   name: traitdefinitions.core.oam.dev
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.definitionRef.name
-    name: DEFINITION-NAME
+  - JSONPath: .spec.appliesToWorkloads
+    name: APPLIES-TO
     type: string
+  - JSONPath: .metadata.annotations.definition\.oam\.dev/description
+    name: DESCRIPTION
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
   group: core.oam.dev
   names:
     categories:
@@ -18,6 +24,8 @@ spec:
     kind: TraitDefinition
     listKind: TraitDefinitionList
     plural: traitdefinitions
+    shortNames:
+    - trait
     singular: traitdefinition
   scope: Namespaced
   subresources:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_workloaddefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_workloaddefinitions.yaml
@@ -7,10 +7,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.2.4
   name: workloaddefinitions.core.oam.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.definitionRef.name
-    name: DEFINITION-NAME
-    type: string
   group: core.oam.dev
   names:
     categories:
@@ -18,6 +14,8 @@ spec:
     kind: WorkloadDefinition
     listKind: WorkloadDefinitionList
     plural: workloaddefinitions
+    shortNames:
+    - workload
     singular: workloaddefinition
   scope: Namespaced
   subresources: {}

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/apply_trait_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/apply_trait_test.go
@@ -273,7 +273,7 @@ spec:
 					return 0
 				}
 				return traitObj.GetGeneration()
-			}, 5*time.Second, time.Second).Should(Equal(int64(2)))
+			}, 20*time.Second, time.Second).Should(Equal(int64(2)))
 
 			By("Check labels are removed")
 			_, found, _ := unstructured.NestedString(traitObj.UnstructuredContent(), "metadata", "labels", "test.label")


### PR DESCRIPTION
fix https://github.com/oam-dev/kubevela/issues/1368

## Application
shortname: `apps`
```
kubectl get apps
NAME          COMPONENT   TYPE         PHASE     HEALTHY   STATUS          AGE
example-app   testsvc     webservice   running   true      status message  14h
```
## AppRevision
shortname: `revisions`,`apprev`

## AppRollout
shortname: `approllout`,`rollout`

```
kubectl get rollout
NAME              TARGET   UPGRADED   READY   BATCH-STATE   ROLLING-STATE    AGE
rolling-example   5        5          5       batchReady    rolloutSucceed   13h
```
## AppDeploy
shortname: `appdeploy`
## ComponentDefinition
shortname: `comp`
```
kubectl get comp
NAME         WORKLOAD-KIND   DESCRIPTION              AGE
webservice   Deployment      Describes a webservice   13h                                                                                                                                                                                                                                     
```
## TraitDefinition
shortname: `trait`
```
kubectl get trait
NAME      APPLIES-TO            DESCRIPTION               AGE
ingress   [webservice worker]   Configures K8s ingress.   12h
```
## WorkloadDefinition
shortname: `workload`
```
kubectl get workload 
NAME         DEFINITION-NAME    DESCRIPTION              AGE
webservice   deployments.apps   Describes a webservice   4s
```

- [x] add  additional print column 
- [x] add shortName for crd