### PR TITLE
Keep docker binary command due to the issue #416

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,6 @@ env:
   # Common versions
   GO_VERSION: '1.14'
   GOLANGCI_VERSION: 'v1.38'
-  DOCKER_BUILDX_VERSION: 'v0.4.2'
   KIND_VERSION: 'v0.7.0'
 
 jobs:

--- a/pkg/builtin/build/build.go
+++ b/pkg/builtin/build/build.go
@@ -101,7 +101,7 @@ func asyncLog(reader io.Reader, stream cmdutil.IOStreams) {
 // buildImage will build a image with name and context.
 func (b *Build) buildImage(io cmdutil.IOStreams, image string) error {
 	//nolint:gosec
-	// TODO(hongchaodeng): remove this dependency by using go lib
+	// keep docker binary command due to the issue #416 https://github.com/oam-dev/kubevela/issues/416
 	cmd := exec.Command("docker", "build", "-t", image, "-f", b.Docker.File, b.Docker.Context)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Brief changes:
- Keep docker binary command due to the issue #416
- Remove the redundant `DOCKER_BUILDX_VERSION`

This closes #416, and closes #1233 (pr)
