### PR TITLE
fix bug: enable gc when definitionRevision is not a new revision

### DIFF
--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -97,6 +97,11 @@ const (
 	// ErrUpdateCapabilityInConfigMap is the error while creating or updating a capability
 	ErrUpdateCapabilityInConfigMap = "cannot create or update capability %s in ConfigMap: %v"
 
+	// ErrUpdateComponentDefinition is the error while update ComponentDefinition
+	ErrUpdateComponentDefinition = "cannot update ComponentDefinition %s: %v"
+	// ErrUpdateTraitDefinition is the error while update TraitDefinition
+	ErrUpdateTraitDefinition = "cannot update TraitDefinition %s: %v"
+
 	// ErrCreateConvertedWorklaodDefinition is the error while apply a WorkloadDefinition
 	ErrCreateConvertedWorklaodDefinition = "cannot create converted WorkloadDefinition %s: %v"
 


### PR DESCRIPTION
When definitionRevision is not a new Revision, the controller still need to trigger the GC mechanism, This will fix failed cases in unit-tests.