### PR TITLE
Enable "vela show" to support namespaced capability

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -19,8 +19,6 @@ package types
 const (
 	// DefaultKubeVelaNS defines the default KubeVela namespace in Kubernetes
 	DefaultKubeVelaNS = "vela-system"
-	// DefaultNamespace defines the default namespace
-	DefaultNamespace = "default"
 	// DefaultKubeVelaReleaseName defines the default name of KubeVela Release
 	DefaultKubeVelaReleaseName = "kubevela"
 	// DefaultKubeVelaChartName defines the default chart name of KubeVela, this variable MUST align to the chart name of this repo

--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -19,6 +19,8 @@ package types
 const (
 	// DefaultKubeVelaNS defines the default KubeVela namespace in Kubernetes
 	DefaultKubeVelaNS = "vela-system"
+	// DefaultNamespace defines the default namespace
+	DefaultNamespace = "default"
 	// DefaultKubeVelaReleaseName defines the default name of KubeVela Release
 	DefaultKubeVelaReleaseName = "kubevela"
 	// DefaultKubeVelaChartName defines the default chart name of KubeVela, this variable MUST align to the chart name of this repo

--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -50,7 +50,6 @@ var _ = ginkgo.Describe("Test Vela Application", func() {
 	e2e.JsonAppFileContext("deploy app-basic", appbasicJsonAppFile)
 	e2e.JsonAppFileContext("update app-basic, add scaler trait with replicas 2", appbasicAddTraitJsonAppFile)
 	e2e.ComponentListContext("ls", applicationName, workloadType, traitAlias)
-	ApplicationShowContext("show", applicationName, workloadType)
 	ApplicationStatusContext("status", applicationName, workloadType)
 	ApplicationStatusDeeplyContext("status", applicationName, workloadType, envName)
 	ApplicationExecContext("exec -- COMMAND", applicationName)
@@ -101,19 +100,6 @@ var ApplicationStatusDeeplyContext = func(context string, applicationName, workl
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(output).To(gomega.ContainSubstring("Checking health status"))
 			// TODO(zzxwill) need to check workloadType after app status is refined
-		})
-	})
-}
-
-var ApplicationShowContext = func(context string, applicationName string, workloadType string) bool {
-	return ginkgo.Context(context, func() {
-		ginkgo.It("should show app information", func() {
-			cli := fmt.Sprintf("vela show %s", applicationName)
-			output, err := e2e.Exec(cli)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			// TODO(zzxwill) need to check workloadType after app show is refined
-			//gomega.Expect(output).To(gomega.ContainSubstring(workloadType))
-			gomega.Expect(output).To(gomega.ContainSubstring(applicationName))
 		})
 	})
 }

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -182,20 +182,20 @@ var (
 		})
 	}
 
-	ShowCapabilityReference = func(context string, capabilityName, namespace string) bool {
+	ShowCapabilityReference = func(context string, capabilityName string) bool {
 		return ginkgo.Context(context, func() {
 			ginkgo.It("should show capability reference", func() {
-				cli := fmt.Sprintf("vela show %s -n %s", capabilityName, namespace)
+				cli := fmt.Sprintf("vela show %s", capabilityName)
 				_, err := Exec(cli)
 				gomega.Expect(err).Should(gomega.BeNil())
 			})
 		})
 	}
 
-	ShowCapabilityReferenceAbnormally = func(context string, capabilityName, namespace string) bool {
+	ShowCapabilityReferenceAbnormally = func(context string, capabilityName string) bool {
 		return ginkgo.Context(context, func() {
 			ginkgo.It("abnormally show capability reference", func() {
-				cli := fmt.Sprintf("vela show %s -n %s", capabilityName, namespace)
+				cli := fmt.Sprintf("vela show %s", capabilityName)
 				output, err := Exec(cli)
 				gomega.Expect(err).Should(gomega.BeNil())
 				gomega.Expect(output).To(gomega.ContainSubstring(fmt.Sprintf("Error: %s is not a valid workload type or trait", capabilityName)))

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -203,15 +203,4 @@ var (
 			})
 		})
 	}
-
-	ShowCapabilityReferenceAbnormally = func(context string, capabilityName string) bool {
-		return ginkgo.Context(context, func() {
-			ginkgo.It("abnormally show capability reference", func() {
-				cli := fmt.Sprintf("vela show %s", capabilityName)
-				output, err := Exec(cli)
-				gomega.Expect(err).Should(gomega.BeNil())
-				gomega.Expect(output).To(gomega.ContainSubstring(fmt.Sprintf("Error: %s is not a valid workload type or trait", capabilityName)))
-			})
-		})
-	}
 )

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -45,6 +45,18 @@ var (
 		})
 	}
 
