### PR TITLE
fix flaky test

### DIFF
--- a/docs/en/end-user/explore.md
+++ b/docs/en/end-user/explore.md
@@ -75,8 +75,6 @@ Here are some highlight information that you need to know:
 
 ### List Application Revisions
 
-> Note: we currently don't support list by label selector until https://github.com/oam-dev/kubevela/issues/1476
-
 When we update an application, if there's any difference on spec, KubeVela will create a new revision.
 
 ```shell

--- a/pkg/oam/discoverymapper/suit_test.go
+++ b/pkg/oam/discoverymapper/suit_test.go
@@ -163,11 +163,10 @@ var _ = Describe("Mapper discovery resources", func() {
 		}))
 
 		var kinds []schema.GroupVersionKind
-		Eventually(func() error {
-			kinds, err = dism.KindsFor(schema.GroupVersionResource{Group: "example.com", Version: "", Resource: "foos"})
-			return err
-		}, time.Second*10, time.Millisecond*300).Should(BeNil())
-		Expect(kinds).Should(Equal([]schema.GroupVersionKind{
+		Eventually(func() []schema.GroupVersionKind {
+			kinds, _ = dism.KindsFor(schema.GroupVersionResource{Group: "example.com", Version: "", Resource: "foos"})
+			return kinds
+		}, time.Second*30, time.Millisecond*300).Should(Equal([]schema.GroupVersionKind{
 			{Group: "example.com", Version: "v1", Kind: "Foo"},
 			{Group: "example.com", Version: "v1beta1", Kind: "Foo"},
 		}))

--- a/test/e2e-test/rollout_plan_test.go
+++ b/test/e2e-test/rollout_plan_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/oam-dev/kubevela/pkg/oam"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -120,6 +122,18 @@ var _ = Describe("Cloneset based rollout tests", func() {
 				app.Spec = targetApp.Spec
 				return k8sClient.Update(ctx, &app)
 			}, time.Second*15, time.Millisecond*500).Should(Succeed())
+
+		By("Get Application Revision created with more than one")
+		Eventually(
+			func() bool {
+				var appRevList = &v1beta1.ApplicationRevisionList{}
+				_ = k8sClient.List(ctx, appRevList, client.MatchingLabels(map[string]string{oam.LabelAppName: targetApp.Name}))
+				if appRevList != nil {
+					return len(appRevList.Items) >= 2
+				}
+				return false
+			},
+			time.Second*30, time.Millisecond*500).Should(BeTrue())
 	}
 
 	createAppRolling := func(newAppRollout *v1beta1.AppRollout) {


### PR DESCRIPTION
```
------------------------------
• Failure [0.197 seconds]
Mapper discovery resources
/home/runner/work/kubevela/kubevela/pkg/oam/discoverymapper/suit_test.go:82
  discovery CRD [It]
  /home/runner/work/kubevela/kubevela/pkg/oam/discoverymapper/suit_test.go:98

  Expected
      <[]schema.GroupVersionKind | len:1, cap:1>: [
          {Group: "example.com", Version: "v1", Kind: "Foo"},
      ]
  to equal
      <[]schema.GroupVersionKind | len:2, cap:2>: [
          {Group: "example.com", Version: "v1", Kind: "Foo"},
          {Group: "example.com", Version: "v1beta1", Kind: "Foo"},
      ]

  /home/runner/work/kubevela/kubevela/pkg/oam/discoverymapper/suit_test.go:170
------------------------------
STEP: Check built-in resource
STEP: CRD should be discovered after refresh

```