### PR TITLE
fix cli: vela show support list the parameter of ComponentDefinition which use helm charts

### DIFF
--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -38,15 +38,16 @@ type CRDInfo struct {
 
 // Capability defines the content of a capability
 type Capability struct {
-	Name           string      `json:"name"`
-	Type           CapType     `json:"type"`
-	CueTemplate    string      `json:"template,omitempty"`
-	CueTemplateURI string      `json:"templateURI,omitempty"`
-	Parameters     []Parameter `json:"parameters,omitempty"`
-	CrdName        string      `json:"crdName,omitempty"`
-	Center         string      `json:"center,omitempty"`
-	Status         string      `json:"status,omitempty"`
-	Description    string      `json:"description,omitempty"`
+	Name           string             `json:"name"`
+	Type           CapType            `json:"type"`
+	CueTemplate    string             `json:"template,omitempty"`
+	CueTemplateURI string             `json:"templateURI,omitempty"`
+	Parameters     []Parameter        `json:"parameters,omitempty"`
+	CrdName        string             `json:"crdName,omitempty"`
+	Center         string             `json:"center,omitempty"`
+	Status         string             `json:"status,omitempty"`
+	Description    string             `json:"description,omitempty"`
+	Category       CapabilityCategory `json:"category,omitempty"`
 
 	// trait only
 	AppliesTo []string `json:"appliesTo,omitempty"`
@@ -121,6 +122,7 @@ type Parameter struct {
 	Usage    string      `json:"usage,omitempty"`
 	Type     cue.Kind    `json:"type,omitempty"`
 	Alias    string      `json:"alias,omitempty"`
+	JSONType string      `json:"jsonType,omitempty"`
 }
 
 // SetFlagBy set cli flag from Parameter

--- a/e2e/plugin/plugin_suit_test.go
+++ b/e2e/plugin/plugin_suit_test.go
@@ -43,6 +43,7 @@ var app v1beta1.Application
 var testShowCdDef v1beta1.ComponentDefinition
 var testShowTdDef v1beta1.TraitDefinition
 var testCdDef v1beta1.ComponentDefinition
+var testCdDefWithHelm v1beta1.ComponentDefinition
 var testTdDef v1beta1.TraitDefinition
 
 func TestKubectlPlugin(t *testing.T) {
@@ -75,6 +76,10 @@ var _ = BeforeSuite(func(done Done) {
 	err = k8sClient.Create(ctx, &testCdDef)
 	Expect(err).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
 
+	Expect(yaml.Unmarshal([]byte(componentDefWithHelm), &testCdDefWithHelm)).Should(BeNil())
+	err = k8sClient.Create(ctx, &testCdDefWithHelm)
+	Expect(err).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
 	Expect(yaml.Unmarshal([]byte(traitDef), &testTdDef)).Should(BeNil())
 	err = k8sClient.Create(ctx, &testTdDef)
 	Expect(err).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
@@ -99,6 +104,7 @@ var _ = AfterSuite(func() {
 	By("delete application and definitions")
 	Expect(k8sClient.Delete(ctx, &app)).Should(BeNil())
 	Expect(k8sClient.Delete(ctx, &testCdDef)).Should(BeNil())
+	Expect(k8sClient.Delete(ctx, &testCdDefWithHelm)).Should(BeNil())
 	Expect(k8sClient.Delete(ctx, &testTdDef)).Should(BeNil())
 	Expect(k8sClient.Delete(ctx, &testShowCdDef)).Should(BeNil())
 	Expect(k8sClient.Delete(ctx, &testShowTdDef)).Should(BeNil())

--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -117,6 +117,12 @@ var _ = Describe("Test Kubectl Plugin", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).Should(Equal(showTdResult))
 		})
+		It("Test show componentDefinition use Helm Charts as Workload", func() {
+			cdName := "test-webapp-chart"
+			output, err := e2e.Exec(fmt.Sprintf("kubectl-vela show %s", cdName))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).Should(ContainSubstring("Properties"))
+		})
 	})
 })
 
@@ -342,6 +348,30 @@ spec:
         	}]
         }
 
