### PR TITLE
Renaming the name of function "SyncDefinitionToLocal"

### DIFF
--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -350,7 +350,7 @@ func getComponentsAndTraits(capabilities []types.Capability) ([]string, []string
 
 // ShowReferenceConsole will show capability reference in console
 func ShowReferenceConsole(ctx context.Context, c common.Args, ioStreams cmdutil.IOStreams, capabilityName string, ns string) error {
-	capability, err := plugins.SyncDefinitionToLocal(ctx, c, capabilityName, ns)
+	capability, err := plugins.GetCapabilityByName(ctx, c, capabilityName, ns)
 	if err != nil {
 		return err
 	}

--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -257,8 +257,8 @@ func SyncDefinitionsToLocal(ctx context.Context, c common.Args, localDefinitionD
 	return syncedTemplates, warnings, nil
 }
 
-// SyncDefinitionToLocal sync definitions to local
-func SyncDefinitionToLocal(ctx context.Context, c common.Args, capabilityName string, ns string) (*types.Capability, error) {
+// GetCapabilityByName gets capability by definition name
+func GetCapabilityByName(ctx context.Context, c common.Args, capabilityName string, ns string) (*types.Capability, error) {
 	var (
 		foundCapability bool
 		template        types.Capability


### PR DESCRIPTION
As we don't need to sync the defintiion .yaml and .cue to local and
then extract it, besides, there is a simliar function "SyncDefinitionsToLocal"
just besides it, rename function "SyncDefinitionToLocal" in order
not to cause confustions