### PR TITLE
vela-cli support use "vela system cue-packages" to list cue-package

### DIFF
--- a/docs/en/platform-engineers/debug-test-cue.md
+++ b/docs/en/platform-engineers/debug-test-cue.md
@@ -302,9 +302,9 @@ There are two kinds of ways to import internal `kube` packages.
 
 #### A workflow to debug with `kube` packages
 
-Here's a workflow that you can debug and test the CUE template with `cue` command line tool and use **exactly the same CUE template** in KubeVela.
+Here's a workflow that you can debug and test the CUE template with `cue` CLI and use **exactly the same CUE template** in KubeVela.
 
-1. Create a test directory, and init cue module.
+1. Create a test directory, Init CUE modules.
 
 ```shell
 mkdir cue-debug && cd cue-debug/
@@ -313,11 +313,10 @@ go mod init oam.dev
 touch def.cue
 ```
 
-2. Download the `third-party packages` by using `cue` cli.
+2. Download the `third-party packages` by using `cue` CLI.
 
-In Kubevela, we don't need to download these packages as they're automatically generated from K8s API.
-But for local test with `cue` cli, we need to use `cue get go` fetches Go packages and convert them to CUE format files.
-
+In KubeVela, we don't need to download these packages as they're automatically generated from K8s API.
+But for local test, we need to use `cue get go` to fetch Go packages and convert them to CUE format files.
 
 So, by using K8s `Deployment` and `Serivice`, we need download and convert to CUE definitions for the `core` and `apps` Kubernetes modules like below:
 
