### PR TITLE
Add package discover refresh when component/trait definition are registered

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/apply_trait_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/apply_trait_test.go
@@ -273,7 +273,7 @@ spec:
 					return 0
 				}
 				return traitObj.GetGeneration()
-			}, 20*time.Second, time.Second).Should(Equal(int64(2)))
+			}, 60*time.Second, time.Second).Should(Equal(int64(2)))
 
 			By("Check labels are removed")
 			_, found, _ := unstructured.NestedString(traitObj.UnstructuredContent(), "metadata", "labels", "test.label")

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
@@ -80,8 +80,8 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		err := utils.RefreshPackageDiscover(r.dm, r.pd, handler.cd.Spec.Workload.Definition,
 			common.DefinitionReference{}, types.TypeComponentDefinition)
 		if err != nil {
-			klog.ErrorS(err, "cannot refresh packageDiscover")
-			r.record.Event(&componentDefinition, event.Warning("cannot refresh packageDiscover", err))
+			klog.ErrorS(err, "cannot discover the open api of the CRD")
+			r.record.Event(&componentDefinition, event.Warning("cannot discover the open api of the CRD", err))
 			return ctrl.Result{}, util.PatchCondition(ctx, r, &componentDefinition,
 				cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrRefreshPackageDiscover, err)))
 		}
@@ -109,7 +109,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		def.Kube = componentDefinition.Spec.Schematic.KUBE
 	default:
 	}
-	err = def.StoreOpenAPISchema(ctx, r, req.Namespace, req.Name)
+	err = def.StoreOpenAPISchema(ctx, r.Client, r.pd, req.Namespace, req.Name)
 	if err != nil {
 		klog.ErrorS(err, "cannot store capability in ConfigMap")
 		r.record.Event(&(def.ComponentDefinition), event.Warning("cannot store capability in ConfigMap", err))

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller_test.go
@@ -22,6 +22,11 @@ import (
 	"fmt"
 	"time"
 
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -621,4 +626,99 @@ spec:
 		})
 	})
 
