### PR TITLE
docs: remove the command prompt to support fast copy/paste

### DIFF
--- a/docs/en/install.mdx
+++ b/docs/en/install.mdx
@@ -196,7 +196,7 @@ KubeVela leverages Helm controller from [Flux v2](https://github.com/fluxcd/flux
 You can enable this feature by installing a minimal Flux v2 chart as below:
 
 ```shell
-$ helm install --create-namespace -n flux-system helm-flux http://oam.dev/catalog/helm-flux2-0.1.0.tgz
+helm install --create-namespace -n flux-system helm-flux http://oam.dev/catalog/helm-flux2-0.1.0.tgz
 ```
 
 Or you could install full Flux v2 following its own guide of course.


### PR DESCRIPTION
The copied command that starts with `$` will not execute correctly.
This PR removes the command prompt to support fast copy/paste.