### PR TITLE
Fix helm install error when disable webhook patch

### DIFF
--- a/charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -72,7 +72,7 @@ webhooks:
     {{- if .Values.admissionWebhooks.patch.enabled  }}
     failurePolicy: Ignore
     {{- else }}
-    failurePolicy: Fails
+    failurePolicy: Fail
     {{- end }}
     name: mutating.core.oam-dev.v1alpha2.components
     sideEffects: None
@@ -99,7 +99,7 @@ webhooks:
     {{- if .Values.admissionWebhooks.patch.enabled  }}
     failurePolicy: Ignore
     {{- else }}
-    failurePolicy: Fails
+    failurePolicy: Fail
     {{- end }}
     name: mcontainerized.kb.io
     sideEffects: None


### PR DESCRIPTION
[failurePolicy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) should be `Fail` instead of `Fails`.