### PR TITLE
Improve makefile and dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
     go build -a -ldflags "-s -w -X github.com/oam-dev/kubevela/version.VelaVersion=${VERSION:-undefined} -X github.com/oam-dev/kubevela/version.GitRevision=${GITVERSION:-undefined}" \
     -o manager-${TARGETARCH} main.go
 
-# Use alpine as base image to reduce image size
+# Use alpine as base image due to the discussion in issue #1448
 # You can replace distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-# Could use `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot` to overwrite
+# Overwrite `BASE_IMAGE` by passing `--build-arg=BASE_IMAGE=gcr.io/distroless/static:nonroot`
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE:-alpine:latest}
 # This is required by daemon connnecting with cri

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Image URL to use all building/pushing image targets
-VELA_IMAGE           ?= vela:latest
 VELA_CORE_IMAGE      ?= vela-core:latest
 VELA_CORE_TEST_IMAGE ?= vela-core-test:$(GIT_COMMIT)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [[ "${1#-}" != "$1" ]]; then
+    set -- manager "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Brief changes:

1. Improve makefile
  - Add `-s -w` in `LDFLAGS` to strip debug information and reduce release binary size
    - In Mac, the binary size of the `vela` is reduced from `79M` to `67M`, and the binary size of the `manager` is reduced from `53M` to `43M`
  - Define docker image name such as `VELA_IMAGE`, `VELA_CORE_IMAGE` and `VELA_CORE_TEST_IMAGE`
  - Define go build env `GOBUILD_ENV`
![image](https://user-images.githubusercontent.com/4902714/114133645-f1454880-9938-11eb-8706-f95e4392ffea.png)

2.  Improve dockerfile
  - Replace base image `ubuntu:latest` with `alpine:latest`, since in many docker libraries, debian and alpine are more popular
  - The docker image size of `vela-core` is reduced from `140M` to `51.1M`
![image](https://user-images.githubusercontent.com/4902714/114133580-d70b6a80-9938-11eb-971f-e1c2e94f0ddc.png)

3. Add entrypoint.sh to support entrypoint and debugging
  - Solve #1177 better
  - The following commands can be supported:

```
docker run -it --rm vela-core:latest manager -use-webhook
docker run -it --rm vela-core:latest -use-webhook
docker run -it --rm vela-core:latest sh
docker run -it --rm vela-core:latest bash
docker run -it --rm vela-core:latest -h
```

![image](https://user-images.githubusercontent.com/4902714/114137973-86e3d680-993f-11eb-844d-3a79db46d3f4.png)


This closes #1448