### PR TITLE
fix bug: store parameter to configMap for definition which parameter is a non-structure type

### DIFF
--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -359,12 +359,14 @@ func GenerateOpenAPISchemaFromDefinition(definitionName, cueTemplate string) ([]
 func prepareParameterCue(capabilityName, capabilityTemplate string) (string, error) {
 	var template string
 	var withParameterFlag bool
-	r := regexp.MustCompile("[[:space:]]*parameter:[[:space:]]*{.*")
+	r := regexp.MustCompile(`[[:space:]]*parameter:[[:space:]]*`)
+	trimRe := regexp.MustCompile(`\s+`)
 
 	for _, text := range strings.Split(capabilityTemplate, "\n") {
 		if r.MatchString(text) {
 			// a variable has to be refined as a definition which starts with "#"
-			text = fmt.Sprintf("parameter: #parameter\n#%s", text)
+			// text may be start with space or tab, we should clean up text
+			text = fmt.Sprintf("parameter: #parameter\n#%s", trimRe.ReplaceAllString(text, ""))
 			withParameterFlag = true
 		}
 		template += fmt.Sprintf("%s\n", text)

--- a/pkg/controller/utils/testdata/definition/workload1.cue
+++ b/pkg/controller/utils/testdata/definition/workload1.cue
@@ -1,7 +1,0 @@
-project: {
-	name: string
-}
-
-parameter: {
-	min: int
-}

--- a/pkg/controller/utils/testdata/definition/workloadNoParameter.cue
+++ b/pkg/controller/utils/testdata/definition/workloadNoParameter.cue
@@ -1,7 +1,0 @@
-project: {
-	name: string
-}
-
-noParameter: {
-	min: int
-}


### PR DESCRIPTION
fix https://github.com/oam-dev/kubevela/issues/1684

fix bug, when apply a definition which parameter is a non-structure type, controller will fail to store the configMap,like:
```yaml
apiVersion: core.oam.dev/v1beta1
kind: TraitDefinition
metadata:
  annotations:
    definition.oam.dev/description: "Add annotations for your Workload."
  name: annotations
spec:
  appliesToWorkloads:
    - webservice
    - worker
  schematic:
    cue:
      template: |-
        patch: {
        	spec: template: metadata: annotations: {
        		for k, v in parameter {
        			"\(k)": v
        		}
        	}
        }
        # Re expression will not match this situation
        parameter: [string]: string
```

and if `parameter: [string]: string` start with space or tab it also fail to store configMap.

```yaml
# Code generated by KubeVela templates. DO NOT EDIT.
apiVersion: core.oam.dev/v1beta1
kind: TraitDefinition
metadata:
  annotations:
    definition.oam.dev/description: "add vpc-id for ingress trait"
  name: vpc-ingress
spec:
  schematic:
    cue:
      template: |
        patch: {
        	context: outputs: ingress: {
        		metadata: annotations: {
        			"vpc-id": parameter.vpcId
        		}
        	}
        }
            parameter:{  # failed to store configMap because the cue template was not be formated 
              vpcId: string
            }
```

this pr modified the Re expression matching `parameter` and clean up the `parameter`
  
  ```
  [:space:]]*parameter:[[:space:]]*{.*   =>   [[:space:]]*parameter:[[:space:]]*
  ```

- [x] 1. fix Re expression
- [x] 2. add test

