### PR TITLE
fix bug: Use stricter syntax check for CUE

### DIFF
--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -160,7 +160,7 @@ spec:
       properties:
         image: crccheck/hello-world
         port: 5000
-        cpu: 0.5
+        cpu: "0.5"
       traits:
         - type: test-ingress
           properties:
@@ -535,7 +535,7 @@ var livediffResult = `---
 -   - name: express-server
 +   - name: new-express-server
       properties:
-+       cpu: 0.5
++       cpu: "0.5"
         image: crccheck/hello-world
 -       port: 80
 +       port: 5000
@@ -671,6 +671,11 @@ var livediffResult = `---
 +             name: new-express-server
 +             ports:
 +             - containerPort: 5000
++             resources:
++               limits:
++                 cpu: "0.5"
++               requests:
++                 cpu: "0.5"
 + status:
 +   observedGeneration: 0
   

--- a/pkg/dsl/definition/template.go
+++ b/pkg/dsl/definition/template.go
@@ -109,7 +109,7 @@ func (wd *workloadDef) Complete(ctx process.Context, abstractTemplate string, pa
 		return err
 	}
 
-	if err := inst.Value().Err(); err != nil {
+	if err := inst.Value().Validate(); err != nil {
 		return errors.WithMessagef(err, "invalid cue template of workload %s after merge parameter and context", wd.name)
 	}
 	output := inst.Lookup(OutputFieldName)
@@ -294,7 +294,7 @@ func (td *traitDef) Complete(ctx process.Context, abstractTemplate string, param
 		return err
 	}
 
-	if err := inst.Value().Err(); err != nil {
+	if err := inst.Value().Validate(); err != nil {
 		return errors.WithMessagef(err, "invalid template of trait %s after merge with parameter and context", td.name)
 	}
 	processing := inst.Lookup("processing")

--- a/test/e2e-test/definition_revision_test.go
+++ b/test/e2e-test/definition_revision_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Test application of the specified definition version", func() 
 				return fmt.Errorf("error defRevison number wants %d, actually %d", 2, len(labelDefRevList.Items))
 			}
 			return nil
-		}, 20*time.Second, time.Second).Should(BeNil())
+		}, 40*time.Second, time.Second).Should(BeNil())
 
 	})
 
@@ -144,7 +144,7 @@ var _ = Describe("Test application of the specified definition version", func() 
 				return fmt.Errorf("error defRevison number wants %d, actually %d", 2, len(workerDefRevList.Items))
 			}
 			return nil
-		}, 20*time.Second, time.Second).Should(BeNil())
+		}, 40*time.Second, time.Second).Should(BeNil())
 
 		webserviceV1 := webServiceWithNoTemplate.DeepCopy()
 		webserviceV1.Spec.Schematic.CUE.Template = webServiceV1Template
@@ -175,7 +175,7 @@ var _ = Describe("Test application of the specified definition version", func() 
 				return fmt.Errorf("error defRevison number wants %d, actually %d", 2, len(webserviceDefRevList.Items))
 			}
 			return nil
-		}, 20*time.Second, time.Second).Should(BeNil())
+		}, 40*time.Second, time.Second).Should(BeNil())
 
 		app := v1beta1.Application{
 			ObjectMeta: metav1.ObjectMeta{
@@ -405,7 +405,7 @@ var _ = Describe("Test application of the specified definition version", func() 
 				return fmt.Errorf("error defRevison number wants %d, actually %d", 2, len(helmworkerDefRevList.Items))
 			}
 			return nil
-		}, 20*time.Second, time.Second).Should(BeNil())
+		}, 40*time.Second, time.Second).Should(BeNil())
 
 		app := v1beta1.Application{
 			ObjectMeta: metav1.ObjectMeta{
@@ -584,7 +584,7 @@ var _ = Describe("Test application of the specified definition version", func() 
 				return fmt.Errorf("error defRevison number wants %d, actually %d", 2, len(kubeworkerDefRevList.Items))
 			}
 			return nil
-		}, 20*time.Second, time.Second).Should(BeNil())
+		}, 40*time.Second, time.Second).Should(BeNil())
 
 		app := v1beta1.Application{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
fix https://github.com/oam-dev/kubevela/issues/1595

The previous logic will not report an error for the following wrong `Application`, and will render incomplete workload which does not contain `env`.

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: myapp
spec:
  components:
    - name: mycomp
      type: webservice
      properties:
        image: nginx:latest
        port: 8080
        env:
          - name: SHOULD_BE_STRING_1
            value: "I'm string"
          - name: SHOULD_BE_STRING_2
            value: 1234 # <=== webservice CUE template requires string type here
```

After fixing the bug, controller will provide a more detailed error logs.

```
{"level":"error","ts":1620785291.581014,"logger":
"Application","msg":"[Handle GenerateApplicationConfiguration]","application":"default/myapp",
"error":"evaluate base template app=myapp in namespace=default: invalid cue template of workload 
mycomp after merge parameter and context: parameter.env.1.value: conflicting values string and 1234 
(mismatched types string and int)
....
```

- [x] change `inst.Value().Err()` to `inst.Value().Validate()`
- [x] add test