### PR TITLE
Clean the docs of the applicationdeployments.core.oam.dev

### DIFF
--- a/docs/en/advanced-install.md
+++ b/docs/en/advanced-install.md
@@ -108,7 +108,6 @@ Then clean up CRDs (CRDs are not removed via helm by default):
   appdeployments.core.oam.dev \
   applicationconfigurations.core.oam.dev \
   applicationcontexts.core.oam.dev \
-  applicationdeployments.core.oam.dev \
   applicationrevisions.core.oam.dev \
   applications.core.oam.dev \
   approllouts.core.oam.dev \


### PR DESCRIPTION
fix #1529 
As I see, the legacy file of the `applicationdeployments.core.oam.dev` has removed at this pr: #1166.
So I just removed a line of the doc.