### PR TITLE
Add Dynamic Admission Control for ComponentDefinition

### DIFF
--- a/charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -115,5 +115,30 @@ webhooks:
           - UPDATE
         resources:
           - podspecworkloads
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: {{ template "kubevela.name" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /mutating-core-oam-dev-v1beta1-componentdefinitions
+    {{- if .Values.admissionWebhooks.patch.enabled  }}
+    failurePolicy: Ignore
+    {{- else }}
+    failurePolicy: Fail
+    {{- end }}
+    name: mutating.core.oam-dev.v1beta1.componentdefinitions
+    sideEffects: None
+    admissionReviewVersions:
+      - v1beta1
+    rules:
+      - apiGroups:
+          - core.oam.dev
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - componentdefinitions
 
 {{- end -}}

--- a/charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -163,4 +163,30 @@ webhooks:
           - UPDATE
         resources:
           - applications
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: {{ template "kubevela.name" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /validating-core-oam-dev-v1beta1-componentdefinitions
+    {{- if .Values.admissionWebhooks.patch.enabled  }}
+    failurePolicy: Ignore
+    {{- else }}
+    failurePolicy: Fail
+    {{- end }}
+    name: validating.core.oam-dev.v1beta1.componentdefinitions
+    sideEffects: None
+    admissionReviewVersions:
+      - v1beta1
+    rules:
+      - apiGroups:
+          - core.oam.dev
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - componentdefinitions
+          
 {{- end -}}

--- a/e2e/cli.go
+++ b/e2e/cli.go
@@ -51,7 +51,7 @@ func Exec(cli string) (string, error) {
 	if err != nil {
 		return string(output), err
 	}
-	s := session.Wait(30 * time.Second)
+	s := session.Wait(60 * time.Second)
 	return string(s.Out.Contents()) + string(s.Err.Contents()), nil
 }
 

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
@@ -82,7 +82,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// refresh package discover when componentDefinition is registered
-	if handler.cd.Spec.Workload.Type == "" {
+	if handler.cd.Spec.Workload.Definition != (common.WorkloadGVK{}) {
 		err := utils.RefreshPackageDiscover(r.dm, r.pd, handler.cd.Spec.Workload.Definition,
 			common.DefinitionReference{}, types.TypeComponentDefinition)
 		if err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/handler.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/handler.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
@@ -40,7 +41,7 @@ type handler struct {
 func (h *handler) CreateWorkloadDefinition(ctx context.Context) (util.WorkloadType, error) {
 	var workloadType = util.ComponentDef
 	var workloadName = h.cd.Name
-	if h.cd.Spec.Workload.Type != "" {
+	if h.cd.Spec.Workload.Type != "" && h.cd.Spec.Workload.Definition == (common.WorkloadGVK{}) {
 		workloadType = util.ReferWorkload
 		workloadName = h.cd.Spec.Workload.Type
 	}

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	"github.com/oam-dev/kubevela/apis/types"
 	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	coredef "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/core"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
@@ -77,8 +76,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// refresh package discover when traitDefinition is registered
 	if traitdefinition.Spec.Reference.Name != "" {
-		err := utils.RefreshPackageDiscover(r.dm, r.pd, common.WorkloadGVK{},
-			traitdefinition.Spec.Reference, types.TypeTrait)
+		err := utils.RefreshPackageDiscover(ctx, r.Client, r.dm, r.pd, &traitdefinition)
 		if err != nil {
 			klog.ErrorS(err, "cannot refresh packageDiscover")
 			r.record.Event(&traitdefinition, event.Warning("cannot refresh packageDiscover", err))

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -762,9 +762,6 @@ func MergeMapOverrideWithDst(src, dst map[string]string) map[string]string {
 // ConvertComponentDef2WorkloadDef help convert a ComponentDefinition to WorkloadDefinition
 func ConvertComponentDef2WorkloadDef(dm discoverymapper.DiscoveryMapper, componentDef *v1beta1.ComponentDefinition,
 	workloadDef *v1beta1.WorkloadDefinition) error {
-	if len(componentDef.Spec.Workload.Type) > 1 {
-		return errors.New("No need to convert ComponentDefinition")
-	}
 	var reference common.DefinitionReference
 	reference, err := ConvertWorkloadGVK2Definition(dm, componentDef.Spec.Workload.Definition)
 	if err != nil {

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -1918,24 +1918,8 @@ func TestGetScopeDefiniton(t *testing.T) {
 }
 
 func TestConvertComponentDef2WorkloadDef(t *testing.T) {
-	var noNeedErr = errors.New("No need to convert ComponentDefinition")
 	var cd = v1beta1.ComponentDefinition{}
 	mapper := mock.NewMockDiscoveryMapper()
-
-	var componentDefWithWorkloadType = `
-apiVersion: core.oam.dev/v1beta1
-kind: ComponentDefinition
-metadata:
-  name: cd-with-workload-type
-spec:
-  workload:
-    type: worker
-`
-
-	err := yaml.Unmarshal([]byte(componentDefWithWorkloadType), &cd)
-	assert.Equal(t, nil, err)
-	err = util.ConvertComponentDef2WorkloadDef(mapper, &cd, &v1beta1.WorkloadDefinition{})
-	assert.Equal(t, noNeedErr.Error(), err.Error())
 
 	var componentDefWithWrongDefinition = `
 apiVersion: core.oam.dev/v1beta1
@@ -1949,7 +1933,7 @@ spec:
       kind: Deployment
 `
 	cd = v1beta1.ComponentDefinition{}
-	err = yaml.Unmarshal([]byte(componentDefWithWrongDefinition), &cd)
+	err := yaml.Unmarshal([]byte(componentDefWithWrongDefinition), &cd)
 	assert.Equal(t, nil, err)
 	err = util.ConvertComponentDef2WorkloadDef(mapper, &cd, &v1beta1.WorkloadDefinition{})
 	assert.Error(t, err)

--- a/pkg/webhook/core.oam.dev/register.go
+++ b/pkg/webhook/core.oam.dev/register.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration"
 	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/applicationrollout"
 	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/component"
+	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition"
 	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/traitdefinition"
 )
 
@@ -32,6 +33,8 @@ import (
 func Register(mgr manager.Manager, args controller.Args) {
 	application.RegisterValidatingHandler(mgr, args)
 	applicationconfiguration.RegisterValidatingHandler(mgr, args)
+	componentdefinition.RegisterMutatingHandler(mgr, args)
+	componentdefinition.RegisterValidatingHandler(mgr, args)
 	traitdefinition.RegisterValidatingHandler(mgr, args)
 	applicationconfiguration.RegisterMutatingHandler(mgr)
 	applicationrollout.RegisterMutatingHandler(mgr)

--- a/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/mutating_handler.go
@@ -1,0 +1,131 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package componentdefinition
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+)
+
+// MutatingHandler handles ComponentDefinition
+type MutatingHandler struct {
+	Mapper discoverymapper.DiscoveryMapper
+	Client client.Client
+	// Decoder decodes objects
+	Decoder *admission.Decoder
+}
+
+var _ admission.Handler = &MutatingHandler{}
+
+// Handle handles admission requests.
+func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	obj := &v1beta1.ComponentDefinition{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	// mutate the object
+	if err := h.Mutate(obj); err != nil {
+		klog.Error(err, "failed to mutate the componentDefinition", "name", obj.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	marshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	resp := admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
+	if len(resp.Patches) > 0 {
+		klog.InfoS("admit ComponentDefinition",
+			"namespace", obj.Namespace, "name", obj.Name, "patches", util.JSONMarshal(resp.Patches))
+	}
+	return resp
+}
+
+// Mutate sets all the default value for the ComponentDefinition
+func (h *MutatingHandler) Mutate(obj *v1beta1.ComponentDefinition) error {
+	klog.InfoS("mutate", "name", obj.Name)
+
+	// If the Type field is not empty, it means that ComponentDefinition refers to an existing WorkloadDefinition
+	if obj.Spec.Workload.Type != "" {
+		return nil
+	}
+	if obj.Spec.Workload.Definition != (common.WorkloadGVK{}) {
+		// If only Definition field exists, fill Type field according to Definition.
+		defRef, err := util.ConvertWorkloadGVK2Definition(h.Mapper, obj.Spec.Workload.Definition)
+		if err != nil {
+			return err
+		}
+		obj.Spec.Workload.Type = defRef.Name
+
+		// Create workloadDefinition which componentDefinition refers to
+		workloadDef := new(v1beta1.WorkloadDefinition)
+		err = h.Client.Get(context.TODO(), client.ObjectKey{Name: defRef.Name, Namespace: obj.Namespace}, workloadDef)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				workloadDef.SetName(defRef.Name)
+				workloadDef.SetNamespace(obj.Namespace)
+				workloadDef.Spec.Reference = defRef
+				return h.Client.Create(context.TODO(), workloadDef)
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+var _ admission.DecoderInjector = &MutatingHandler{}
+
+// InjectDecoder injects the decoder into the ComponentDefinitionMutatingHandler
+func (h *MutatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.Decoder = d
+	return nil
+}
+
+var _ inject.Client = &MutatingHandler{}
+
+// InjectClient injects the client into the ApplicationValidateHandler
+func (h *MutatingHandler) InjectClient(c client.Client) error {
+	if h.Client != nil {
+		return nil
+	}
+	h.Client = c
+	return nil
+}
+
+// RegisterMutatingHandler will register component mutation handler to the webhook
+func RegisterMutatingHandler(mgr manager.Manager, args controller.Args) {
+	server := mgr.GetWebhookServer()
+	server.Register("/mutating-core-oam-dev-v1beta1-componentdefinitions", &webhook.Admission{Handler: &MutatingHandler{Mapper: args.DiscoveryMapper}})
+}

--- a/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler.go
@@ -1,0 +1,107 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package componentdefinition
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+)
+
+var componentDefGVR = v1beta1.SchemeGroupVersion.WithResource("componentdefinitions")
+
+// ValidatingHandler handles validation of component definition
+type ValidatingHandler struct {
+	Mapper discoverymapper.DiscoveryMapper
+
+	// Decoder decodes object
+	Decoder *admission.Decoder
+}
+
+var _ admission.Handler = &ValidatingHandler{}
+
+// Handle validate component definition
+func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	obj := &v1beta1.ComponentDefinition{}
+	if req.Resource.String() != componentDefGVR.String() {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("expect resource to be %s", componentDefGVR))
+	}
+
+	if req.Operation == admissionv1beta1.Create || req.Operation == admissionv1beta1.Update {
+		err := h.Decoder.Decode(req, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		err = ValidateWorkload(h.Mapper, obj)
+		if err != nil {
+			return admission.Denied(err.Error())
+		}
+	}
+	return admission.ValidationResponse(true, "")
+}
+
+var _ admission.DecoderInjector = &ValidatingHandler{}
+
+// InjectDecoder injects the decoder into the ValidatingHandler
+func (h *ValidatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.Decoder = d
+	return nil
+}
+
+// RegisterValidatingHandler will register TraitDefinition validation to webhook
+func RegisterValidatingHandler(mgr manager.Manager, args controller.Args) {
+	server := mgr.GetWebhookServer()
+	server.Register("/validating-core-oam-dev-v1beta1-componentdefinitions", &webhook.Admission{Handler: &ValidatingHandler{
+		Mapper: args.DiscoveryMapper,
+	}})
+}
+
+// ValidateWorkload validates whether the Workload field is valid
+func ValidateWorkload(dm discoverymapper.DiscoveryMapper, cd *v1beta1.ComponentDefinition) error {
+
+	// If the Type and Definition are all empty, it will be rejected.
+	if cd.Spec.Workload.Type == "" && cd.Spec.Workload.Definition == (common.WorkloadGVK{}) {
+		return fmt.Errorf("neither the type nor the definition of the workload field in the ComponentDefinition %s can be empty", cd.Name)
+	}
+
+	// if Type and Definitiondon‘t point to the same workloaddefinition, it will be rejected.
+	if cd.Spec.Workload.Type != "" && cd.Spec.Workload.Definition != (common.WorkloadGVK{}) {
+		defRef, err := util.ConvertWorkloadGVK2Definition(dm, cd.Spec.Workload.Definition)
+		if err != nil {
+			return err
+		}
+		if defRef.Name != cd.Spec.Workload.Type {
+			return fmt.Errorf("the type and the definition of the workload field in ComponentDefinition %s should represent the same workload", cd.Name)
+		}
+	}
+
+	if cd.Spec.Schematic.HELM != nil && cd.Spec.Workload.Definition == (common.WorkloadGVK{}) {
+		return fmt.Errorf("the definition of the workload field should be set when you use HELM in ComponentDefinition %s", cd.Name)
+	}
+	return nil
+}

--- a/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler.go
@@ -100,7 +100,7 @@ func ValidateWorkload(dm discoverymapper.DiscoveryMapper, cd *v1beta1.ComponentD
 		}
 	}
 
-	if cd.Spec.Schematic.HELM != nil && cd.Spec.Workload.Definition == (common.WorkloadGVK{}) {
+	if cd.Spec.Schematic != nil && cd.Spec.Schematic.HELM != nil && cd.Spec.Workload.Definition == (common.WorkloadGVK{}) {
 		return fmt.Errorf("the definition of the workload field should be set when you use HELM in ComponentDefinition %s", cd.Name)
 	}
 	return nil

--- a/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler_test.go
@@ -1,0 +1,193 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package componentdefinition
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	core "github.com/oam-dev/kubevela/apis/core.oam.dev"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
+)
+
+var handler ValidatingHandler
+var req admission.Request
+var reqResource metav1.GroupVersionResource
+var decoder *admission.Decoder
+var cd v1beta1.ComponentDefinition
+var cdRaw []byte
+var testScheme = runtime.NewScheme()
+var testEnv *envtest.Environment
+var cfg *rest.Config
+
+func TestTraitdefinition(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Traitdefinition Suite")
+}
+
+var _ = BeforeSuite(func(done Done) {
+	var yamlPath string
+	if _, set := os.LookupEnv("COMPATIBILITY_TEST"); set {
+		yamlPath = "../../../../../test/compatibility-test/testdata"
+	} else {
+		yamlPath = filepath.Join("../../../../..", "charts", "vela-core", "crds")
+	}
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{yamlPath},
+	}
+	testEnv = &envtest.Environment{}
+
+	err := core.AddToScheme(testScheme)
+	Expect(err).Should(BeNil())
+	err = scheme.AddToScheme(testScheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+	decoder, err = admission.NewDecoder(testScheme)
+	Expect(err).Should(BeNil())
+
+	cd = v1beta1.ComponentDefinition{}
+	cd.SetGroupVersionKind(v1beta1.ComponentDefinitionGroupVersionKind)
+	cdRaw, _ = json.Marshal(cd)
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = Describe("Test ComponentDefinition validating handler", func() {
+	BeforeEach(func() {
+		dm, err := discoverymapper.New(cfg)
+		Expect(err).Should(BeNil())
+		reqResource = metav1.GroupVersionResource{
+			Group:    v1beta1.Group,
+			Version:  v1beta1.Version,
+			Resource: "componentdefinitions"}
+		handler = ValidatingHandler{Mapper: dm}
+		handler.InjectDecoder(decoder)
+	})
+
+	It("Test wrong resource of admission request", func() {
+		wrongReqResource := metav1.GroupVersionResource{
+			Group:    v1beta1.Group,
+			Version:  v1beta1.Version,
+			Resource: "foos"}
+		req = admission.Request{
+			AdmissionRequest: admissionv1beta1.AdmissionRequest{
+				Operation: admissionv1beta1.Create,
+				Resource:  wrongReqResource,
+				Object:    runtime.RawExtension{Raw: []byte("")},
+			},
+		}
+		resp := handler.Handle(context.TODO(), req)
+		Expect(resp.Allowed).Should(BeFalse())
+	})
+
+	It("Test bad admission request", func() {
+		req = admission.Request{
+			AdmissionRequest: admissionv1beta1.AdmissionRequest{
+				Operation: admissionv1beta1.Create,
+				Resource:  reqResource,
+				Object:    runtime.RawExtension{Raw: []byte("bad request")},
+			},
+		}
+		resp := handler.Handle(context.TODO(), req)
+		Expect(resp.Allowed).Should(BeFalse())
+	})
+
+	Context("Test create/update operation admission request", func() {
+		It("Test componentDefinition without type and definition", func() {
+			wrongCd := v1beta1.ComponentDefinition{}
+			wrongCd.SetGroupVersionKind(v1beta1.ComponentDefinitionGroupVersionKind)
+			wrongCd.SetName("wrongCd")
+			wrongCdRaw, _ := json.Marshal(wrongCd)
+			req := admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					Resource:  reqResource,
+					Object:    runtime.RawExtension{Raw: wrongCdRaw},
+				},
+			}
+			resp := handler.Handle(context.TODO(), req)
+			Expect(resp.Allowed).Should(BeFalse())
+			Expect(resp.Result.Reason).Should(Equal(metav1.StatusReason("neither the type nor the definition of the workload field in the ComponentDefinition wrongCd can be empty")))
+		})
+
+		It("Test componentDefinition which type and definition point to different workload type", func() {
+			wrongCd := v1beta1.ComponentDefinition{}
+			wrongCd.SetGroupVersionKind(v1beta1.ComponentDefinitionGroupVersionKind)
+			wrongCd.SetName("wrongCd")
+			wrongCd.Spec.Workload.Type = "jobs.batch"
+			wrongCd.Spec.Workload.Definition = common.WorkloadGVK{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			}
+			wrongCdRaw, _ := json.Marshal(wrongCd)
+			req := admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					Resource:  reqResource,
+					Object:    runtime.RawExtension{Raw: wrongCdRaw},
+				},
+			}
+			resp := handler.Handle(context.TODO(), req)
+			Expect(resp.Allowed).Should(BeFalse())
+			Expect(resp.Result.Reason).Should(Equal(metav1.StatusReason("the type and the definition of the workload field in ComponentDefinition wrongCd should represent the same workload")))
+		})
+
+		It("Test HELM type componentDefinition without definition", func() {
+			helmCd := v1beta1.ComponentDefinition{}
+			helmCd.SetGroupVersionKind(v1beta1.ComponentDefinitionGroupVersionKind)
+			helmCd.SetName("helmCd")
+			helmCd.Spec.Workload.Type = "deployments.apps"
+			helmCd.Spec.Schematic = &common.Schematic{
+				HELM: &common.Helm{},
+			}
+			helmCdRaw, _ := json.Marshal(helmCd)
+			req := admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					Resource:  reqResource,
+					Object:    runtime.RawExtension{Raw: helmCdRaw},
+				},
+			}
+			resp := handler.Handle(context.TODO(), req)
+			Expect(resp.Allowed).Should(BeFalse())
+			Expect(resp.Result.Reason).Should(Equal(metav1.StatusReason("the definition of the workload field should be set when you use HELM in ComponentDefinition helmCd")))
+		})
+	})
+})

--- a/test/e2e-test/definition_revision_test.go
+++ b/test/e2e-test/definition_revision_test.go
@@ -371,6 +371,7 @@ var _ = Describe("Test application of the specified definition version", func() 
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 			}
+			helmworkerV1.Spec.Workload.Type = "deployments.apps"
 			helmworkerV1.Spec.Schematic = &common.Schematic{
 				HELM: &common.Helm{
 					Release: util.Object2RawExtension(map[string]interface{}{
@@ -551,6 +552,7 @@ var _ = Describe("Test application of the specified definition version", func() 
 				APIVersion: "batch/v1",
 				Kind:       "Job",
 			}
+			kubeworkerV1.Spec.Workload.Type = "jobs.batch"
 			kubeworkerV1.Spec.Schematic = &common.Schematic{
 				KUBE: &common.Kube{
 					Template: generateTemplate(KUBEWorkerV2Template),

--- a/test/e2e-test/definition_test.go
+++ b/test/e2e-test/definition_test.go
@@ -1,0 +1,115 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+)
+
+var _ = Describe("Test application of the specified definition version", func() {
+	ctx := context.Background()
+
+	var namespace string
+	var ns corev1.Namespace
+
+	BeforeEach(func() {
+		namespace = randomNamespaceName("def-e2e-test")
+		ns = corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+
+		Eventually(func() error {
+			return k8sClient.Create(ctx, &ns)
+		}, time.Second*3, time.Microsecond*300).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+	})
+
+	AfterEach(func() {
+		By("Clean up resources after a test")
+		k8sClient.DeleteAllOf(ctx, &v1beta1.ComponentDefinition{}, client.InNamespace(namespace))
+		k8sClient.DeleteAllOf(ctx, &v1beta1.WorkloadDefinition{}, client.InNamespace(namespace))
+		k8sClient.DeleteAllOf(ctx, &v1beta1.TraitDefinition{}, client.InNamespace(namespace))
+		k8sClient.DeleteAllOf(ctx, &v1beta1.DefinitionRevision{}, client.InNamespace(namespace))
+
+		By(fmt.Sprintf("Delete the entire namespaceName %s", ns.Name))
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(Succeed())
+	})
+
+	Context("Test dynamic admission control for componentDefinition", func() {
+		It("Test componentDefinition only set definition fields", func() {
+			testCd := webServiceWithNoTemplate.DeepCopy()
+			testCd.Spec.Schematic.CUE.Template = webServiceV1Template
+			testCd.SetName("test-componentdef-v1")
+			testCd.SetNamespace(namespace)
+			Expect(k8sClient.Create(ctx, testCd)).Should(Succeed())
+
+			By("check MutatingWebhook fill the type filed")
+			newCd := new(v1beta1.ComponentDefinition)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: testCd.Name, Namespace: namespace}, newCd)
+			}, 15*time.Second, time.Second).Should(BeNil())
+
+			Expect(newCd.Spec.Workload.Type).Should(Equal("deployments.apps"))
+
+			By("check workloadDefinition created by MutatingWebhook")
+			newWd := new(v1beta1.WorkloadDefinition)
+			wdName := newCd.Spec.Workload.Type
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: wdName, Namespace: namespace}, newWd)
+			}, 15*time.Second, time.Second).Should(BeNil())
+
+			Expect(newWd.Spec.Reference.Name).Should(Equal(wdName))
+			Expect(newWd.Spec.Reference.Version).To(Equal("v1"))
+		})
+
+		It("Test componentDefinition which definition and type fields are all empty", func() {
+			testCd := webServiceWithNoTemplate.DeepCopy()
+			testCd.SetName("test-componentdef-v2")
+			testCd.Spec.Workload.Definition = common.WorkloadGVK{}
+			testCd.Spec.Schematic.CUE.Template = webServiceV1Template
+			testCd.SetNamespace(namespace)
+			Expect(k8sClient.Create(ctx, testCd)).Should(HaveOccurred())
+		})
+
+		It("Test componentDefinition which definition and type point to same workload type", func() {
+			testCd := webServiceWithNoTemplate.DeepCopy()
+			testCd.SetName("test-componentdef-v3")
+			testCd.Spec.Workload.Type = "deployments.apps"
+			testCd.Spec.Schematic.CUE.Template = webServiceV1Template
+			testCd.SetNamespace(namespace)
+			Expect(k8sClient.Create(ctx, testCd)).Should(Succeed())
+		})
+
+		It("Test componentDefinition which definition and type point to different workload type", func() {
+			testCd := webServiceWithNoTemplate.DeepCopy()
+			testCd.SetName("test-componentdef-v4")
+			testCd.Spec.Workload.Type = "jobs.batch"
+			testCd.Spec.Schematic.CUE.Template = webServiceV1Template
+			testCd.SetNamespace(namespace)
+			Expect(k8sClient.Create(ctx, testCd)).Should(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
fix https://github.com/oam-dev/kubevela/issues/1473, align with https://github.com/oam-dev/kubevela/issues/1563

Add dynamic admission control for ComponentDefinition.

**MutatingWebhook**

`MutatingWebhook` will generate WorkloadDefinition based on the `Spec.Workload.Definition` field(if workloaddefinition does not exist), and fill in the `Spec.Workload.Type` field to point to the created workloaddefinition.

``` yaml
apiVersion: core.oam.dev/v1beta1
kind: ComponentDefinition
metadata:
  name: worker
  namespace: default
spec:
  workload:
    definition:
      apiVersion: apps/v1
      kind: Deployment
  schematic:
    cue:
      template: |
....
```

After being processed by `MutatingWebhook`

``` yaml
apiVersion: core.oam.dev/v1beta1
kind: ComponentDefinition
metadata:
  name: worker
  namespace: default
spec:
  workload:
    definition:
      apiVersion: apps/v1
      kind: Deployment
    type: deployments.app # MutatingWebhook filld the type field
  schematic:
    cue:
      template: |
...
```

Generate a `WorkloadDefinition` named `deployments.app`(If it doesn't exist).

```yaml
kind: WorkloadDefinition
metadata:
  name: deployments.app
spec:
  definitionRef:
    name: deployments.app
    version: v1
```

**ValidatingWebhook** check `Type` and `Definition` fields in `Spec.Workload`:

1. If  the fields are all empty, `ValidatingWebhook` will reject;


``` yaml
# Rejected!
apiVersion: core.oam.dev/v1beta1
kind: ComponentDefinition
metadata:
  name: worker
  namespace: default
spec:
  workload:
    definition:
    type:
  schematic:
    cue:
      template: |
....
```

2. if `Type` and `Definition`don‘t point to the same workloaddefinition, `ValidatingWebhook` will also reject.

``` yaml
# Rejected!
apiVersion: core.oam.dev/v1beta1
kind: ComponentDefinition
metadata:
  name: worker
  namespace: default
spec:
  workload:
    definition:
      apiVersion: apps/v1
      kind: Deployment
    type: containerizedworkloads.core.oam.dev  # definition and type point to different workload type
  schematic:
    cue:
      template: |
...
```

for details, please see:

https://github.com/oam-dev/spec/blob/master/3.component_model.md
https://github.com/oam-dev/spec/blob/master/4.workload_types.md

- [x] add webhook
- [x] add test