+`
+
+var componentDefWithHelm = `
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: test-webapp-chart
+  namespace: default
+  annotations:
+    definition.oam.dev/description: helm chart for webapp
+spec:
+  workload:
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+  schematic:
+    helm:
+      release:
+        chart:
+          spec:
+            chart: "podinfo"
+            version: "5.1.4"
+      repository:
+        url: "http://oam.dev/catalog/"
 `
 
 var traitDef = `

--- a/hack/references/generate.go
+++ b/hack/references/generate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -25,7 +26,8 @@ import (
 
 func main() {
 	ref := &plugins.MarkdownReference{}
-	if err := ref.GenerateReferenceDocs(plugins.BaseRefPath); err != nil {
+	ctx := context.Background()
+	if err := ref.GenerateReferenceDocs(ctx, plugins.BaseRefPath); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -132,8 +132,18 @@ func startReferenceDocsSite(ctx context.Context, c common.Args, ioStreams cmduti
 	if !capabilityIsValid {
 		return fmt.Errorf("%s is not a valid component type or trait", capabilityName)
 	}
-	ref := &plugins.MarkdownReference{}
-	if err := ref.CreateMarkdown(capabilities, docsPath, plugins.ReferenceSourcePath); err != nil {
+
+	cli, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	ref := &plugins.MarkdownReference{
+		ParseReference: plugins.ParseReference{
+			Client: cli,
+		},
+	}
+
+	if err := ref.CreateMarkdown(ctx, capabilities, docsPath, plugins.ReferenceSourcePath); err != nil {
 		return err
 	}
 
@@ -357,15 +367,20 @@ func ShowReferenceConsole(ctx context.Context, c common.Args, ioStreams cmdutil.
 		return err
 	}
 
-	ref := &plugins.ConsoleReference{}
+	cli, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	ref := &plugins.ConsoleReference{
+		ParseReference: plugins.ParseReference{
+			Client: cli,
+		},
+	}
+
 	var propertyConsole []plugins.ConsoleReference
 	switch capability.Category {
 	case types.HelmCategory:
-		cli, err := c.GetClient()
-		if err != nil {
-			return err
-		}
-		propertyConsole, err = ref.GenerateHELMProperties(ctx, cli, capability)
+		_, propertyConsole, err = ref.GenerateHELMProperties(ctx, capability)
 		if err != nil {
 			return err
 		}

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -358,9 +358,24 @@ func ShowReferenceConsole(ctx context.Context, c common.Args, ioStreams cmdutil.
 	}
 
 	ref := &plugins.ConsoleReference{}
-	propertyConsole, err := ref.GenerateCapabilityProperties(capability)
-	if err != nil {
-		return err
+	var propertyConsole []plugins.ConsoleReference
+	switch capability.Category {
+	case types.HelmCategory:
+		cli, err := c.GetClient()
+		if err != nil {
+			return err
+		}
+		propertyConsole, err = ref.GenerateHELMProperties(ctx, cli, capability)
+		if err != nil {
+			return err
+		}
+	case types.CUECategory:
+		propertyConsole, err = ref.GenerateCUETemplateProperties(capability)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupport capability category %s", capability.Category)
 	}
 	for _, p := range propertyConsole {
 		ioStreams.Info(p.TableName)

--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -205,15 +205,17 @@ func HandleTemplate(in *runtime.RawExtension, schematic *commontypes.Schematic, 
 		tmp.CueTemplate = string(b)
 	}
 	if tmp.CueTemplate == "" {
+		if schematic != nil && schematic.HELM != nil {
+			tmp.Category = types.HelmCategory
+			return tmp, nil
+		}
 		return types.Capability{}, errors.New("template not exist in definition")
-	}
-	if err != nil {
-		return types.Capability{}, err
 	}
 	tmp.Parameters, err = cue.GetParameters(tmp.CueTemplate)
 	if err != nil {
 		return types.Capability{}, err
 	}
+	tmp.Category = types.CUECategory
 	return tmp, nil
 }
 
@@ -279,6 +281,7 @@ func SyncDefinitionToLocal(ctx context.Context, c common.Args, localDefinitionDi
 		template, err := HandleDefinition(capabilityName, ref.Name,
 			componentDef.Annotations, componentDef.Spec.Extension, types.TypeComponentDefinition, nil, componentDef.Spec.Schematic)
 		if err == nil {
+			template.Namespace = componentDef.Namespace
 			return &template, nil
 		}
 	}
@@ -293,6 +296,7 @@ func SyncDefinitionToLocal(ctx context.Context, c common.Args, localDefinitionDi
 		template, err := HandleDefinition(capabilityName, traitDef.Spec.Reference.Name,
 			traitDef.Annotations, traitDef.Spec.Extension, types.TypeTrait, nil, traitDef.Spec.Schematic)
 		if err == nil {
+			template.Namespace = traitDef.Namespace
 			return &template, nil
 		}
 	}

--- a/references/plugins/cluster_test.go
+++ b/references/plugins/cluster_test.go
@@ -48,6 +48,7 @@ var _ = Describe("DefinitionFiles", func() {
 		Type:        types.TypeComponentDefinition,
 		CrdName:     "deployments.apps",
 		Description: "description not defined",
+		Category:    types.CUECategory,
 		Parameters: []types.Parameter{
 			{
 				Type: cue.ListKind,
@@ -80,6 +81,7 @@ var _ = Describe("DefinitionFiles", func() {
 		Name:        WebserviceName,
 		Type:        types.TypeComponentDefinition,
 		Description: "description not defined",
+		Category:    types.CUECategory,
 		Parameters: []types.Parameter{{
 			Name: "env", Type: cue.ListKind,
 		}, {

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -18,12 +18,15 @@ package plugins
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
@@ -126,5 +129,199 @@ func TestDeleteRefTestDir(t *testing.T) {
 	if _, err := os.Stat(RefTestDir); err == nil {
 		err := os.RemoveAll(RefTestDir)
 		assert.NoError(t, err)
+	}
+}
+
+func TestWalkParameterSchema(t *testing.T) {
+	testcases := []struct {
+		data       string
+		ExpectRefs map[string]map[string]ReferenceParameter
+	}{
+		{
+			data: `{
+    "properties": {
+        "cmd": {
+            "description": "Commands to run in the container", 
+            "items": {
+                "type": "string"
+            }, 
+            "title": "cmd", 
+            "type": "array"
+        }, 
+        "image": {
+            "description": "Which image would you like to use for your service", 
+            "title": "image", 
+            "type": "string"
+        }
+    }, 
+    "required": [
+        "image"
+    ], 
+    "type": "object"
+}`,
+			ExpectRefs: map[string]map[string]ReferenceParameter{
+				"# Properties": {
+					"cmd": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "cmd",
+							Usage:    "Commands to run in the container",
+							JSONType: "array",
+						},
+						PrintableType: "array",
+					},
+					"image": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "image",
+							Required: true,
+							Usage:    "Which image would you like to use for your service",
+							JSONType: "string",
+						},
+						PrintableType: "string",
+					},
+				},
+			},
+		},
+		{
+			data: `{
+    "properties": { 
+        "obj": {
+            "properties": {
+                "f0": {
+                    "default": "v0", 
+                    "type": "string"
+                }, 
+                "f1": {
+                    "default": "v1", 
+                    "type": "string"
+                }, 
+                "f2": {
+                    "default": "v2", 
+                    "type": "string"
+                }
+            }, 
+            "type": "object"
+        },
+    }, 
+    "type": "object"
+}`,
+			ExpectRefs: map[string]map[string]ReferenceParameter{
+				"# Properties": {
+					"obj": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "obj",
+							JSONType: "object",
+						},
+						PrintableType: "[obj](#obj)",
+					},
+				},
+				"## obj": {
+					"f0": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "f0",
+							Default:  "v0",
+							JSONType: "string",
+						},
+						PrintableType: "string",
+					},
+					"f1": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "f1",
+							Default:  "v1",
+							JSONType: "string",
+						},
+						PrintableType: "string",
+					},
+					"f2": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "f2",
+							Default:  "v2",
+							JSONType: "string",
+						},
+						PrintableType: "string",
+					},
+				},
+			},
+		},
+		{
+			data: `{
+    "properties": {
+        "obj": {
+            "properties": {
+                "f0": {
+                    "default": "v0", 
+                    "type": "string"
+                }, 
+                "f1": {
+                    "default": "v1", 
+                    "type": "object", 
+                    "properties": {
+                        "g0": {
+                            "default": "v2", 
+                            "type": "string"
+                        }
+                    }
+                }
+            }, 
+            "type": "object"
+        }
+    }, 
+    "type": "object"
+}`,
+			ExpectRefs: map[string]map[string]ReferenceParameter{
+				"# Properties": {
+					"obj": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "obj",
+							JSONType: "object",
+						},
+						PrintableType: "[obj](#obj)",
+					},
+				},
+				"## obj": {
+					"f0": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "f0",
+							Default:  "v0",
+							JSONType: "string",
+						},
+						PrintableType: "string",
+					},
+					"f1": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "f1",
+							Default:  "v1",
+							JSONType: "object",
+						},
+						PrintableType: "[f1](#f1)",
+					},
+				},
+				"### f1": {
+					"g0": ReferenceParameter{
+						Parameter: types.Parameter{
+							Name:     "g0",
+							Default:  "v2",
+							JSONType: "string",
+						},
+						PrintableType: "string",
+					},
+				},
+			},
+		},
+	}
+	for _, cases := range testcases {
+		helmRefs = make([]HELMReference, 0)
+		parameterJSON := fmt.Sprintf(BaseOpenAPIV3Template, cases.data)
+		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData(json.RawMessage(parameterJSON))
+		assert.Equal(t, nil, err)
+		parameters := swagger.Components.Schemas["parameter"].Value
+		WalkParameterSchema(parameters, "Properties", 0)
+		refs := make(map[string]map[string]ReferenceParameter)
+		for _, items := range helmRefs {
+			refs[items.Name] = make(map[string]ReferenceParameter)
+			for _, item := range items.Parameters {
+				refs[items.Name][item.Name] = item
+			}
+		}
+		assert.Equal(t, true, reflect.DeepEqual(cases.ExpectRefs, refs))
 	}
 }

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -89,9 +90,10 @@ parameter: {
 		},
 	}
 	ref := &MarkdownReference{}
