### PR TITLE
Fix cue parameter

### DIFF
--- a/docs/en/end-user/labels.md
+++ b/docs/en/end-user/labels.md
@@ -39,10 +39,12 @@ spec:
       traits:
         - type: labels
           properties:
-            "release": "stable"
+            labels:
+              "release": "stable"
         - type: annotations
           properties:
-            "description": "web application"
+            annotations
+              "description": "web application"
 ```
 
 Apply this Application.

--- a/hack/vela-templates/cue/annotations.cue
+++ b/hack/vela-templates/cue/annotations.cue
@@ -1,8 +1,10 @@
 patch: {
 	spec: template: metadata: annotations: {
-		for k, v in parameter {
+		for k, v in parameter.annotations {
 			"\(k)": v
 		}
 	}
 }
-parameter: [string]: string
+parameter:{
+	annotations: [string]: string
+}

--- a/hack/vela-templates/cue/labels.cue
+++ b/hack/vela-templates/cue/labels.cue
@@ -1,8 +1,10 @@
 patch: {
 	spec: template: metadata: labels: {
-		for k, v in parameter {
+		for k, v in parameter.labels {
 			"\(k)": v
 		}
 	}
 }
-parameter: [string]: string
+parameter: {
+	labels: [string]: string
+}


### PR DESCRIPTION
#### get annotations traitdefinitions 
```
 kubectl get  -n vela-system traitdefinitions.core.oam.dev  annotations -oyaml 
```
#### see 
```
status:
  conditions:
  - lastTransitionTime: "2021-04-22T09:04:25Z"
    message: 'cannot store capability annotations in ConfigMap: cannot generate OpenAPI
      v3 JSON schema for capability annotations: capability annotations doesn''t contain
      section `parameter`'
    reason: ReconcileError
```
#### cause：
```
#annotations.cue kubevela/hack/vela-templates/cue/annotations.cue
patch: {
	spec: template: metadata: annotations: {
		for k, v in parameter {
			"\(k)": v
		}
	}
}
parameter: [string]: string
```

#### after change to 
```
patch: {
	spec: template: metadata: annotations: {
		for k, v in parameter.annotations {
			"\(k)": v
		}
	}
}
parameter:{
	annotations: [string]: string
}
```
status：
```
#### status:
  configMapRef: schema-annotations
```
#### comfigmap store success

#### test case
```
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: website
spec:
  components:
    - name: frontend
      type: webservice
      properties:
        image: nginx
      traits:
        - type: labels
          properties:
            labels:
               bbb: bb
        - type: annotations
          properties:
            annotations:
               aaa: aaa
```

