### PR TITLE
fix webhook: set a default workload.type for componentdefinition which doesn't refer to a workload

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -29,6 +29,8 @@ const (
 	DefaultEnvName = "default"
 	// DefaultAppNamespace defines the default K8s namespace for Apps created by KubeVela
 	DefaultAppNamespace = "default"
+	// AutoDetectWorkloadDefinition defines the default WorkloadDefinition for ComponentDefinition which doesn't specify a workload
+	AutoDetectWorkloadDefinition = "autodetect.core.oam.dev"
 )
 
 const (

--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -29,8 +29,8 @@ const (
 	DefaultEnvName = "default"
 	// DefaultAppNamespace defines the default K8s namespace for Apps created by KubeVela
 	DefaultAppNamespace = "default"
-	// AutoDetectWorkloadDefinition defines the default WorkloadDefinition for ComponentDefinition which doesn't specify a workload
-	AutoDetectWorkloadDefinition = "autodetect.core.oam.dev"
+	// AutoDetectWorkloadDefinition defines the default workload type for ComponentDefinition which doesn't specify a workload
+	AutoDetectWorkloadDefinition = "autodetects.core.oam.dev"
 )
 
 const (

--- a/charts/vela-core/templates/definitions/autodetect.yaml
+++ b/charts/vela-core/templates/definitions/autodetect.yaml
@@ -1,0 +1,8 @@
+apiVersion: core.oam.dev/v1beta1
+kind: WorkloadDefinition
+metadata:
+  name: autodetect.core.oam.dev
+  namespace: {{.Values.systemDefinitionNamespace}}
+spec:
+  definitionRef:
+    name: autodetect.core.oam.dev

--- a/charts/vela-core/templates/definitions/autodetect.yaml
+++ b/charts/vela-core/templates/definitions/autodetect.yaml
@@ -1,8 +1,10 @@
 apiVersion: core.oam.dev/v1beta1
 kind: WorkloadDefinition
 metadata:
-  name: autodetect.core.oam.dev
+  annotations:
+    definition.oam.dev/description: "autodetects.core.oam.dev is the default workload type of ComponentDefinition"
+  name: autodetects.core.oam.dev
   namespace: {{.Values.systemDefinitionNamespace}}
 spec:
   definitionRef:
-    name: autodetect.core.oam.dev
+    name: autodetects.core.oam.dev

--- a/pkg/appfile/appfile_test.go
+++ b/pkg/appfile/appfile_test.go
@@ -89,9 +89,11 @@ var _ = Describe("Test Helm schematic appfile", func() {
 						},
 					},
 					FullTemplate: &Template{
-						Reference: common.WorkloadGVK{
-							APIVersion: "apps/v1",
-							Kind:       "Deployment",
+						Reference: common.WorkloadTypeDescriptor{
+							Definition: common.WorkloadGVK{
+								APIVersion: "apps/v1",
+								Kind:       "Deployment",
+							},
 						},
 						Helm: &common.Helm{
 							Release: util.Object2RawExtension(map[string]interface{}{
@@ -316,9 +318,11 @@ spec:
 								},
 							},
 						},
-						Reference: common.WorkloadGVK{
-							APIVersion: "apps/v1",
-							Kind:       "Deployment",
+						Reference: common.WorkloadTypeDescriptor{
+							Definition: common.WorkloadGVK{
+								APIVersion: "apps/v1",
+								Kind:       "Deployment",
+							},
 						},
 					},
 				},

--- a/pkg/appfile/template.go
+++ b/pkg/appfile/template.go
@@ -52,7 +52,7 @@ type Template struct {
 	Health             string
 	CustomStatus       string
 	CapabilityCategory types.CapabilityCategory
-	Reference          common.WorkloadGVK
+	Reference          common.WorkloadTypeDescriptor
 	Helm               *common.Helm
 	Kube               *common.Kube
 	Terraform          *common.Terraform
@@ -85,9 +85,11 @@ func LoadTemplate(ctx context.Context, dm discoverymapper.DiscoveryMapper, cli c
 				if err != nil {
 					return nil, errors.WithMessagef(err, "Get GVK from workload definition [%s]", capName)
 				}
-				tmpl.Reference = common.WorkloadGVK{
-					APIVersion: gvk.GroupVersion().String(),
-					Kind:       gvk.Kind,
+				tmpl.Reference = common.WorkloadTypeDescriptor{
+					Definition: common.WorkloadGVK{
+						APIVersion: gvk.GroupVersion().String(),
+						Kind:       gvk.Kind,
+					},
 				}
 				return tmpl, nil
 			}
@@ -165,7 +167,7 @@ func DryRunTemplateLoader(defs []oam.Object) TemplateLoaderFn {
 
 func newTemplateOfCompDefinition(compDef *v1beta1.ComponentDefinition) (*Template, error) {
 	tmpl := &Template{
-		Reference:           compDef.Spec.Workload.Definition,
+		Reference:           compDef.Spec.Workload,
 		ComponentDefinition: compDef,
 	}
 	if err := loadSchematicToTemplate(tmpl, compDef.Spec.Status, compDef.Spec.Schematic, compDef.Spec.Extension); err != nil {

--- a/pkg/appfile/template_test.go
+++ b/pkg/appfile/template_test.go
@@ -486,9 +486,11 @@ spec:
 		Health:             "testHealthPolicy",
 		CustomStatus:       "testCustomStatus",
 		CapabilityCategory: types.CUECategory,
-		Reference: common.WorkloadGVK{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
+		Reference: common.WorkloadTypeDescriptor{
+			Definition: common.WorkloadGVK{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
 		},
 		Helm:                nil,
 		Kube:                nil,

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -86,6 +86,7 @@ type appHandler struct {
 	revisionHash             string
 	acrossNamespaceResources []v1beta1.TypedReference
 	resourceTracker          *v1beta1.ResourceTracker
+	autodetect               bool
 }
 
 // setInplace will mark if the application should upgrade the workload within the same instance(name never changed)
@@ -132,12 +133,21 @@ func (h *appHandler) apply(ctx context.Context, appRev *v1beta1.ApplicationRevis
 		return h.createOrUpdateAppRevision(ctx, appRev)
 	}
 
+	var needTracker bool
+	var err error
 	for _, comp := range comps {
 		comp.SetOwnerReferences(owners)
-		needTracker, err := h.checkAndSetResourceTracker(&comp.Spec.Workload)
+		if h.checkAutoDetect(comp) && h.isNewRevision {
+			if err = h.applyHelmModuleResources(ctx, comp, owners); err != nil {
+				return errors.Wrap(err, "cannot apply Helm module resources")
+			}
+			continue
+		}
+		needTracker, err = h.checkAndSetResourceTracker(&comp.Spec.Workload)
 		if err != nil {
 			return err
 		}
+
 		newComp := comp.DeepCopy()
 		// newComp will be updated and return the revision name instead of the component name
 		revisionName, err := h.createOrUpdateComponent(ctx, newComp)
@@ -172,17 +182,24 @@ func (h *appHandler) apply(ctx context.Context, appRev *v1beta1.ApplicationRevis
 	ac.SetOwnerReferences(owners)
 	h.FinalizeAppRevision(appRev, ac, comps)
 
+	if h.autodetect {
+		// TODO(yangsoon) autodetect is temporarily not implemented
+		return fmt.Errorf("helm mode component doesn't specify workload")
+	}
+
 	if err := h.createOrUpdateAppRevision(ctx, appRev); err != nil {
 		return err
 	}
 
-	// the rollout will create AppContext which will launch the real K8s resources.
+	// `h.inplace`: the rollout will create AppContext which will launch the real K8s resources.
 	// Otherwise, we should create/update the appContext here when there if no rollout controller to take care of new versions
 	// In this case, the workload should update with the annotation `app.oam.dev/inplace-upgrade=true`
-	if h.inplace {
+	// `!h.autodetect`: If the workload type of the helm mode component is not clear, an autodetect type workload will be specified by default
+	// In this case, the traits attached to the helm mode component will fail to generate,
+	// so we only call applyHelmModuleResources to create the helm resource, don't generate ApplicationContext.
+	if h.inplace && !h.autodetect {
 		return h.createOrUpdateAppContext(ctx, owners)
 	}
-
 	return nil
 }
 
@@ -211,7 +228,7 @@ func (h *appHandler) statusAggregate(appFile *appfile.Appfile) ([]common.Applica
 	for _, wl := range appFile.Workloads {
 		var status = common.ApplicationComponentStatus{
 			Name:               wl.Name,
-			WorkloadDefinition: wl.FullTemplate.Reference,
+			WorkloadDefinition: wl.FullTemplate.Reference.Definition,
 			Healthy:            true,
 		}
 
@@ -480,6 +497,14 @@ func (h *appHandler) checkAndSetResourceTracker(resource *runtime.RawExtension) 
 	return needTracker, nil
 }
 
+func (h *appHandler) checkAutoDetect(component *v1alpha2.Component) bool {
+	if len(component.Spec.Workload.Raw) == 0 && component.Spec.Workload.Object == nil && component.Spec.Helm != nil {
+		h.autodetect = true
+		return true
+	}
+	return false
+}
+
 // genResourceTrackerOwnerReference check the related resourceTracker whether have been created.
 // If not, create it. And return the ownerReference of this resourceTracker.
 func (h *appHandler) genResourceTrackerOwnerReference() *metav1.OwnerReference {
@@ -709,6 +734,9 @@ func (h *appHandler) handleResourceTracker(ctx context.Context, components []*v1
 	resourceTracker := new(v1beta1.ResourceTracker)
 	needTracker := false
 	for _, c := range components {
+		if h.checkAutoDetect(c) {
+			continue
+		}
 		u, err := oamutil.RawExtension2Unstructured(&c.Spec.Workload)
 		if err != nil {
 			return err

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -137,7 +137,10 @@ func (h *appHandler) apply(ctx context.Context, appRev *v1beta1.ApplicationRevis
 	var err error
 	for _, comp := range comps {
 		comp.SetOwnerReferences(owners)
-		if h.checkAutoDetect(comp) && h.isNewRevision {
+
+		// If the helm mode component doesn't specify the workload
+		// we just install a helm chart resources
+		if h.checkAutoDetect(comp) {
 			if err = h.applyHelmModuleResources(ctx, comp, owners); err != nil {
 				return errors.Wrap(err, "cannot apply Helm module resources")
 			}
@@ -184,7 +187,7 @@ func (h *appHandler) apply(ctx context.Context, appRev *v1beta1.ApplicationRevis
 
 	if h.autodetect {
 		// TODO(yangsoon) autodetect is temporarily not implemented
-		return fmt.Errorf("helm mode component doesn't specify workload")
+		return fmt.Errorf("helm mode component doesn't specify workload, the traits attached to the helm mode component will fail to work")
 	}
 
 	if err := h.createOrUpdateAppRevision(ctx, appRev); err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply_test.go
@@ -301,8 +301,12 @@ var _ = Describe("Test statusAggregate", func() {
 			appFile = &appfile.Appfile{
 				Workloads: []*appfile.Workload{
 					{
-						Name:               componentName,
-						FullTemplate:       &appfile.Template{Reference: common.WorkloadGVK{APIVersion: "v1", Kind: "A1"}},
+						Name: componentName,
+						FullTemplate: &appfile.Template{
+							Reference: common.WorkloadTypeDescriptor{
+								Definition: common.WorkloadGVK{APIVersion: "v1", Kind: "A1"},
+							},
+						},
 						CapabilityCategory: velatypes.TerraformCategory,
 					},
 				},

--- a/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/mutating_handler.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
 	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
@@ -101,7 +102,9 @@ func (h *MutatingHandler) Mutate(obj *v1beta1.ComponentDefinition) error {
 			}
 			return err
 		}
+		return nil
 	}
+	obj.Spec.Workload.Type = types.AutoDetectWorkloadDefinition
 	return nil
 }
 

--- a/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler.go
@@ -99,9 +99,5 @@ func ValidateWorkload(dm discoverymapper.DiscoveryMapper, cd *v1beta1.ComponentD
 			return fmt.Errorf("the type and the definition of the workload field in ComponentDefinition %s should represent the same workload", cd.Name)
 		}
 	}
-
-	if cd.Spec.Schematic != nil && cd.Spec.Schematic.HELM != nil && cd.Spec.Workload.Definition == (common.WorkloadGVK{}) {
-		return fmt.Errorf("the definition of the workload field should be set when you use HELM in ComponentDefinition %s", cd.Name)
-	}
 	return nil
 }

--- a/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/componentdefinition/validating_handler_test.go
@@ -186,8 +186,7 @@ var _ = Describe("Test ComponentDefinition validating handler", func() {
 				},
 			}
 			resp := handler.Handle(context.TODO(), req)
-			Expect(resp.Allowed).Should(BeFalse())
-			Expect(resp.Result.Reason).Should(Equal(metav1.StatusReason("the definition of the workload field should be set when you use HELM in ComponentDefinition helmCd")))
+			Expect(resp.Allowed).Should(BeTrue())
 		})
 	})
 })

--- a/test/e2e-test/definition_test.go
+++ b/test/e2e-test/definition_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
@@ -125,7 +126,13 @@ var _ = Describe("ComponentDefinition Normal tests", func() {
 			testCd1.Spec.Workload.Definition = common.WorkloadGVK{}
 			testCd1.Spec.Schematic.CUE.Template = webServiceV1Template
 			testCd1.SetNamespace(namespace)
-			Expect(k8sClient.Create(ctx, testCd1)).Should(HaveOccurred())
+			Expect(k8sClient.Create(ctx, testCd1)).Should(BeNil())
+
+			newCd := new(v1beta1.ComponentDefinition)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: testCd1.Name, Namespace: namespace}, newCd)
+			}, 15*time.Second, time.Second).Should(BeNil())
+			Expect(newCd.Spec.Workload.Type).Should(Equal(types.AutoDetectWorkloadDefinition))
 		})
 
 		It("Test componentDefinition which definition and type point to same workload type", func() {

--- a/test/e2e-test/helm_app_test.go
+++ b/test/e2e-test/helm_app_test.go
@@ -339,7 +339,7 @@ var _ = Describe("Test application containing helm module", func() {
 
 	It("Test deploy an application containing helm module and the componet refer to autodetect type worklaod", func() {
 		cd := v1alpha2.ComponentDefinition{}
-		cd.SetName("wrong-cd")
+		cd.SetName("podinfo")
 		cd.SetNamespace(namespace)
 		cd.Spec.Schematic = &common.Schematic{
 			HELM: &common.Helm{
@@ -368,7 +368,7 @@ var _ = Describe("Test application containing helm module", func() {
 				Components: []v1alpha2.ApplicationComponent{
 					{
 						Name:         compName,
-						WorkloadType: "wrong-cd",
+						WorkloadType: "podinfo",
 						Settings: util.Object2RawExtension(map[string]interface{}{
 							"image": map[string]interface{}{
 								"tag": "5.1.2",


### PR DESCRIPTION
refer to https://github.com/oam-dev/kubevela/pull/1680#discussion_r634808401

The validating logic of the componentdeifnition webhook will reject if the componentDefinition doesn't refer to a workload.
Now we will set a default workloaddefinition `autodetect.core.oam.dev` for the componentDefinition.