### PR TITLE
Check whether parameter.cmd is nill for sidecar trait

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/sidecar.yaml
+++ b/charts/vela-core/templates/defwithtemplate/sidecar.yaml
@@ -16,9 +16,11 @@ spec:
         patch: {
         	// +patchKey=name
         	spec: template: spec: containers: [{
-        		name:    parameter.name
-        		image:   parameter.image
-        		command: parameter.cmd
+        		name:  parameter.name
+        		image: parameter.image
+        		if parameter.cmd != _|_ {
+        			command: parameter.cmd
+        		}
         		if parameter["volumes"] != _|_ {
         			volumeMounts: [ for v in parameter.volumes {
         				{

--- a/hack/vela-templates/cue/sidecar.cue
+++ b/hack/vela-templates/cue/sidecar.cue
@@ -1,9 +1,11 @@
 patch: {
 	// +patchKey=name
 	spec: template: spec: containers: [{
-		name:    parameter.name
-		image:   parameter.image
-		command: parameter.cmd
+		name:  parameter.name
+		image: parameter.image
+		if parameter.cmd != _|_ {
+			command: parameter.cmd
+		}
 		if parameter["volumes"] != _|_ {
 			volumeMounts: [ for v in parameter.volumes {
 				{


### PR DESCRIPTION
Deploying error with https://kubevela.io/zh/docs/application#step-2-design-and-deploy-application , error message:
```
evaluate template trait=sidecar app=frontend: invalid patch trait sidecar into workload: compile patch file: spec.template.spec.containers.0.command: reference \"parameter\" not found
```
This PR is referenced from https://github.com/oam-dev/kubevela/pull/1067/files