+	EnvInitWithNamespaceOptionContext = func(context string, envName string, namespace string) bool {
+		return ginkgo.Context(context, func() {
+			ginkgo.It("should print environment initiation successful message", func() {
+				cli := fmt.Sprintf("vela env init %s --namespace %s", envName, namespace)
+				output, err := Exec(cli)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedOutput := fmt.Sprintf("environment %s created,", envName)
+				gomega.Expect(output).To(gomega.ContainSubstring(expectedOutput))
+			})
+		})
+	}
+
 	JsonAppFileContext = func(context, jsonAppFile string) bool {
 		return ginkgo.Context(context, func() {
 			ginkgo.It("Start the application through the app file in JSON format.", func() {

--- a/e2e/commonContext.go
+++ b/e2e/commonContext.go
@@ -181,4 +181,25 @@ var (
 			})
 		})
 	}
+
+	ShowCapabilityReference = func(context string, capabilityName, namespace string) bool {
+		return ginkgo.Context(context, func() {
+			ginkgo.It("should show capability reference", func() {
+				cli := fmt.Sprintf("vela show %s -n %s", capabilityName, namespace)
+				_, err := Exec(cli)
+				gomega.Expect(err).Should(gomega.BeNil())
+			})
+		})
+	}
+
+	ShowCapabilityReferenceAbnormally = func(context string, capabilityName, namespace string) bool {
+		return ginkgo.Context(context, func() {
+			ginkgo.It("abnormally show capability reference", func() {
+				cli := fmt.Sprintf("vela show %s -n %s", capabilityName, namespace)
+				output, err := Exec(cli)
+				gomega.Expect(err).Should(gomega.BeNil())
+				gomega.Expect(output).To(gomega.ContainSubstring(fmt.Sprintf("Error: %s is not a valid workload type or trait", capabilityName)))
+			})
+		})
+	}
 )

--- a/e2e/env/env_test.go
+++ b/e2e/env/env_test.go
@@ -47,5 +47,4 @@ var _ = ginkgo.Describe("Env", func() {
 
 	e2e.EnvDeleteContext("env delete", envName2)
 	e2e.EnvDeleteCurrentUsingContext("env delete currently using one", envName)
-	// TODO(zzxwill) Delete an env which does not exist
 })

--- a/e2e/trait/trait_test.go
+++ b/e2e/trait/trait_test.go
@@ -27,7 +27,11 @@ var _ = ginkgo.Describe("Trait", func() {
 })
 
 var _ = ginkgo.Describe("Test vela show", func() {
-	e2e.ShowCapabilityReference("show ingress", "ingress", "")
-	e2e.ShowCapabilityReference("show ingress with namespace", "ingress", "vela-system")
-	e2e.ShowCapabilityReferenceAbnormally("abnormally show ingress", "ingress", "namespace-not-existed-xxxfwrr23erfm")
+	e2e.ShowCapabilityReference("show ingress", "ingress")
+
+	env := "namespace-not-existed-traitdefinition-xxxfwrr23erfm"
+	e2e.EnvInitContext("env init", env)
+	e2e.EnvSetContext("env switch", env)
+	e2e.ShowCapabilityReferenceAbnormally("abnormally show ingress", "ingress")
+	e2e.EnvDeleteContext("env delete", env)
 })