+	ctx := context.Background()
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := ref.CreateMarkdown(tc.capabilities, RefTestDir, ReferenceSourcePath)
+			got := ref.CreateMarkdown(ctx, tc.capabilities, RefTestDir, ReferenceSourcePath)
 			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nCreateMakrdown(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
@@ -113,7 +115,7 @@ func TestPrepareParameterTable(t *testing.T) {
 	parameterName := "cpu"
 	parameterList[0].Name = parameterName
 	parameterList[0].Required = true
-	refContent := ref.prepareParameter(tableName, parameterList)
+	refContent := ref.prepareParameter(tableName, parameterList, types.CUECategory)
 	assert.Contains(t, refContent, parameterName)
 	assert.Contains(t, refContent, "cpu")
 }

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -69,11 +69,13 @@ parameter: {
 					Name:        workloadName,
 					Type:        types.TypeWorkload,
 					CueTemplate: workloadCueTemplate,
+					Category:    types.CUECategory,
 				},
 				{
 					Name:        traitName,
 					Type:        types.TypeTrait,
 					CueTemplate: traitCueTemplate,
+					Category:    types.CUECategory,
 				},
 			},
 			want: nil,

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -295,8 +295,7 @@ func (ref *MarkdownReference) CreateMarkdown(ctx context.Context, caps []types.C
 				return fmt.Errorf("failed to retrieve `parameters` value from %s with err: %w", c.Name, err)
 			}
 			for _, property := range properties {
-				tableName := fmt.Sprintf("%s %s", strings.Repeat("#", property.Depth+2), property.Name)
-				refContent += ref.prepareParameter(tableName, property.Parameters, types.HelmCategory)
+				refContent += ref.prepareParameter("#"+property.Name, property.Parameters, types.HelmCategory)
 			}
 		default:
 			return fmt.Errorf("unsupport capability category %s", c.Category)