+	FContext("When the CUE Template in ComponentDefinition import new added CRD", func() {
+		It("Applying ComponentDefinition", func() {
+			By("create new crd")
+			newCrd := crdv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo.example.com",
+				},
+				Spec: crdv1.CustomResourceDefinitionSpec{
+					Group: "example.com",
+					Names: crdv1.CustomResourceDefinitionNames{
+						Kind:     "Foo",
+						ListKind: "FooList",
+						Plural:   "foo",
+						Singular: "foo",
+					},
+					Versions: []crdv1.CustomResourceDefinitionVersion{{
+						Name:         "v1",
+						Served:       true,
+						Storage:      true,
+						Subresources: &crdv1.CustomResourceSubresources{Status: &crdv1.CustomResourceSubresourceStatus{}},
+						Schema: &crdv1.CustomResourceValidation{
+							OpenAPIV3Schema: &crdv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]crdv1.JSONSchemaProps{
+									"spec": {
+										Type:                   "object",
+										XPreserveUnknownFields: pointer.BoolPtr(true),
+										Properties: map[string]crdv1.JSONSchemaProps{
+											"key": {Type: "string"},
+										}},
+									"status": {
+										Type:                   "object",
+										XPreserveUnknownFields: pointer.BoolPtr(true),
+										Properties: map[string]crdv1.JSONSchemaProps{
+											"key":      {Type: "string"},
+											"app-hash": {Type: "string"},
+										}}}}}},
+					},
+					Scope: crdv1.NamespaceScoped,
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), &newCrd)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+			componentDef := `
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: test-refresh
+  namespace: default
+spec:
+  workload:
+    definition:
+      apiVersion: example.com/v1
+      kind: Foo
+  schematic:
+    cue:
+      template: |
+        import (
+          ev1 "example.com/v1"
+        )
+        output: ev1.#Foo
+        output: {
+          spec: key: parameter.key1
+          status: key: parameter.key2
+        }
+        parameter: {
+          key1: string
+          key2: string
+        }
+`
+			var cd v1beta1.ComponentDefinition
+			Expect(yaml.Unmarshal([]byte(componentDef), &cd)).Should(BeNil())
+			Expect(k8sClient.Create(ctx, &cd)).Should(Succeed())
+			req := reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-refresh", Namespace: "default"}}
+
+			By("check workload")
+			var wd v1beta1.WorkloadDefinition
+			var wdName = "test-refresh"
+			Eventually(func() bool {
+				reconcileRetry(&r, req)
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: wdName}, &wd)
+				return err == nil
+			}, 20*time.Second, time.Second).Should(BeTrue())
+
+			//By("Check whether ConfigMap is created")
+			//var cm corev1.ConfigMap
+			//name := fmt.Sprintf("%s%s", types.CapabilityConfigMapNamePrefix, "test-refresh")
+			//reconcileRetry(&r, req)
+			//Eventually(func() bool {
+			//	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &cm)
+			//	return err == nil
+			//}, 20*time.Second, time.Second).Should(BeTrue())
+			//Expect(cm.Data[types.OpenapiV3JSONSchema]).Should(Not(Equal("")))
+		})
+	})
 })

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller_test.go
@@ -22,21 +22,20 @@ import (
 	"fmt"
 	"time"
 
-	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/utils/pointer"
-
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
@@ -169,9 +168,9 @@ spec:
 			// API server will convert blank namespace to `default`
 			def.Namespace = namespace
 			Expect(k8sClient.Create(ctx, &def)).Should(Succeed())
+			reconcileRetry(&r, req)
 
 			By("Check whether ConfigMap is created")
-			reconcileRetry(&r, req)
 			var cm corev1.ConfigMap
 			name := fmt.Sprintf("%s%s", types.CapabilityConfigMapNamePrefix, componentDefinitionName)
 			Eventually(func() bool {
@@ -260,9 +259,9 @@ spec:
 			var def v1alpha2.ComponentDefinition
 			Expect(yaml.Unmarshal([]byte(validComponentDefinition), &def)).Should(BeNil())
 			Expect(k8sClient.Create(ctx, &def)).Should(Succeed())
+			reconcileRetry(&r, req)
 
 			By("Check whether ConfigMap is created")
-			reconcileRetry(&r, req)
 			var cm corev1.ConfigMap
 			name := fmt.Sprintf("%s%s", types.CapabilityConfigMapNamePrefix, componentDefinitionName)
 			Eventually(func() bool {
@@ -469,9 +468,9 @@ spec:
 			Expect(yaml.Unmarshal([]byte(validComponentDefinition), &def)).Should(BeNil())
 			def.Namespace = namespace
 			Expect(k8sClient.Create(ctx, &def)).Should(Succeed())
-
-			By("Check whether WorkloadDefinition is created")
 			reconcileRetry(&r, req)
+			By("Check whether WorkloadDefinition is created")
+
 			var wd v1alpha2.WorkloadDefinition
 			var wdName = componentDefinitionName
 			Eventually(func() bool {
@@ -512,9 +511,9 @@ spec:
 			}
 			By("Create ComponentDefinition")
 			Expect(k8sClient.Create(ctx, &cd)).Should(Succeed())
+			reconcileRetry(&r, req)
 
 			By("Check whether WorkloadDefinition is created")
-			reconcileRetry(&r, req)
 			var wd v1alpha2.WorkloadDefinition
 			var wdName = componentDefinitionName
 			Eventually(func() bool {
@@ -615,7 +614,7 @@ spec:
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &cm)
 				return err == nil
-			}, 10*time.Second, time.Second).Should(BeTrue())
+			}, 15*time.Second, time.Second).Should(BeTrue())
 			Expect(cm.Data[types.OpenapiV3JSONSchema]).Should(Not(Equal("")))
 
 			By("Check whether ConfigMapRef refer to right")
@@ -626,8 +625,10 @@ spec:
 		})
 	})
 