--- a/e2e/trait/trait_test.go
+++ b/e2e/trait/trait_test.go
@@ -25,3 +25,9 @@ import (
 var _ = ginkgo.Describe("Trait", func() {
 	e2e.TraitCapabilityListContext()
 })
+
+var _ = ginkgo.Describe("Test vela show", func() {
+	e2e.ShowCapabilityReference("show ingress", "ingress", "")
+	e2e.ShowCapabilityReference("show ingress with namespace", "ingress", "vela-system")
+	e2e.ShowCapabilityReferenceAbnormally("abnormally show ingress", "ingress", "namespace-not-existed-xxxfwrr23erfm")
+})

--- a/e2e/trait/trait_test.go
+++ b/e2e/trait/trait_test.go
@@ -29,10 +29,10 @@ var _ = ginkgo.Describe("Trait", func() {
 var _ = ginkgo.Describe("Test vela show", func() {
 	e2e.ShowCapabilityReference("show ingress", "ingress")
 
-	env := "namespace-not-existed-traitdefinition-xxxfwrr23erfm"
+	env := "namespace-xxxfwrr23erfm"
 	e2e.EnvInitWithNamespaceOptionContext("env init", env, env)
 	e2e.EnvSetContext("env switch", env)
-	e2e.ShowCapabilityReferenceAbnormally("abnormally show ingress", "ingress")
+	e2e.ShowCapabilityReference("show ingress", "ingress")
 	e2e.EnvSetContext("env switch", "default")
 	e2e.EnvDeleteContext("env delete", env)
 })

--- a/e2e/trait/trait_test.go
+++ b/e2e/trait/trait_test.go
@@ -30,8 +30,9 @@ var _ = ginkgo.Describe("Test vela show", func() {
 	e2e.ShowCapabilityReference("show ingress", "ingress")
 
 	env := "namespace-not-existed-traitdefinition-xxxfwrr23erfm"
-	e2e.EnvInitContext("env init", env)
+	e2e.EnvInitWithNamespaceOptionContext("env init", env, env)
 	e2e.EnvSetContext("env switch", env)
 	e2e.ShowCapabilityReferenceAbnormally("abnormally show ingress", "ingress")
+	e2e.EnvSetContext("env switch", "default")
 	e2e.EnvDeleteContext("env delete", env)
 })

--- a/e2e/workload/workload_test.go
+++ b/e2e/workload/workload_test.go
@@ -27,7 +27,11 @@ var _ = ginkgo.Describe("Workload", func() {
 })
 
 var _ = ginkgo.Describe("Test vela show", func() {
-	e2e.ShowCapabilityReference("show webservice", "webservice", "")
-	e2e.ShowCapabilityReference("show webservice with namespace", "webservice", "vela-system")
-	e2e.ShowCapabilityReferenceAbnormally("abnormally show webservice", "webservice", "namespace-not-existed-xxxfwrr23erfm")
+	e2e.ShowCapabilityReference("show webservice", "webservice")
+
+	env := "namespace-not-existed-componentdefinition-xxxfwrr23erfm"
+	e2e.EnvInitContext("env init", env)
+	e2e.EnvSetContext("env switch", env)
+	e2e.ShowCapabilityReferenceAbnormally("abnormally show webservice", "webservice")
+	e2e.EnvDeleteContext("env delete", env)
 })

--- a/e2e/workload/workload_test.go
+++ b/e2e/workload/workload_test.go
@@ -25,3 +25,9 @@ import (
 var _ = ginkgo.Describe("Workload", func() {
 	e2e.WorkloadCapabilityListContext()
 })
+
+var _ = ginkgo.Describe("Test vela show", func() {
+	e2e.ShowCapabilityReference("show webservice", "webservice", "")
+	e2e.ShowCapabilityReference("show webservice with namespace", "webservice", "vela-system")
+	e2e.ShowCapabilityReferenceAbnormally("abnormally show webservice", "webservice", "namespace-not-existed-xxxfwrr23erfm")
+})

--- a/e2e/workload/workload_test.go
+++ b/e2e/workload/workload_test.go
@@ -29,10 +29,10 @@ var _ = ginkgo.Describe("Workload", func() {
 var _ = ginkgo.Describe("Test vela show", func() {
 	e2e.ShowCapabilityReference("show webservice", "webservice")
 
-	env := "namespace-not-existed-componentdefinition-xxxfwrr23erfm"
+	env := "namespace-xxxfwrr23erfm"
 	e2e.EnvInitWithNamespaceOptionContext("env init", env, env)
 	e2e.EnvSetContext("env switch", env)
-	e2e.ShowCapabilityReferenceAbnormally("abnormally show webservice", "webservice")
+	e2e.ShowCapabilityReference("show webservice", "webservice")
 	e2e.EnvSetContext("env switch", "default")
 	e2e.EnvDeleteContext("env delete", env)
 })

--- a/e2e/workload/workload_test.go
+++ b/e2e/workload/workload_test.go
@@ -30,8 +30,9 @@ var _ = ginkgo.Describe("Test vela show", func() {
 	e2e.ShowCapabilityReference("show webservice", "webservice")
 
 	env := "namespace-not-existed-componentdefinition-xxxfwrr23erfm"
-	e2e.EnvInitContext("env init", env)
+	e2e.EnvInitWithNamespaceOptionContext("env init", env, env)
 	e2e.EnvSetContext("env switch", env)
 	e2e.ShowCapabilityReferenceAbnormally("abnormally show webservice", "webservice")
+	e2e.EnvSetContext("env switch", "default")
 	e2e.EnvDeleteContext("env delete", env)
 })

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -58,7 +58,7 @@ const (
 )
 
 var (
-	webSite bool
+	webSite   bool
 	namespace string
 )
 

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -57,7 +57,10 @@ const (
 	Port = ":18081"
 )
 
-var webSite bool
+var (
+	webSite bool
+	namespace string
+)
 
 // NewCapabilityShowCommand shows the reference doc for a workload type or trait
 func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
@@ -75,14 +78,10 @@ func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra
 			}
 			ctx := context.Background()
 			capabilityName := args[0]
-			velaEnv, err := GetEnv(cmd)
-			if err != nil {
-				return err
-			}
 			if webSite {
 				return startReferenceDocsSite(ctx, c, ioStreams, capabilityName)
 			}
-			return ShowReferenceConsole(ctx, c, ioStreams, capabilityName, velaEnv.Namespace)
+			return ShowReferenceConsole(ctx, c, ioStreams, capabilityName, namespace)
 		},
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeStart,
@@ -90,6 +89,7 @@ func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra
 	}
 
 	cmd.Flags().BoolVarP(&webSite, "web", "", false, " start web doc site")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace of the workload type or trait")
 	cmd.SetOut(ioStreams.Out)
 	return cmd
 }
@@ -340,19 +340,7 @@ func getComponentsAndTraits(capabilities []types.Capability) ([]string, []string
 
 // ShowReferenceConsole will show capability reference in console
 func ShowReferenceConsole(ctx context.Context, c common.Args, ioStreams cmdutil.IOStreams, capabilityName string, ns string) error {
-	home, err := system.GetVelaHomeDir()
-	if err != nil {
-		return err
-	}
-	referenceHome := filepath.Join(home, "reference")
-
-	definitionPath := filepath.Join(referenceHome, "capabilities")
-	if _, err := os.Stat(definitionPath); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(definitionPath, 0750); err != nil {
-			return err
-		}
-	}
-	capability, err := plugins.SyncDefinitionToLocal(ctx, c, definitionPath, capabilityName, ns)
+	capability, err := plugins.SyncDefinitionToLocal(ctx, c, capabilityName, ns)
 	if err != nil {
 		return err
 	}

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -57,10 +57,7 @@ const (
 	Port = ":18081"
 )
 
-var (
-	webSite   bool
-	namespace string
-)
+var webSite bool
 
 // NewCapabilityShowCommand shows the reference doc for a workload type or trait
 func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
@@ -78,10 +75,14 @@ func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra
 			}
 			ctx := context.Background()
 			capabilityName := args[0]
+			velaEnv, err := GetEnv(cmd)
+			if err != nil {
+				return err
+			}
 			if webSite {
 				return startReferenceDocsSite(ctx, c, ioStreams, capabilityName)
 			}
-			return ShowReferenceConsole(ctx, c, ioStreams, capabilityName, namespace)
+			return ShowReferenceConsole(ctx, c, ioStreams, capabilityName, velaEnv.Namespace)
 		},
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeStart,
@@ -89,7 +90,6 @@ func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra
 	}
 
 	cmd.Flags().BoolVarP(&webSite, "web", "", false, " start web doc site")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace of the workload type or trait")
 	cmd.SetOut(ioStreams.Out)
 	return cmd
 }