@@ -345,7 +344,7 @@ After that, the module directory will show the following contents:
 └── go.sum
 ```
 
-The package import path in `def.cue` file is the path in `gen` directory, like:
+The package import path in CUE template should be:
 
 ```cue
 import (
@@ -354,16 +353,17 @@ import (
 )
 ```
 
+3. Refactor directory hierarchy.
+
 Our goal is to test template locally and use the same template in KubeVela.
-So we need to refactor our local CUE module directories a bit to align with the import path provided by KubeVela, 
+So we need to refactor our local CUE module directories a bit to align with the import path provided by KubeVela,
 
-3. Refactor directories hierarchy.
-
-Copy the `apps` and `core` from `cue.mod/gen/k8s.io/api` to `cue.mod/gen/k8s.io`(Note, To avoid import path loss, we should keep 
-the source directory `apps` and `core` in `gen/k8s.io/api`).
+Copy the `apps` and `core` from `cue.mod/gen/k8s.io/api` to `cue.mod/gen/k8s.io`.
+(Note we should keep the source directory `apps` and `core` in `gen/k8s.io/api` to avoid package dependency issues).
 
 ```bash
-cp -r cue.mod/gen/k8s.io/api/apps cue.mod/gen/k8s.io/api/core cue.mod/gen/k8s.io
+cp -r cue.mod/gen/k8s.io/api/apps cue.mod/gen/k8s.io
+cp -r cue.mod/gen/k8s.io/api/core cue.mod/gen/k8s.io
 ```
 
 The modified module directory should like:
@@ -387,7 +387,7 @@ The modified module directory should like:
 └── go.sum
 ```
 
-So, you can import the package use the following path:
+So, you can import the package use the following path that aligns with KubeVela:
 
 ```cue
 import (
@@ -396,7 +396,9 @@ import (
 )
 ```
 
-Finally, we can test CUE Template which use the `Kube` package. Copy the cue file below to `def.cue`.
+4. Test and Run.
+
+Finally, we can test CUE Template which use the `Kube` package.
 
 ```cue
 import (

--- a/docs/en/platform-engineers/debug-test-cue.md
+++ b/docs/en/platform-engineers/debug-test-cue.md
@@ -309,21 +309,20 @@ Here's a workflow that you can debug and test the CUE template with `cue` comman
 ```shell
 mkdir cue-debug && cd cue-debug/
 cue mod init oam.dev
+go mod init oam.dev
 touch def.cue
 ```
 
 2. Download the `third-party packages` by using `cue` cli.
 
 In Kubevela, we don't need to download these packages as they're automatically generated from K8s API.
-But for local test with `cue` cli, we need to download these Go modules(`go get`) and convert them to CUE format files(`cue get`).
+But for local test with `cue` cli, we need to use `cue get go` fetches Go packages and convert them to CUE format files.
+
 
 So, by using K8s `Deployment` and `Serivice`, we need download and convert to CUE definitions for the `core` and `apps` Kubernetes modules like below:
 
 ```shell
-go get k8s.io/api/core/v1
 cue get go k8s.io/api/core/v1
-
-go get k8s.io/api/apps/v1
 cue get go k8s.io/api/apps/v1
 ```
 
@@ -341,7 +340,9 @@ After that, the module directory will show the following contents:
 │   ├── module.cue
 │   ├── pkg
 │   └── usr
-└── def.cue
+├── def.cue
+├── go.mod
+└── go.sum
 ```
 
 The package import path in `def.cue` file is the path in `gen` directory, like:
@@ -358,8 +359,12 @@ So we need to refactor our local CUE module directories a bit to align with the 
 
 3. Refactor directories hierarchy.
 
-Copy the `apps` and `core` from `gen/k8s.io/api` to `gen/k8s.io`(Note, To avoid import path loss, we should keep 
+Copy the `apps` and `core` from `cue.mod/gen/k8s.io/api` to `cue.mod/gen/k8s.io`(Note, To avoid import path loss, we should keep 
 the source directory `apps` and `core` in `gen/k8s.io/api`).
+
+```bash
+cp -r cue.mod/gen/k8s.io/api/apps cue.mod/gen/k8s.io/api/core cue.mod/gen/k8s.io
+```
 
 The modified module directory should like:
 
@@ -377,7 +382,9 @@ The modified module directory should like:
 │   ├── module.cue
 │   ├── pkg
 │   └── usr
-└── def.cue
+├── def.cue
+├── go.mod
+└── go.sum
 ```
 
 So, you can import the package use the following path:

--- a/references/cli/cue_packages.go
+++ b/references/cli/cue_packages.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gosuri/uitable"
+
 	"github.com/spf13/cobra"
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
@@ -51,7 +53,7 @@ func printCUEPackageList(c common.Args, ioStreams cmdutil.IOStreams) error {
 		return fmt.Errorf("get cue package discover: %w", err)
 	}
 
-	table := newUITable()
+	table := uitable.New()
 	table.AddRow("DEFINITION-NAME", "IMPORT-PATH", " USAGE")
 
 	packages := pd.ListPackageKinds()

--- a/references/cli/cue_packages.go
+++ b/references/cli/cue_packages.go
@@ -1,0 +1,69 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
+)
+
+// NewCUEPackageCommand creates `cue-package` command
+func NewCUEPackageCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "cue-packages",
+		DisableFlagsInUseLine: true,
+		Short:                 "List cue package",
+		Long:                  "List cue package",
+		Example:               `vela system cue-packages`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return c.SetConfig()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return printCUEPackageList(c, ioStreams)
+		},
+	}
+	cmd.SetOut(ioStreams.Out)
+	return cmd
+}
+
+func printCUEPackageList(c common.Args, ioStreams cmdutil.IOStreams) error {
+	pd, err := c.GetPackageDiscover()
+	if err != nil {
+		return fmt.Errorf("get cue package discover: %w", err)
+	}
+
+	table := newUITable()
+	table.AddRow("DEFINITION-NAME", "IMPORT-PATH", " USAGE")
+
+	packages := pd.ListPackageKinds()
+	for path, kinds := range packages {
+		if strings.HasPrefix(path, "kube/") {
+			continue
+		}
+		for _, kind := range kinds {
+			// TODO(yangsoon) support other kind object in future
+			table.AddRow(kind.DefinitionName, path, "Kube Object for "+kind.APIVersion+"."+kind.Kind)
+		}
+	}
+	ioStreams.Info(table.String())
+	return nil
+}

--- a/references/cli/system.go
+++ b/references/cli/system.go
@@ -84,6 +84,7 @@ func SystemCommandGroup(c common.Args, ioStream cmdutil.IOStreams) *cobra.Comman
 	}
 	cmd.AddCommand(NewDryRunCommand(c, ioStream))
 	cmd.AddCommand(NewAdminInfoCommand(ioStream))
+	cmd.AddCommand(NewCUEPackageCommand(c, ioStream))
 	return cmd
 }
 


### PR DESCRIPTION
fix https://github.com/oam-dev/kubevela/issues/1404

use `vela system cue-packages` to show what are the inner packages supported in cluster

```
$ vela system cue-packages
Definition-Name                 Import-Path                                      Usage                                                      
#Event                          kube/events.k8s.io/v1beta1                      Kube Object for events.k8s.io/v1beta1.Event                                 
#Event                          k8s.io/events/v1beta1                           Kube Object for events.k8s.io/v1beta1.Event                                 
#RolloutTrait                   kube/standard.oam.dev/v1alpha1                  Kube Object for standard.oam.dev/v1alpha1.RolloutTrait                      
#PodSpecWorkload                kube/standard.oam.dev/v1alpha1                  Kube Object for standard.oam.dev/v1alpha1.PodSpecWorkload                   
#CustomResourceDefinition       k8s.io/apiextensions/v1                         Kube Object for apiextensions.k8s.io/v1.CustomResourceDefinition            
#CustomResourceDefinition       kube/apiextensions.k8s.io/v1beta1               Kube Object for apiextensions.k8s.io/v1beta1.CustomResourceDefinition 
```