### PR TITLE
Add krew auto release and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,3 +135,5 @@ jobs:
           COMMIT_ID: ${{ github.sha }}
         run: |
           bash ./hack/website/release.sh
+      - name: Update kubectl plugin version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.38

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,47 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: vela
+spec:
+  version: "{{ .TagName }}"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/oam-dev/kubevela/releases/download/{{ .TagName }}/kubectl-vela-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
+    files:
+    - from: "*/kubectl-vela"
+      to: "."
+    - from: "*/LICENSE"
+      to: "."
+    bin: "kubectl-vela"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/oam-dev/kubevela/releases/download/{{ .TagName }}/kubectl-vela-{{ .TagName }}-darwin-amd64.tar.gz" .TagName }}
+    files:
+    - from: "*/kubectl-vela"
+      to: "."
+    - from: "*/LICENSE"
+      to: "."
+    bin: "kubectl-vela"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/oam-dev/kubevela/releases/download/{{ .TagName }}/kubectl-vela-{{ .TagName }}-windows-amd64.zip" .TagName }}
+    files:
+    - from: "*/kubectl-vela.exe"
+      to: "."
+    - from: "*/LICENSE"
+      to: "."
+    bin: "kubectl-vela.exe"
+  shortDescription: Easily interact with KubeVela
+  homepage: https://kubevela.io
+  description: |
+    kubectl vela is a kubectl plugin from the KubeVela project. KubeVela is
+    a modern application platform that is fully self-service, and adapts to
+    your needs when you grow. This plugin allows you to better view, manage
+    and maintain KubeVela applications.

--- a/docs/en/end-user/kubectlplugin.mdx
+++ b/docs/en/end-user/kubectlplugin.mdx
@@ -1,6 +1,8 @@
 ---
 title: Install kubectl plugin
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Install vela kubectl plugin can help you to ship applications more easily!
 
@@ -9,34 +11,36 @@ Install vela kubectl plugin can help you to ship applications more easily!
 You can install kubectl plugin `kubectl vela` by:
 
 <Tabs
-    className="unique-tabs"
-    defaultValue="krew"
-    values={[
-        {label: 'Krew', value: 'krew'},
-        {label: 'Script', value: 'script'},
-    ]}>
-    <TabItem value="krew">
+className="unique-tabs"
+defaultValue="krew"
+values={[
+    {label: 'Krew', value: 'krew'},
+    {label: 'Script', value: 'script'},
+]}>
+<TabItem value="krew">
 
-        1. [Install and set up](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) Krew on your machine.
-        2. Discover plugins available on Krew:
-        ```shell
-        kubectl krew update
-        ```
-        3. install kubectl vela:
-        ```shell script
-        kubectl krew install vela
-        ```
+1. [Install and set up](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) Krew on your machine.
+2. Discover plugins available on Krew:
+```shell
+kubectl krew update
+```
+3. install kubectl vela:
+```shell script
+kubectl krew install vela
+```
 
-    </TabItem>
-    <TabItem value="script">
-        **macOS/Linux**
-        ```shell script
-        curl -fsSl https://kubevela.io/script/install-kubectl-vela.sh | bash
-        ```
+</TabItem>
+<TabItem value="script">
 
-        You can also download the binary from [release pages ( >= v1.0.3)](https://github.com/oam-dev/kubevela/releases) manually.
-        Kubectl will discover it from your system path automatically.
-    </TabItem>
+**macOS/Linux**
+```shell script
+curl -fsSl https://kubevela.io/script/install-kubectl-vela.sh | bash
+```
+
+You can also download the binary from [release pages ( >= v1.0.3)](https://github.com/oam-dev/kubevela/releases) manually.
+Kubectl will discover it from your system path automatically.
+
+</TabItem>
 </Tabs>
 
 

--- a/docs/en/end-user/kubectlplugin.mdx
+++ b/docs/en/end-user/kubectlplugin.mdx
@@ -8,13 +8,38 @@ Install vela kubectl plugin can help you to ship applications more easily!
 
 You can install kubectl plugin `kubectl vela` by:
 
-**macOS/Linux**
-```shell script
-curl -fsSl https://kubevela.io/script/install-kubectl-vela.sh | bash
-```
+<Tabs
+    className="unique-tabs"
+    defaultValue="krew"
+    values={[
+        {label: 'Krew', value: 'krew'},
+        {label: 'Script', value: 'script'},
+    ]}>
+    <TabItem value="krew">
 
-You can also download the binary from [release pages ( >= v1.0.3)](https://github.com/oam-dev/kubevela/releases) manually.
-Kubectl will discover it from your system path automatically.
+        1. [Install and set up](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) Krew on your machine.
+        2. Discover plugins available on Krew:
+        ```shell
+        kubectl krew update
+        ```
+        3. install kubectl vela:
+        ```shell script
+        kubectl krew install vela
+        ```
+
+    </TabItem>
+    <TabItem value="script">
+        **macOS/Linux**
+        ```shell script
+        curl -fsSl https://kubevela.io/script/install-kubectl-vela.sh | bash
+        ```
+
+        You can also download the binary from [release pages ( >= v1.0.3)](https://github.com/oam-dev/kubevela/releases) manually.
+        Kubectl will discover it from your system path automatically.
+    </TabItem>
+</Tabs>
+
+
 
 ## Usage
 


### PR DESCRIPTION
[kubectl vela krew plugin manifests](https://github.com/kubernetes-sigs/krew-index/blob/master/plugins/vela.yaml) has been merged into krew-index, and it is now possible to install kubectl vela via krew, now with the addition of an automatic release action that will automatically push each subsequent release to krew.