--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -259,7 +259,7 @@ func SyncDefinitionToLocal(ctx context.Context, c common.Args, capabilityName st
 	err = newClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: capabilityName}, &componentDef)
 	if err == nil {
 		foundCapability = true
-	} else if kerrors.IsNotFound(err) && ns != types.DefaultKubeVelaNS {
+	} else if kerrors.IsNotFound(err) && ns == types.DefaultNamespace {
 		err = newClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: capabilityName}, &componentDef)
 		if err == nil {
 			foundCapability = true
@@ -287,7 +287,7 @@ func SyncDefinitionToLocal(ctx context.Context, c common.Args, capabilityName st
 	err = newClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: capabilityName}, &traitDef)
 	if err == nil {
 		foundCapability = true
-	} else if kerrors.IsNotFound(err) && ns != types.DefaultKubeVelaNS {
+	} else if kerrors.IsNotFound(err) && ns == types.DefaultNamespace {
 		err = newClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: capabilityName}, &traitDef)
 		if err == nil {
 			foundCapability = true

--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -249,9 +249,8 @@ func SyncDefinitionsToLocal(ctx context.Context, c common.Args, localDefinitionD
 }
 
 // SyncDefinitionToLocal sync definitions to local
-func SyncDefinitionToLocal(ctx context.Context, c common.Args, localDefinitionDir string, capabilityName string, ns string) (*types.Capability, error) {
+func SyncDefinitionToLocal(ctx context.Context, c common.Args, capabilityName string, ns string) (*types.Capability, error) {
 	var foundCapability bool
-
 	newClient, err := c.GetClient()
 	if err != nil {
 		return nil, err
@@ -260,7 +259,7 @@ func SyncDefinitionToLocal(ctx context.Context, c common.Args, localDefinitionDi
 	err = newClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: capabilityName}, &componentDef)
 	if err == nil {
 		foundCapability = true
-	} else if kerrors.IsNotFound(err) {
+	} else if kerrors.IsNotFound(err) && ns != types.DefaultKubeVelaNS {
 		err = newClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: capabilityName}, &componentDef)
 		if err == nil {
 			foundCapability = true
@@ -285,9 +284,14 @@ func SyncDefinitionToLocal(ctx context.Context, c common.Args, localDefinitionDi
 
 	foundCapability = false
 	var traitDef v1beta1.TraitDefinition
-	err = newClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: capabilityName}, &traitDef)
+	err = newClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: capabilityName}, &traitDef)
 	if err == nil {
 		foundCapability = true
+	} else if kerrors.IsNotFound(err) && ns != types.DefaultKubeVelaNS {
+		err = newClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: capabilityName}, &traitDef)
+		if err == nil {
+			foundCapability = true
+		}
 	}
 	if foundCapability {
 		template, err := HandleDefinition(capabilityName, traitDef.Spec.Reference.Name,

--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -259,7 +259,7 @@ func SyncDefinitionToLocal(ctx context.Context, c common.Args, capabilityName st
 	err = newClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: capabilityName}, &componentDef)
 	if err == nil {
 		foundCapability = true
-	} else if kerrors.IsNotFound(err) && ns == types.DefaultNamespace {
+	} else if kerrors.IsNotFound(err) {
 		err = newClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: capabilityName}, &componentDef)
 		if err == nil {
 			foundCapability = true
@@ -287,7 +287,7 @@ func SyncDefinitionToLocal(ctx context.Context, c common.Args, capabilityName st
 	err = newClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: capabilityName}, &traitDef)
 	if err == nil {
 		foundCapability = true
-	} else if kerrors.IsNotFound(err) && ns == types.DefaultNamespace {
+	} else if kerrors.IsNotFound(err) {
 		err = newClient.Get(ctx, client.ObjectKey{Namespace: types.DefaultKubeVelaNS, Name: capabilityName}, &traitDef)
 		if err == nil {
 			foundCapability = true


### PR DESCRIPTION
If env is default, and capabilities are located in
vela-system, it will continue to retrieve the capability in
vela-system directory.

Fix #1520