-	FContext("When the CUE Template in ComponentDefinition import new added CRD", func() {
-		It("Applying ComponentDefinition", func() {
+	Context("When the CUE Template in ComponentDefinition import new added CRD", func() {
+		var componentDefinationName = "test-refresh"
+		var namespace = "default"
+		It("Applying ComponentDefinition import new crd in CUE Template, should create a ConfigMap", func() {
 			By("create new crd")
 			newCrd := crdv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
@@ -699,26 +700,26 @@ spec:
 			var cd v1beta1.ComponentDefinition
 			Expect(yaml.Unmarshal([]byte(componentDef), &cd)).Should(BeNil())
 			Expect(k8sClient.Create(ctx, &cd)).Should(Succeed())
-			req := reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-refresh", Namespace: "default"}}
+			req := reconcile.Request{NamespacedName: client.ObjectKey{Name: componentDefinationName, Namespace: namespace}}
+			reconcileRetry(&r, req)
 
 			By("check workload")
 			var wd v1beta1.WorkloadDefinition
-			var wdName = "test-refresh"
+			var wdName = componentDefinationName
 			Eventually(func() bool {
-				reconcileRetry(&r, req)
-				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: wdName}, &wd)
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: wdName}, &wd)
 				return err == nil
 			}, 20*time.Second, time.Second).Should(BeTrue())
 
-			//By("Check whether ConfigMap is created")
-			//var cm corev1.ConfigMap
-			//name := fmt.Sprintf("%s%s", types.CapabilityConfigMapNamePrefix, "test-refresh")
-			//reconcileRetry(&r, req)
-			//Eventually(func() bool {
-			//	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &cm)
-			//	return err == nil
-			//}, 20*time.Second, time.Second).Should(BeTrue())
-			//Expect(cm.Data[types.OpenapiV3JSONSchema]).Should(Not(Equal("")))
+			By("Check whether ConfigMap is created")
+			var cm corev1.ConfigMap
+			name := fmt.Sprintf("%s%s", types.CapabilityConfigMapNamePrefix, componentDefinationName)
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &cm)
+				return err == nil
+			}, 15*time.Second, time.Second).Should(BeTrue())
+			Expect(cm.Data[types.OpenapiV3JSONSchema]).Should(Not(Equal("")))
 		})
+
 	})
 })

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_suit_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_suit_test.go
@@ -25,6 +25,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	oamCore "github.com/oam-dev/kubevela/apis/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/dsl/definition"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 )
 
@@ -63,6 +66,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	err = oamCore.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	Expect(crdv1.AddToScheme(scheme.Scheme)).Should(BeNil())
 
 	By("Create the k8s client")
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
@@ -80,11 +84,14 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	_, err = dm.Refresh()
 	Expect(err).ToNot(HaveOccurred())
+	pd, err := definition.NewPackageDiscover(cfg)
+	Expect(err).ToNot(HaveOccurred())
 
 	r = Reconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		dm:     dm,
+		pd:     pd,
 	}
 	Expect(r.SetupWithManager(mgr)).ToNot(HaveOccurred())
 	controllerDone = make(chan struct{}, 1)

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_suit_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_suit_test.go
@@ -116,5 +116,5 @@ func reconcileRetry(r reconcile.Reconciler, req reconcile.Request) {
 	Eventually(func() error {
 		_, err := r.Reconcile(req)
 		return err
-	}, 3*time.Second, time.Second).Should(BeNil())
+	}, 20*time.Second, time.Second).Should(BeNil())
 }

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
@@ -31,7 +31,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
+	"github.com/oam-dev/kubevela/apis/types"
 	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
 	"github.com/oam-dev/kubevela/pkg/dsl/definition"
@@ -66,6 +68,17 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// this is a placeholder for finalizer here in the future
 	if traitdefinition.DeletionTimestamp != nil {
 		return ctrl.Result{}, nil
+	}
+
+	if traitdefinition.Spec.Reference.Name != "" {
+		err := utils.RefreshPackageDiscover(r.dm, r.pd, common.WorkloadGVK{},
+			traitdefinition.Spec.Reference, types.TypeTrait)
+		if err != nil {
+			klog.ErrorS(err, "cannot refresh packageDiscover")
+			r.record.Event(&traitdefinition, event.Warning("cannot refresh packageDiscover", err))
+			return ctrl.Result{}, util.PatchCondition(ctx, r, &traitdefinition,
+				cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrRefreshPackageDiscover, err)))
+		}
 	}
 
 	var def utils.CapabilityTraitDefinition

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
@@ -84,7 +84,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	var def utils.CapabilityTraitDefinition
 	def.Name = req.NamespacedName.Name
 
-	err := def.StoreOpenAPISchema(ctx, r, req.Namespace, req.Name)
+	err := def.StoreOpenAPISchema(ctx, r.Client, r.pd, req.Namespace, req.Name)
 	if err != nil {
 		klog.ErrorS(err, "cannot store capability in ConfigMap")
 		r.record.Event(&(def.TraitDefinition), event.Warning("cannot store capability in ConfigMap", err))

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller_test.go
@@ -23,6 +23,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/pointer"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -272,4 +276,95 @@ spec:
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: invalidTraitDefinitionName, Namespace: namespace}, gotTraitDefinition)).Should(BeNil())
 		})
 	})