@@ -336,7 +335,7 @@ func (ref *MarkdownReference) prepareParameter(tableName string, parameterList [
 	case types.HelmCategory:
 		for _, p := range parameterList {
 			printableDefaultValue := ref.getHELMPrintableDefaultValue(p.JSONType, p.Default)
-			refContent += fmt.Sprintf(" %s | %s | %s | %t | %s \n", p.Name, p.Usage, p.PrintableType, p.Required, printableDefaultValue)
+			refContent += fmt.Sprintf(" %s | %s | %s | %t | %s \n", p.Name, strings.ReplaceAll(p.Usage, "\n", ""), p.PrintableType, p.Required, printableDefaultValue)
 		}
 	default:
 	}
@@ -586,13 +585,13 @@ func WalkParameterSchema(parameters *openapi3.Schema, name string, depth int) {
 					Schemas: v.Value,
 				})
 			}
-			p.PrintableType += fmt.Sprintf("(%s)", k)
+			p.PrintableType = fmt.Sprintf("[%s](#%s)", k, k)
 		}
 		helmParameters = append(helmParameters, p)
 	}
 
 	helmRefs = append(helmRefs, HELMReference{
-		Name:       name,
+		Name:       fmt.Sprintf("%s %s", strings.Repeat("#", depth+1), name),
 		Parameters: helmParameters,
 		Depth:      depth + 1,
 	})


