### PR TITLE
remove printcolumn AGE from Component/Trait/Workload Definition 

### DIFF
--- a/apis/core.oam.dev/v1alpha2/componentdefinition_types.go
+++ b/apis/core.oam.dev/v1alpha2/componentdefinition_types.go
@@ -71,7 +71,6 @@ type ComponentDefinitionStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="WORKLOAD-KIND",type=string,JSONPath=".spec.workload.definition.kind"
 // +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
-// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type ComponentDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1alpha2/core_types.go
+++ b/apis/core.oam.dev/v1alpha2/core_types.go
@@ -71,7 +71,6 @@ type WorkloadDefinitionStatus struct {
 // Component.
 // +kubebuilder:resource:scope=Namespaced,categories={oam},shortName=workload
 // +kubebuilder:printcolumn:name="DEFINITION-NAME",type=string,JSONPath=".spec.definitionRef.name"
-// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type WorkloadDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -167,7 +166,6 @@ type TraitDefinitionStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="APPLIES-TO",type=string,JSONPath=".spec.appliesToWorkloads"
 // +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
-// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type TraitDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1beta1/componentdefinition_types.go
+++ b/apis/core.oam.dev/v1beta1/componentdefinition_types.go
@@ -72,7 +72,6 @@ type ComponentDefinitionStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="WORKLOAD-KIND",type=string,JSONPath=".spec.workload.definition.kind"
 // +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
-// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type ComponentDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/core.oam.dev/v1beta1/core_types.go
+++ b/apis/core.oam.dev/v1beta1/core_types.go
@@ -72,7 +72,6 @@ type WorkloadDefinitionStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="DEFINITION-NAME",type=string,JSONPath=".spec.definitionRef.name"
 // +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
-// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type WorkloadDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -169,7 +168,6 @@ type TraitDefinitionStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="APPLIES-TO",type=string,JSONPath=".spec.appliesToWorkloads"
 // +kubebuilder:printcolumn:name="DESCRIPTION",type=string,JSONPath=".metadata.annotations.definition\\.oam\\.dev/description"
-// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=".metadata.creationTimestamp"
 type TraitDefinition struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/vela-core/crds/core.oam.dev_componentdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_componentdefinitions.yaml
@@ -26,9 +26,6 @@ spec:
     - jsonPath: .metadata.annotations.definition\.oam\.dev/description
       name: DESCRIPTION
       type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: AGE
-      type: date
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -225,9 +222,6 @@ spec:
     - jsonPath: .metadata.annotations.definition\.oam\.dev/description
       name: DESCRIPTION
       type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: AGE
-      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
@@ -26,9 +26,6 @@ spec:
     - jsonPath: .metadata.annotations.definition\.oam\.dev/description
       name: DESCRIPTION
       type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: AGE
-      type: date
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -209,9 +206,6 @@ spec:
     - jsonPath: .metadata.annotations.definition\.oam\.dev/description
       name: DESCRIPTION
       type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: AGE
-      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/charts/vela-core/crds/core.oam.dev_workloaddefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_workloaddefinitions.yaml
@@ -23,9 +23,6 @@ spec:
     - jsonPath: .spec.definitionRef.name
       name: DEFINITION-NAME
       type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: AGE
-      type: date
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -212,9 +209,6 @@ spec:
     - jsonPath: .metadata.annotations.definition\.oam\.dev/description
       name: DESCRIPTION
       type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: AGE
-      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/docs/en/end-user/labels.md
+++ b/docs/en/end-user/labels.md
@@ -7,14 +7,14 @@ We will introduce how to add labels and annotations to your Application.
 ## List Traits
 
 ```bash
-kubectl get trait -n vela-system
-NAME          APPLIES-TO                DESCRIPTION                                                                                                                           AGE
-annotations   ["webservice","worker"]   Add annotations for your Workload.                                                                                                    24h
-cpuscaler     ["webservice","worker"]   configure k8s HPA with CPU metrics for Deployment                                                                                     24h
-ingress       ["webservice","worker"]   Configures K8s ingress and service to enable web traffic for your service. Please use route trait in cap center for advanced usage.   24h
-labels        ["webservice","worker"]   Add labels for your Workload.                                                                                                         24h
-scaler        ["webservice","worker"]   Configures replicas for your service by patch replicas field.                                                                         24h
-sidecar       ["webservice","worker"]   inject a sidecar container into your app                                                                                              24h
+$ kubectl get trait -n vela-system
+NAME          APPLIES-TO                DESCRIPTION
+annotations   ["webservice","worker"]   Add annotations for your Workload.
+cpuscaler     ["webservice","worker"]   configure k8s HPA with CPU metrics for Deployment
+ingress       ["webservice","worker"]   Configures K8s ingress and service to enable web traffic for your service. Please use route trait in cap center for advanced usage.
+labels        ["webservice","worker"]   Add labels for your Workload.
+scaler        ["webservice","worker"]   Configures replicas for your service by patch replicas field.
+sidecar       ["webservice","worker"]   inject a sidecar container into your app
 ```
 
 You can use `label` and `annotations` traits to add labels and annotations for your workload.

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_componentdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_componentdefinitions.yaml
@@ -14,9 +14,6 @@ spec:
   - JSONPath: .metadata.annotations.definition\.oam\.dev/description
     name: DESCRIPTION
     type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: core.oam.dev
   names:
     categories:

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
@@ -14,9 +14,6 @@ spec:
   - JSONPath: .metadata.annotations.definition\.oam\.dev/description
     name: DESCRIPTION
     type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: core.oam.dev
   names:
     categories:


### PR DESCRIPTION
Remove useless printcolumn field AGE from  Component/Trait/Workload Definition.

```shell
$ kubectl get trait -n vela-system
NAME          APPLIES-TO                DESCRIPTION
annotations   ["webservice","worker"]   Add annotations for your Workload.
cpuscaler     ["webservice","worker"]   configure k8s HPA with CPU metrics for Deployment
ingress       ["webservice","worker"]   Configures K8s ingress and service to enable web traffic for your service. Please use route trait in cap center for advanced usage.
labels        ["webservice","worker"]   Add labels for your Workload.
scaler        ["webservice","worker"]   Configures replicas for your service by patch replicas field.
sidecar       ["webservice","worker"]   inject a sidecar container into your app
```

```shell
$ kubectl get comp -n vela-system
NAME         WORKLOAD-KIND   DESCRIPTION
task         Job             Describes jobs that run code or a script to completion.
webservice   Deployment      Describes long-running, scalable, containerized services that have a stable network endpoint to receive external network traffic from customers.
worker       Deployment      Describes long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic.
```

```shell
$ kubectl get workload -n vela-system
NAME                                  DEFINITION-NAME                       DESCRIPTION
containerizedworkloads.core.oam.dev   containerizedworkloads.core.oam.dev
task                                  jobs.batch                            Describes jobs that run code or a script to completion.
webservice                            deployments.apps                      Describes long-running, scalable, containerized services that have a stable network endpoint to receive external network traffic from customers.
worker                                deployments.apps                      Describes long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic.
```