### PR TITLE
Redirect to Discussions if users want to open Question issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,1 +1,0 @@
-blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Help
+    url: https://github.com/oam-dev/kubevela/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
It will help direct developers to our recommended `Discussions` when trying to create a Question issue by `Issues --> new issue`.
![image](https://user-images.githubusercontent.com/2805315/115646625-1c766180-a355-11eb-8f70-916509d668b9.png)
