### PR TITLE
fix CI: Add clean-image action to clean up dangling docker image

### DIFF
--- a/.github/workflows/timed-task.yml
+++ b/.github/workflows/timed-task.yml
@@ -1,0 +1,10 @@
+name: Timed Task
+on:
+  schedule:
+    - cron: '0 16 * * *'
+jobs:
+  clean-image:
+    runs-on: aliyun
+    steps:
+      - name: Cleanup image
+        run: docker image prune -f


### PR DESCRIPTION
fix https://github.com/oam-dev/kubevela/issues/1429 

add timed task, clean up dangling docker image