+
+	FContext("When the CUE Template in TraitDefinition import new added CRD", func() {
+		It("Applying ComponentDefinition", func() {
+			By("create new crd")
+			newCrd := crdv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo.example.com",
+				},
+				Spec: crdv1.CustomResourceDefinitionSpec{
+					Group: "example.com",
+					Names: crdv1.CustomResourceDefinitionNames{
+						Kind:     "Foo",
+						ListKind: "FooList",
+						Plural:   "foo",
+						Singular: "foo",
+					},
+					Versions: []crdv1.CustomResourceDefinitionVersion{{
+						Name:         "v1",
+						Served:       true,
+						Storage:      true,
+						Subresources: &crdv1.CustomResourceSubresources{Status: &crdv1.CustomResourceSubresourceStatus{}},
+						Schema: &crdv1.CustomResourceValidation{
+							OpenAPIV3Schema: &crdv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]crdv1.JSONSchemaProps{
+									"spec": {
+										Type:                   "object",
+										XPreserveUnknownFields: pointer.BoolPtr(true),
+										Properties: map[string]crdv1.JSONSchemaProps{
+											"key": {Type: "string"},
+										}},
+									"status": {
+										Type:                   "object",
+										XPreserveUnknownFields: pointer.BoolPtr(true),
+										Properties: map[string]crdv1.JSONSchemaProps{
+											"key":      {Type: "string"},
+											"app-hash": {Type: "string"},
+										}}}}}},
+					},
+					Scope: crdv1.NamespaceScoped,
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), &newCrd)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+			traitDef := `
+apiVersion: core.oam.dev/v1alpha2
+kind: TraitDefinition
+metadata:
+  annotations:
+    definition.oam.dev/description: "Configures replicas for your service."
+  name: test-refresh
+  namespace: default
+spec:
+  appliesToWorkloads:
+    - webservice
+    - worker
+  definitionRef:
+    name: foo.example.com
+  schematic:
+    cue:
+      template: |
+        import (
+          ev1 "example.com/v1"
+        )
+        output: ev1.#Foo
+        output: {
+          spec: key: parameter.key1
+          status: key: parameter.key2
+        }
+        parameter: {
+          key1: string
+          key2: string
+        }
+`
+			var td v1beta1.TraitDefinition
+			Expect(yaml.Unmarshal([]byte(traitDef), &td)).Should(BeNil())
+			Expect(k8sClient.Create(ctx, &td)).Should(Succeed())
+			//req := reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-refresh", Namespace: "default"}}
+
+			//By("Check whether ConfigMap is created")
+			//reconcileRetry(&r, req)
+			//var cm corev1.ConfigMap
+			//name := fmt.Sprintf("%s%s", types.CapabilityConfigMapNamePrefix, "test-refresh")
+			//Eventually(func() bool {
+			//	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &cm)
+			//	return err == nil
+			//}, 10*time.Second, time.Second).Should(BeTrue())
+			//Expect(cm.Data[types.OpenapiV3JSONSchema]).Should(Not(Equal("")))
+		})
+	})
+
 })

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_suite_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_suite_test.go
@@ -54,7 +54,6 @@ var _ = BeforeSuite(func(done Done) {
 	useExistCluster := false
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			"./testdata/crd",
 			filepath.Join("../../../../../../..", "charts/vela-core/crds"), // this has all the required CRDs,
 		},
 		UseExistingCluster: &useExistCluster,

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_suite_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_suite_test.go
@@ -22,6 +22,10 @@ import (
 	"testing"
 	"time"
 
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/oam-dev/kubevela/pkg/dsl/definition"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -62,6 +66,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	err = oamCore.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	Expect(crdv1.AddToScheme(scheme.Scheme)).Should(BeNil())
 
 	By("Create the k8s client")
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
@@ -77,11 +82,14 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	dm, err := discoverymapper.New(mgr.GetConfig())
 	Expect(err).ToNot(HaveOccurred())
+	pd, err := definition.NewPackageDiscover(cfg)
+	Expect(err).ToNot(HaveOccurred())
 
 	r = Reconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		dm:     dm,
+		pd:     pd,
 	}
 	Expect(r.SetupWithManager(mgr)).ToNot(HaveOccurred())
 	controllerDone = make(chan struct{}, 1)

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/build"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -37,6 +38,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/appfile/helm"
 	mycue "github.com/oam-dev/kubevela/pkg/cue"
+	"github.com/oam-dev/kubevela/pkg/dsl/definition"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 )
@@ -104,12 +106,12 @@ func (def *CapabilityComponentDefinition) GetCapabilityObject(ctx context.Contex
 }
 
 // GetOpenAPISchema gets OpenAPI v3 schema by WorkloadDefinition name
