### PR TITLE
[WIP] fix docs: start/build docs in docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,21 +64,16 @@ doc-gen:
 	go run hack/docgen/gen.go
 	go run hack/references/generate.go
 
+PWD := $(shell pwd)
 docs-build:
-ifneq ($(wildcard git-page),)
-	rm -rf git-page
-endif
-	sh ./hack/website/test-build.sh
+	docker run -it -v $(PWD)/docs/sidebars.js:/workspace/kubevela.io/sidebars.js \
+	 -v $(PWD)/docs/en:/workspace/kubevela.io/docs \
+	 yangsoon/kubevela.io:v1 -t build
 
 docs-start:
-ifeq ($(wildcard git-page),)
-	git clone --single-branch --depth 1 https://github.com/oam-dev/kubevela.io.git git-page
-endif
-	rm -r git-page/docs
-	rm git-page/sidebars.js
-	cat docs/sidebars.js > git-page/sidebars.js
-	cp -R docs/en git-page/docs
-	cd git-page && yarn install && yarn start
+	docker run -it -p 3000:3000 -v $(PWD)/docs/sidebars.js:/workspace/kubevela.io/sidebars.js \
+	 -v $(PWD)/docs/en:/workspace/kubevela.io/docs \
+	 yangsoon/kubevela.io:v1 -t start
 
 api-gen:
 	swag init -g references/apiserver/route.go --output references/apiserver/docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,8 +56,8 @@ When you add or modify the docs, these three files(`docs/en/`, `docs/en/resource
    
 ## Local Development
 
-You can preview the website locally with the `node` and `yarn` installed.
-Every time you modify the files under the docs, you need to re-run the following command, it will not sync automatically:
+You can preview the website locally with docker container. Every time you modify the files under the docs or sidebars.js, 
+it will sync automatically:
 
 ```shell
 make docs-start

--- a/hack/website/release.sh
+++ b/hack/website/release.sh
@@ -36,11 +36,7 @@ echo "clear en docs"
 rm -r git-page/docs/*
 #echo "clear zh docs"
 #rm -r git-page/i18n/zh/docusaurus-plugin-content-docs/*
-echo "clear resources"
-rm -r git-page/resources/*
 
-echo "update resources"
-cp -R docs/resources/* git-page/resources/
 
 echo "update docs"
 cp -R docs/en/* git-page/docs/


### PR DESCRIPTION
now we can preview website in docker, every time you modify the related files, the change will sync automatically.
we can also build and check the correctness of docs in docker container.

You can see the docker image details here https://github.com/yangsoon/kubevela-website