### PR TITLE
Fix: update homebrew before install kubevela client

### DIFF
--- a/docs/en/install.mdx
+++ b/docs/en/install.mdx
@@ -196,6 +196,13 @@ powershell -Command "iwr -useb https://kubevela.io/script/install.ps1 | iex"
 <TabItem value="homebrew">
 
 **macOS/Linux**
+
+Update your brew firstly.
+```shell script
+brew update
+```
+Then install kubevela client.
+
 ```shell script
 brew install kubevela
 ```


### PR DESCRIPTION
Install the client via brew should update brew itself firstly.

Linked: oam-dev/kubevela#1391