-func (def *CapabilityComponentDefinition) GetOpenAPISchema(ctx context.Context, k8sClient client.Client, namespace, name string) ([]byte, error) {
+func (def *CapabilityComponentDefinition) GetOpenAPISchema(ctx context.Context, k8sClient client.Client, pd *definition.PackageDiscover, namespace, name string) ([]byte, error) {
 	capability, err := def.GetCapabilityObject(ctx, k8sClient, namespace, name)
 	if err != nil {
 		return nil, err
 	}
-	return getOpenAPISchema(*capability)
+	return getOpenAPISchema(*capability, pd)
 }
 
 // GetKubeSchematicOpenAPISchema gets OpenAPI v3 schema based on kube schematic parameters
@@ -150,7 +152,7 @@ func (def *CapabilityComponentDefinition) GetKubeSchematicOpenAPISchema(params [
 }
 
 // StoreOpenAPISchema stores OpenAPI v3 schema in ConfigMap from WorkloadDefinition
-func (def *CapabilityComponentDefinition) StoreOpenAPISchema(ctx context.Context, k8sClient client.Client, namespace, name string) error {
+func (def *CapabilityComponentDefinition) StoreOpenAPISchema(ctx context.Context, k8sClient client.Client, pd *definition.PackageDiscover, namespace, name string) error {
 	var jsonSchema []byte
 	var err error
 	switch def.WorkloadType {
@@ -159,7 +161,7 @@ func (def *CapabilityComponentDefinition) StoreOpenAPISchema(ctx context.Context
 	case util.KubeDef:
 		jsonSchema, err = def.GetKubeSchematicOpenAPISchema(def.Kube.Parameters)
 	default:
-		jsonSchema, err = def.GetOpenAPISchema(ctx, k8sClient, namespace, name)
+		jsonSchema, err = def.GetOpenAPISchema(ctx, k8sClient, pd, namespace, name)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to generate OpenAPI v3 JSON schema for capability %s: %w", def.Name, err)
@@ -210,17 +212,17 @@ func (def *CapabilityTraitDefinition) GetCapabilityObject(ctx context.Context, k
 }
 
 // GetOpenAPISchema gets OpenAPI v3 schema by TraitDefinition name
-func (def *CapabilityTraitDefinition) GetOpenAPISchema(ctx context.Context, k8sClient client.Client, namespace, name string) ([]byte, error) {
+func (def *CapabilityTraitDefinition) GetOpenAPISchema(ctx context.Context, k8sClient client.Client, pd *definition.PackageDiscover, namespace, name string) ([]byte, error) {
 	capability, err := def.GetCapabilityObject(ctx, k8sClient, namespace, name)
 	if err != nil {
 		return nil, err
 	}
-	return getOpenAPISchema(*capability)
+	return getOpenAPISchema(*capability, pd)
 }
 
 // StoreOpenAPISchema stores OpenAPI v3 schema from TraitDefinition in ConfigMap
-func (def *CapabilityTraitDefinition) StoreOpenAPISchema(ctx context.Context, k8sClient client.Client, namespace, name string) error {
-	jsonSchema, err := def.GetOpenAPISchema(ctx, k8sClient, namespace, name)
+func (def *CapabilityTraitDefinition) StoreOpenAPISchema(ctx context.Context, k8sClient client.Client, pd *definition.PackageDiscover, namespace, name string) error {
+	jsonSchema, err := def.GetOpenAPISchema(ctx, k8sClient, pd, namespace, name)
 	if err != nil {
 		return fmt.Errorf(util.ErrGenerateOpenAPIV2JSONSchemaForCapability, def.Name, err)
 	}
@@ -287,8 +289,8 @@ func (def *CapabilityBaseDefinition) CreateOrUpdateConfigMap(ctx context.Context
 }
 
 // getDefinition is the main function for GetDefinition API
-func getOpenAPISchema(capability types.Capability) ([]byte, error) {
-	openAPISchema, err := generateOpenAPISchemaFromCapabilityParameter(capability)
+func getOpenAPISchema(capability types.Capability, pd *definition.PackageDiscover) ([]byte, error) {
+	openAPISchema, err := generateOpenAPISchemaFromCapabilityParameter(capability, pd)
 	if err != nil {
 		return nil, err
 	}
@@ -306,8 +308,25 @@ func getOpenAPISchema(capability types.Capability) ([]byte, error) {
 }
 
 // generateOpenAPISchemaFromCapabilityParameter returns the parameter of a definition in cue.Value format
-func generateOpenAPISchemaFromCapabilityParameter(capability types.Capability) ([]byte, error) {
-	return GenerateOpenAPISchemaFromDefinition(capability.Name, capability.CueTemplate)
+func generateOpenAPISchemaFromCapabilityParameter(capability types.Capability, pd *definition.PackageDiscover) ([]byte, error) {
+	template, err := prepareParameterCue(capability.Name, capability.CueTemplate)
+	if err != nil {
+		return nil, err
+	}
+	template += mycue.BaseTemplate
+	bi := build.NewContext().NewInstance("", nil)
+	err = bi.AddFile("-", template)
+	if err != nil {
+		return nil, err
+	}
+	pd.ImportBuiltinPackagesFor(bi)
+
+	var r cue.Runtime
+	cueInst, err := r.Build(bi)
+	if err != nil {
+		return nil, err
+	}
+	return common.GenOpenAPI(cueInst)
 }
 
 // GenerateOpenAPISchemaFromDefinition returns the parameter of a definition

--- a/pkg/controller/utils/capability_integrate_test.go
+++ b/pkg/controller/utils/capability_integrate_test.go
@@ -113,7 +113,7 @@ spec:
 			Expect(capability).Should(Not(BeNil()))
 
 			By("Test GetOpenAPISchema")
-			schema, err := def.GetOpenAPISchema(ctx, k8sClient, namespace, componentDefinitionName)
+			schema, err := def.GetOpenAPISchema(ctx, k8sClient, pd, namespace, componentDefinitionName)
 			Expect(err).Should(BeNil())
 			Expect(schema).Should(Not(BeNil()))
 
@@ -179,7 +179,7 @@ spec:
 
 			By("Test GetOpenAPISchema")
 			var expectedSchema = "{\"properties\":{\"replicas\":{\"default\":1,\"description\":\"Replicas of the workload\",\"title\":\"replicas\",\"type\":\"integer\"}},\"required\":[\"replicas\"],\"type\":\"object\"}"
-			schema, err := def.GetOpenAPISchema(ctx, k8sClient, namespace, traitDefinitionName)
+			schema, err := def.GetOpenAPISchema(ctx, k8sClient, pd, namespace, traitDefinitionName)
 			Expect(err).Should(BeNil())
 			Expect(string(schema)).Should(Equal(expectedSchema))
 		})

--- a/pkg/controller/utils/capability_suite_test.go
+++ b/pkg/controller/utils/capability_suite_test.go
@@ -29,11 +29,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	oamCore "github.com/oam-dev/kubevela/apis/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/dsl/definition"
 )
 
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var pd *definition.PackageDiscover
 
 func TestCapability(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -61,6 +63,9 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
+
+	pd, err = definition.NewPackageDiscover(cfg)
+	Expect(err).ToNot(HaveOccurred())
 
 	close(done)
 }, 60)

--- a/pkg/controller/utils/capability_test.go
+++ b/pkg/controller/utils/capability_test.go
@@ -75,7 +75,7 @@ func TestGetOpenAPISchema(t *testing.T) {
 				},
 			}
 			capability, _ := util.ConvertTemplateJSON2Object(tc.name, nil, schematic)
-			schema, err := getOpenAPISchema(capability)
+			schema, err := getOpenAPISchema(capability, pd)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ngetOpenAPISchema(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -138,7 +138,7 @@ func TestGenerateOpenAPISchemaFromCapabilityParameter(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, err := generateOpenAPISchemaFromCapabilityParameter(tc.capability)
+			got, err := generateOpenAPISchemaFromCapabilityParameter(tc.capability, pd)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ngetDefinition(...): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -275,7 +275,6 @@ func RefreshPackageDiscover(dm discoverymapper.DiscoveryMapper, pd *definition.P
 		}
 	case oamtypes.TypeWorkload, oamtypes.TypeScope:
 	}
-	fmt.Printf("look gvk %v\n", gvk)
 	targetGVK := metav1.GroupVersionKind{
 		Group:   gvk.Group,
 		Version: gvk.Version,

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -275,9 +275,23 @@ func RefreshPackageDiscover(dm discoverymapper.DiscoveryMapper, pd *definition.P
 		}
 	case oamtypes.TypeWorkload, oamtypes.TypeScope:
 	}
-	exist := pd.Exist(metav1.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind})
-	if !exist {
-		return pd.RefreshKubePackagesFromCluster()
+	fmt.Printf("look gvk %v\n", gvk)
+	targetGVK := metav1.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+	}
+	if exist := pd.Exist(targetGVK); exist {
+		return nil
+	}
+
+	if err := pd.RefreshKubePackagesFromCluster(); err != nil {
+		return err
+	}
+
+	// Test whether the refresh is successful
+	if exist := pd.Exist(targetGVK); !exist {
+		return fmt.Errorf("get CRD %s error", targetGVK.String())
 	}
 	return nil
 }

--- a/pkg/oam/discoverymapper/mapper.go
+++ b/pkg/oam/discoverymapper/mapper.go
@@ -59,12 +59,13 @@ func New(c *rest.Config) (DiscoveryMapper, error) {
 // Prefer lazy discovery, because resources created after refresh can not be found
 func (d *DefaultDiscoveryMapper) GetMapper() (meta.RESTMapper, error) {
 	d.mutex.RLock()
-	if d.mapper == nil {
-		d.mutex.RUnlock()
+	mapper := d.mapper
+	d.mutex.RUnlock()
+
+	if mapper == nil {
 		return d.Refresh()
 	}
-	d.mutex.RUnlock()
-	return d.mapper, nil
+	return mapper, nil
 }
 
 // Refresh will re-create the mapper by getting the new resource from K8s API by using discovery client

--- a/pkg/oam/discoverymapper/mapper.go
+++ b/pkg/oam/discoverymapper/mapper.go
@@ -17,6 +17,8 @@ limitations under the License.
 package discoverymapper
 
 import (
+	"sync"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -39,6 +41,7 @@ var _ DiscoveryMapper = &DefaultDiscoveryMapper{}
 type DefaultDiscoveryMapper struct {
 	dc     *discovery.DiscoveryClient
 	mapper meta.RESTMapper
+	mutex  sync.RWMutex
 }
 
 // New will create a new DefaultDiscoveryMapper by giving a K8s rest config
@@ -55,9 +58,12 @@ func New(c *rest.Config) (DiscoveryMapper, error) {
 // GetMapper will get the cached restmapper, if nil, it will create one by refresh
 // Prefer lazy discovery, because resources created after refresh can not be found
 func (d *DefaultDiscoveryMapper) GetMapper() (meta.RESTMapper, error) {
+	d.mutex.RLock()
 	if d.mapper == nil {
+		d.mutex.RUnlock()
 		return d.Refresh()
 	}
+	d.mutex.RUnlock()
 	return d.mapper, nil
 }
 
@@ -67,6 +73,8 @@ func (d *DefaultDiscoveryMapper) Refresh() (meta.RESTMapper, error) {
 	if err != nil {
 		return nil, err
 	}
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	d.mapper = restmapper.NewDiscoveryRESTMapper(gr)
 	return d.mapper, nil
 }

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -99,7 +99,7 @@ const (
 	ErrCreateConvertedWorklaodDefinition = "cannot create converted WorkloadDefinition %s: %v"
 
 	// ErrRefreshPackageDiscover is the error while refresh PackageDiscover
-	ErrRefreshPackageDiscover = "cannot refresh PackageDiscover : %v"
+	ErrRefreshPackageDiscover = "cannot discover the open api of the CRD : %v"
 )
 
 // WorkloadType describe the workload type of ComponentDefinition

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -97,6 +97,9 @@ const (
 
 	// ErrCreateConvertedWorklaodDefinition is the error while apply a WorkloadDefinition
 	ErrCreateConvertedWorklaodDefinition = "cannot create converted WorkloadDefinition %s: %v"
+
+	// ErrRefreshPackageDiscover is the error while refresh PackageDiscover
+	ErrRefreshPackageDiscover = "cannot refresh PackageDiscover : %v"
 )
 
 // WorkloadType describe the workload type of ComponentDefinition


### PR DESCRIPTION
fix https://github.com/oam-dev/kubevela/issues/1387

refresh package discover when component/trait definition are registered.

- [x] add discover refresh
- [x] add test