### PR TITLE
fix controller: fix the bug which the controller cannot start due to the format error of the third-party CRD 

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -182,6 +182,9 @@ func main() {
 	pd, err := definition.NewPackageDiscover(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "failed to create CRD discovery for CUE package client")
+		if !definition.IsCUEParseErr(err) {
+			os.Exit(1)
+		}
 	}
 	controllerArgs.PackageDiscover = pd
 

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -182,7 +182,6 @@ func main() {
 	pd, err := definition.NewPackageDiscover(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "failed to create CRD discovery for CUE package client")
-		os.Exit(1)
 	}
 	controllerArgs.PackageDiscover = pd
 

--- a/pkg/dsl/definition/package.go
+++ b/pkg/dsl/definition/package.go
@@ -70,7 +70,7 @@ func NewPackageDiscover(config *rest.Config) (*PackageDiscover, error) {
 		pkgKinds: make(map[string][]VersionKind),
 	}
 	if err = pd.RefreshKubePackagesFromCluster(); err != nil {
-		return nil, err
+		return pd, err
 	}
 	return pd, nil
 }

--- a/pkg/dsl/definition/package.go
+++ b/pkg/dsl/definition/package.go
@@ -42,6 +42,9 @@ const (
 	BuiltinPackageDomain = "kube"
 	// K8sResourcePrefix Indicates that the definition comes from kubernetes
 	K8sResourcePrefix = "io_k8s_api_"
+
+	// ParseJSONSchemaErr describes the error that occurs when cue parses json
+	ParseJSONSchemaErr ParseErrType = "parse json schema of k8s crds error"
 )
 
 // PackageDiscover defines the inner CUE packages loaded from K8s cluster
@@ -57,6 +60,25 @@ type VersionKind struct {
 	DefinitionName string
 	APIVersion     string
 	Kind           string
+}
+
+// ParseErrType represents the type of CUEParseError
+type ParseErrType string
+
+// CUEParseError describes an error when CUE parse error
+type CUEParseError struct {
+	err     error
+	errType ParseErrType
+}
+
+// Error implements the Error interface.
+func (cueErr CUEParseError) Error() string {
+	return fmt.Sprintf("%s: %s", cueErr.errType, cueErr.err.Error())
+}
+
+// IsCUEParseErr returns true if the specified error is CUEParseError type.
+func IsCUEParseErr(err error) bool {
+	return errors.As(err, &CUEParseError{})
 }
 
 // NewPackageDiscover will create a PackageDiscover client with the K8s config file.
@@ -197,7 +219,10 @@ func (pd *PackageDiscover) addKubeCUEPackagesFromCluster(apiSchema string) error
 		Map:  openAPIMapping(dgvkMapper),
 	})
 	if err != nil {
-		return err
+		return CUEParseError{
+			err:     err,
+			errType: ParseJSONSchemaErr,
+		}
 	}
 	kubePkg := newPackage("kube")
 	kubePkg.processOpenAPIFile(oaFile)


### PR DESCRIPTION
Refer to https://github.com/oam-dev/kubevela/issues/1313 , the format error of third-party CRD will lead to vela-controller exited. In this case, we need to keep the vela-controller run normally.
