### PR TITLE
refactor vela-cli: refactor dry-run and live-diff 

### DIFF
--- a/references/cli/livediff.go
+++ b/references/cli/livediff.go
@@ -33,16 +33,17 @@ import (
 	"github.com/oam-dev/kubevela/references/appfile/dryrun"
 )
 
-type livediffCmdOptions struct {
-	dryRunCmdOptions
-	revision string
-	context  int
+// LiveDiffCmdOptions contains the live-diff cmd options
+type LiveDiffCmdOptions struct {
+	DryRunCmdOptions
+	Revision string
+	Context  int
 }
 
 // NewLiveDiffCommand creates `live-diff` command
 func NewLiveDiffCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
-	o := &livediffCmdOptions{
-		dryRunCmdOptions: dryRunCmdOptions{
+	o := &LiveDiffCmdOptions{
+		DryRunCmdOptions: DryRunCmdOptions{
 			IOStreams: ioStreams,
 		}}
 	cmd := &cobra.Command{
@@ -55,85 +56,95 @@ func NewLiveDiffCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Comma
 			return c.SetConfig()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			newClient, err := c.GetClient()
-			if err != nil {
-				return err
-			}
-
 			velaEnv, err := GetEnv(cmd)
 			if err != nil {
 				return err
 			}
-			objs := []oam.Object{}
-			if o.definitionFile != "" {
-				objs, err = ReadObjectsFromFile(o.definitionFile)
-				if err != nil {
-					return err
-				}
-			}
-			pd, err := c.GetPackageDiscover()
+			buff, err := LiveDiffApplication(o, c, velaEnv.Namespace)
 			if err != nil {
 				return err
 			}
-
-			dm, err := discoverymapper.New(c.Config)
-			if err != nil {
-				return err
-			}
-
-			app, err := readApplicationFromFile(o.applicationFile)
-			if err != nil {
-				return errors.WithMessagef(err, "read application file: %s", o.applicationFile)
-			}
-			if app.Namespace == "" {
-				app.SetNamespace(velaEnv.Namespace)
-			}
-
-			appRevision := &v1beta1.ApplicationRevision{}
-			if o.revision != "" {
-				// get the revision if user specifies
-				if err := newClient.Get(context.Background(),
-					client.ObjectKey{Name: o.revision, Namespace: app.Namespace}, appRevision); err != nil {
-					return errors.Wrapf(err, "cannot get application revision %q", o.revision)
-				}
-			} else {
-				// get the latest revision of the application
-				livingApp := &v1beta1.Application{}
-				if err := newClient.Get(context.Background(),
-					client.ObjectKey{Name: app.Name, Namespace: app.Namespace}, livingApp); err != nil {
-					return errors.Wrapf(err, "cannot get application %q", app.Name)
-				}
-				if livingApp.Status.LatestRevision != nil {
-					latestRevName := livingApp.Status.LatestRevision.Name
-					if err := newClient.Get(context.Background(),
-						client.ObjectKey{Name: latestRevName, Namespace: app.Namespace}, appRevision); err != nil {
-						return errors.Wrapf(err, "cannot get application revision %q", o.revision)
-					}
-				} else {
-					// .status.latestRevision is nil, that means the app has not
-					// been rendered yet
-					return fmt.Errorf("the application %q has no revision in the cluster", app.Name)
-				}
-			}
-
-			liveDiffOption := dryrun.NewLiveDiffOption(newClient, dm, pd, objs)
-			diffResult, err := liveDiffOption.Diff(context.Background(), app, appRevision)
-			if err != nil {
-				return errors.WithMessage(err, "cannot calculate diff")
-			}
-
-			var buff = bytes.Buffer{}
-			reportDiffOpt := dryrun.NewReportDiffOption(o.context, &buff)
-			reportDiffOpt.PrintDiffReport(diffResult)
 			o.Info(buff.String())
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.applicationFile, "file", "f", "./app.yaml", "application file name")
-	cmd.Flags().StringVarP(&o.definitionFile, "definition", "d", "", "specify a file or directory containing capability definitions, they will only be used in dry-run rather than applied to K8s cluster")
-	cmd.Flags().StringVarP(&o.revision, "revision", "r", "", "specify an application revision name, by default, it will compare with the latest revision")
-	cmd.Flags().IntVarP(&o.context, "context", "c", -1, "output number lines of context around changes, by default show all unchanged lines")
+	cmd.Flags().StringVarP(&o.ApplicationFile, "file", "f", "./app.yaml", "application file name")
+	cmd.Flags().StringVarP(&o.DefinitionFile, "definition", "d", "", "specify a file or directory containing capability definitions, they will only be used in dry-run rather than applied to K8s cluster")
+	cmd.Flags().StringVarP(&o.Revision, "Revision", "r", "", "specify an application Revision name, by default, it will compare with the latest Revision")
+	cmd.Flags().IntVarP(&o.Context, "context", "c", -1, "output number lines of context around changes, by default show all unchanged lines")
 	cmd.SetOut(ioStreams.Out)
 	return cmd
+}
+
+// LiveDiffApplication can return user what would change if upgrade an application.
+func LiveDiffApplication(cmdOption *LiveDiffCmdOptions, c common.Args, namespace string) (bytes.Buffer, error) {
+	var buff = bytes.Buffer{}
+
+	newClient, err := c.GetClient()
+	if err != nil {
+		return buff, err
+	}
+	objs := []oam.Object{}
+	if cmdOption.DefinitionFile != "" {
+		objs, err = ReadObjectsFromFile(cmdOption.DefinitionFile)
+		if err != nil {
+			return buff, err
+		}
+	}
+	pd, err := c.GetPackageDiscover()
+	if err != nil {
+		return buff, err
+	}
+
+	dm, err := discoverymapper.New(c.Config)
+	if err != nil {
+		return buff, err
+	}
+
+	app, err := readApplicationFromFile(cmdOption.ApplicationFile)
+	if err != nil {
+		return buff, errors.WithMessagef(err, "read application file: %s", cmdOption.ApplicationFile)
+	}
+	if app.Namespace == "" {
+		app.SetNamespace(namespace)
+	}
+
+	appRevision := &v1beta1.ApplicationRevision{}
+	if cmdOption.Revision != "" {
+		// get the Revision if user specifies
+		if err := newClient.Get(context.Background(),
+			client.ObjectKey{Name: cmdOption.Revision, Namespace: app.Namespace}, appRevision); err != nil {
+			return buff, errors.Wrapf(err, "cannot get application Revision %q", cmdOption.Revision)
+		}
+	} else {
+		// get the latest Revision of the application
+		livingApp := &v1beta1.Application{}
+		if err := newClient.Get(context.Background(),
+			client.ObjectKey{Name: app.Name, Namespace: app.Namespace}, livingApp); err != nil {
+			return buff, errors.Wrapf(err, "cannot get application %q", app.Name)
+		}
+		if livingApp.Status.LatestRevision != nil {
+			latestRevName := livingApp.Status.LatestRevision.Name
+			if err := newClient.Get(context.Background(),
+				client.ObjectKey{Name: latestRevName, Namespace: app.Namespace}, appRevision); err != nil {
+				return buff, errors.Wrapf(err, "cannot get application Revision %q", cmdOption.Revision)
+			}
+		} else {
+			// .status.latestRevision is nil, that means the app has not
+			// been rendered yet
+			return buff, fmt.Errorf("the application %q has no Revision in the cluster", app.Name)
+		}
+	}
+
+	liveDiffOption := dryrun.NewLiveDiffOption(newClient, dm, pd, objs)
+	diffResult, err := liveDiffOption.Diff(context.Background(), app, appRevision)
+	if err != nil {
+		return buff, errors.WithMessage(err, "cannot calculate diff")
+	}
+
+	reportDiffOpt := dryrun.NewReportDiffOption(cmdOption.Context, &buff)
+	reportDiffOpt.PrintDiffReport(diffResult)
+
+	return buff, nil
 }


### PR DESCRIPTION
Extract public functions to allow other packages to call:

1.` DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace string) (bytes.Buffer, error)`
2. `LiveDiffApplication(cmdOption *LiveDiffCmdOptions, c common.Args, namespace string) (bytes.Buffer, error)`