### PR TITLE
fix cli: fix output of kubectl-vela -h

### DIFF
--- a/pkg/plugin/cli/cli.go
+++ b/pkg/plugin/cli/cli.go
@@ -40,9 +40,9 @@ func NewCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			allCommands := cmd.Commands()
 			cmd.Printf("A Highly Extensible Platform Engine based on Kubernetes and Open Application Model.\n\nUsage:\n  kubectl vela [flags]\n  kubectl vela [command]\n\nAvailable Commands:\n\n")
+			cli.PrintHelpByTag(cmd, allCommands, types.TypePlugin)
 			cmd.Println("Flags:")
 			cmd.Println("  -h, --help   help for vela")
-			cli.PrintHelpByTag(cmd, allCommands, types.TypePlugin)
 			cmd.Println()
 			cmd.Println(`Use "kubectl vela [command] --help" for more information about a command.`)
 		},

--- a/references/cli/help.go
+++ b/references/cli/help.go
@@ -53,7 +53,6 @@ func RunHelp(cmd *cobra.Command, args []string) {
 
 // PrintHelpByTag print custom defined help message
 func PrintHelpByTag(cmd *cobra.Command, all []*cobra.Command, tag string) {
-	cmd.Printf("  %s:\n\n", tag)
 	table := newUITable()
 	for _, c := range all {
 		if val, ok := c.Annotations[types.TagCommandType]; ok && val == tag {


### PR DESCRIPTION
output of kubectl-vela -h

```
$ kubectl vela -h
A Highly Extensible Platform Engine based on Kubernetes and Open Application Model.

Usage:
  kubectl vela [flags]
  kubectl vela [command]

Available Commands:

    dry-run     Dry Run an application, and output the K8s resources as     
                result to stdout, only CUE template supported for now       
    live-diff   Dry-run an application, and do diff on a specific app       
                revison. The provided capability definitions will be used   
                during Dry-run. If any capabilities used in the app are not 
                found in the provided ones, it will try to find from        
                cluster.                                                    
    show        Show the reference doc for a workload type or trait         
    version     Prints out build version information                        

Flags:
  -h, --help   help for vela

Use "kubectl vela [command] --help" for more information about a command.

```