### PR TITLE
Change metric-server port in unit test

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/appdeployment/suite_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/appdeployment/suite_test.go
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func(done Done) {
 	// setup the controller manager since we need the component handler to run in the background
 	ctlManager, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                  common.Scheme,
-		MetricsBindAddress:      ":8080",
+		MetricsBindAddress:      ":8091",
 		LeaderElection:          false,
 		LeaderElectionNamespace: "default",
 		LeaderElectionID:        "test",

--- a/pkg/controller/core.oam.dev/v1alpha2/application/suite_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/suite_test.go
@@ -141,7 +141,7 @@ var _ = BeforeSuite(func(done Done) {
 	// setup the controller manager since we need the component handler to run in the background
 	ctlManager, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                  testScheme,
-		MetricsBindAddress:      ":8080",
+		MetricsBindAddress:      ":8090",
 		LeaderElection:          false,
 		LeaderElectionNamespace: "default",
 		LeaderElectionID:        "test",


### PR DESCRIPTION
When running `make test` locally, this change can avoid the conflicts with local 8080 port by running kubevela
core and by other test cases .