### PR DESCRIPTION
fix https://github.com/oam-dev/kubevela/issues/1394

vela show now support list the parameter of ComponentDefinition which use helm charts as workload. 

When a new ComponentDefinition use helm charts is registered,  the ComponentDefinition controller will parse
the values.yaml in charts and store as openapi into configMap. (refer to https://github.com/oam-dev/kubevela/pull/1250)

vela show will get the openapi data in configMap, and list the parameters to the terminal.

take [webapp-chart](https://github.com/oam-dev/kubevela/blob/master/docs/examples/helm-module/webapp-chart-cd.yaml) as an example.

``` 
$ vela show webapp-chart
# Properties
+----------------+-------------------------------------------+-----------------------------------+----------+---------+
|      NAME      |                DESCRIPTION                |               TYPE                | REQUIRED | DEFAULT |
+----------------+-------------------------------------------+-----------------------------------+----------+---------+
| backends       |                                           | array                             | false    | []      |
| faults         |                                           | [faults](#faults)                 | false    | {}      |
| linkerd        |                                           | [linkerd](#linkerd)               | false    | {}      |
| serviceMonitor |                                           | [serviceMonitor](#serviceMonitor) | false    | {}      |
| ui             |                                           | [ui](#ui)                         | false    | {}      |
| podAnnotations |                                           | [podAnnotations](#podAnnotations) | false    | {}      |
| resources      |                                           | [resources](#resources)           | false    | {}      |
| tolerations    |                                           | array                             | false    | []      |
| affinity       |                                           | [affinity](#affinity)             | false    | {}      |
| backend        |                                           |                                   | false    |         |
| certificate    | create a certificate manager certificate  | [certificate](#certificate)       | false    | {}      |
| image          |                                           | [image](#image)                   | false    | {}      |
| logLevel       |                                           | string                            | false    | info    |
| redis          | Redis deployment                          | [redis](#redis)                   | false    | {}      |
| serviceAccount |                                           | [serviceAccount](#serviceAccount) | false    | {}      |
| cache          | Redis address in the format <host>:<port> | string                            | false    |         |
| h2c            |                                           | [h2c](#h2c)                       | false    | {}      |
| hpa            | metrics-server add-on required            | [hpa](#hpa)                       | false    | {}      |
| ingress        |                                           | [ingress](#ingress)               | false    | {}      |
| nodeSelector   |                                           | [nodeSelector](#nodeSelector)     | false    | {}      |
| replicaCount   |                                           | integer                           | false    |       1 |
| service        |                                           | [service](#service)               | false    | {}      |
| tls            | enable tls on the podinfo service         | [tls](#tls)                       | false    | {}      |
+----------------+-------------------------------------------+-----------------------------------+----------+---------+


## faults
+-------------+-------------+---------+----------+---------+
|    NAME     | DESCRIPTION |  TYPE   | REQUIRED | DEFAULT |
+-------------+-------------+---------+----------+---------+
| testFail    |             | boolean | false    | false   |
| testTimeout |             | boolean | false    | false   |
| unhealthy   |             | boolean | false    | false   |
| unready     |             | boolean | false    | false   |
| delay       |             | boolean | false    | false   |
| error       |             | boolean | false    | false   |
+-------------+-------------+---------+----------+---------+


## linkerd
+---------+-------------+---------------------+----------+---------+
|  NAME   | DESCRIPTION |        TYPE         | REQUIRED | DEFAULT |
+---------+-------------+---------------------+----------+---------+
| profile |             | [profile](#profile) | false    | {}      |
+---------+-------------+---------------------+----------+---------+


### profile
+---------+-------------+---------+----------+---------+
|  NAME   | DESCRIPTION |  TYPE   | REQUIRED | DEFAULT |
+---------+-------------+---------+----------+---------+
| enabled |             | boolean | false    | false   |
+---------+-------------+---------+----------+---------+


## serviceMonitor
+----------+-------------+---------+----------+---------+
|   NAME   | DESCRIPTION |  TYPE   | REQUIRED | DEFAULT |
+----------+-------------+---------+----------+---------+
| enabled  |             | boolean | false    | false   |
| interval |             | string  | false    | 15s     |
+----------+-------------+---------+----------+---------+


## ui
+---------+-------------+--------+----------+---------+
|  NAME   | DESCRIPTION |  TYPE  | REQUIRED | DEFAULT |
+---------+-------------+--------+----------+---------+
| color   |             | string | false    | #34577c |
| logo    |             | string | false    |         |
| message |             | string | false    |         |
+---------+-------------+--------+----------+---------+


## resources
+----------+-------------+-----------------------+----------+---------+
|   NAME   | DESCRIPTION |         TYPE          | REQUIRED | DEFAULT |
+----------+-------------+-----------------------+----------+---------+
| limits   |             |                       | false    |         |
| requests |             | [requests](#requests) | false    | {}      |
+----------+-------------+-----------------------+----------+---------+


### requests
+--------+-------------+--------+----------+---------+
|  NAME  | DESCRIPTION |  TYPE  | REQUIRED | DEFAULT |
+--------+-------------+--------+----------+---------+
| cpu    |             | string | false    | 1m      |
| memory |             | string | false    | 16Mi    |
+--------+-------------+--------+----------+---------+


## certificate
+-----------+--------------------------------------------------------------+-------------------------+----------+-----------+
|   NAME    |                         DESCRIPTION                          |          TYPE           | REQUIRED |  DEFAULT  |
+-----------+--------------------------------------------------------------+-------------------------+----------+-----------+
| create    |                                                              | boolean                 | false    | false     |
| dnsNames  | the hostname / subject alternative names for the certificate | array                   | false    | [podinfo] |
| issuerRef | the issuer used to issue the certificate                     | [issuerRef](#issuerRef) | false    | {}        |
+-----------+--------------------------------------------------------------+-------------------------+----------+-----------+


### issuerRef
+------+-------------+--------+----------+---------------+
| NAME | DESCRIPTION |  TYPE  | REQUIRED |    DEFAULT    |
+------+-------------+--------+----------+---------------+
| kind |             | string | false    | ClusterIssuer |
| name |             | string | false    | self-signed   |
+------+-------------+--------+----------+---------------+

.......
```

```
vela show webapp-chart --web
```

![截屏2021-04-22 上午11 24 17](https://user-images.githubusercontent.com/29531394/115651252-63685500-a35d-11eb-8479-6739786700b3.png)
