### PR TITLE
refactor the way of get OpenAPISchema in trait/component definition controller

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
@@ -111,39 +111,40 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	def := utils.NewCapabilityComponentDef(&componentDefinition)
 
 	// Store the parameter of componentDefinition to configMap
-	err = def.StoreOpenAPISchema(ctx, r.Client, r.pd, req.Namespace, req.Name, defRev.Name)
+	cmName, err := def.StoreOpenAPISchema(ctx, r.Client, r.pd, req.Namespace, req.Name, defRev.Name)
 	if err != nil {
 		klog.ErrorS(err, "cannot store capability in ConfigMap")
-		r.record.Event(&(def.ComponentDefinition), event.Warning("cannot store capability in ConfigMap", err))
-		return ctrl.Result{}, util.PatchCondition(ctx, r, &(def.ComponentDefinition),
+		r.record.Event(&(componentDefinition), event.Warning("cannot store capability in ConfigMap", err))
+		return ctrl.Result{}, util.PatchCondition(ctx, r, &(componentDefinition),
 			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrStoreCapabilityInConfigMap, def.Name, err)))
 	}
+	componentDefinition.Status.ConfigMapRef = cmName
 	klog.Info("Successfully stored Capability Schema in ConfigMap")
 
-	if err = r.createOrUpdateComponentDefRevision(ctx, req.Namespace, &def.ComponentDefinition, defRev); err != nil {
+	if err = r.createOrUpdateComponentDefRevision(ctx, req.Namespace, &componentDefinition, defRev); err != nil {
 		klog.ErrorS(err, "cannot create DefinitionRevision")
-		r.record.Event(&(def.ComponentDefinition), event.Warning("cannot create DefinitionRevision", err))
-		return ctrl.Result{}, util.PatchCondition(ctx, r, &(def.ComponentDefinition),
+		r.record.Event(&(componentDefinition), event.Warning("cannot create DefinitionRevision", err))
+		return ctrl.Result{}, util.PatchCondition(ctx, r, &(componentDefinition),
 			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrCreateOrUpdateDefinitionRevision, defRev.Name, err)))
 	}
 	klog.InfoS("Successfully create DefinitionRevision", "name", defRev.Name)
 
-	def.ComponentDefinition.Status.LatestRevision = &common.Revision{
+	componentDefinition.Status.LatestRevision = &common.Revision{
 		Name:         defRev.Name,
 		Revision:     defRev.Spec.Revision,
 		RevisionHash: defRev.Spec.RevisionHash,
 	}
 
-	if err := r.UpdateStatus(ctx, &def.ComponentDefinition); err != nil {
+	if err := r.UpdateStatus(ctx, &componentDefinition); err != nil {
 		klog.ErrorS(err, "cannot update componentDefinition Status")
-		r.record.Event(&(def.ComponentDefinition), event.Warning("cannot update ComponentDefinition Status", err))
-		return ctrl.Result{}, util.PatchCondition(ctx, r, &(def.ComponentDefinition),
-			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrUpdateComponentDefinition, def.ComponentDefinition.Name, err)))
+		r.record.Event(&(componentDefinition), event.Warning("cannot update ComponentDefinition Status", err))
+		return ctrl.Result{}, util.PatchCondition(ctx, r, &(componentDefinition),
+			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrUpdateComponentDefinition, componentDefinition.Name, err)))
 	}
 
-	if err := coredef.CleanUpDefinitionRevision(ctx, r.Client, &def.ComponentDefinition, r.defRevLimit); err != nil {
+	if err := coredef.CleanUpDefinitionRevision(ctx, r.Client, &componentDefinition, r.defRevLimit); err != nil {
 		klog.Error("[Garbage collection]")
-		r.record.Event(&def.ComponentDefinition, event.Warning("failed to garbage collect DefinitionRevision of type ComponentDefinition", err))
+		r.record.Event(&componentDefinition, event.Warning("failed to garbage collect DefinitionRevision of type ComponentDefinition", err))
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller.go
@@ -109,43 +109,46 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
-	var def utils.CapabilityTraitDefinition
-	def.Name = req.NamespacedName.Name
+	def := utils.CapabilityTraitDefinition{
+		Name:            traitdefinition.Name,
+		TraitDefinition: traitdefinition,
+	}
 
 	// Store the parameter of traitDefinition to configMap
-	err = def.StoreOpenAPISchema(ctx, r.Client, r.pd, req.Namespace, req.Name)
+	cmName, err := def.StoreOpenAPISchema(ctx, r.Client, r.pd, req.Namespace, req.Name, defRev.Name)
 	if err != nil {
 		klog.ErrorS(err, "cannot store capability in ConfigMap")
-		r.record.Event(&(def.TraitDefinition), event.Warning("cannot store capability in ConfigMap", err))
-		return ctrl.Result{}, util.PatchCondition(ctx, r, &def.TraitDefinition,
-			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrStoreCapabilityInConfigMap, def.Name, err)))
+		r.record.Event(&(traitdefinition), event.Warning("cannot store capability in ConfigMap", err))
+		return ctrl.Result{}, util.PatchCondition(ctx, r, &traitdefinition,
+			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrStoreCapabilityInConfigMap, traitdefinition.Name, err)))
 	}
+	traitdefinition.Status.ConfigMapRef = cmName
 	klog.Info("Successfully stored Capability Schema in ConfigMap")
 
-	if err = r.createOrUpdateTraitDefRevision(ctx, req.Namespace, &def.TraitDefinition, defRev); err != nil {
+	if err = r.createOrUpdateTraitDefRevision(ctx, req.Namespace, &traitdefinition, defRev); err != nil {
 		klog.ErrorS(err, "cannot create DefinitionRevision")
-		r.record.Event(&(def.TraitDefinition), event.Warning("cannot create DefinitionRevision", err))
-		return ctrl.Result{}, util.PatchCondition(ctx, r, &(def.TraitDefinition),
+		r.record.Event(&(traitdefinition), event.Warning("cannot create DefinitionRevision", err))
+		return ctrl.Result{}, util.PatchCondition(ctx, r, &(traitdefinition),
 			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrCreateOrUpdateDefinitionRevision, defRev.Name, err)))
 	}
 	klog.InfoS("Successfully create DefinitionRevision", "name", defRev.Name)
 
-	def.TraitDefinition.Status.LatestRevision = &common.Revision{
+	traitdefinition.Status.LatestRevision = &common.Revision{
 		Name:         defRev.Name,
 		Revision:     defRev.Spec.Revision,
 		RevisionHash: defRev.Spec.RevisionHash,
 	}
 
-	if err := r.UpdateStatus(ctx, &def.TraitDefinition); err != nil {
+	if err := r.UpdateStatus(ctx, &traitdefinition); err != nil {
 		klog.ErrorS(err, "cannot update TraitDefinition Status")
-		r.record.Event(&(def.TraitDefinition), event.Warning("cannot update TraitDefinition Status", err))
-		return ctrl.Result{}, util.PatchCondition(ctx, r, &(def.TraitDefinition),
-			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrUpdateTraitDefinition, def.TraitDefinition.Name, err)))
+		r.record.Event(&(traitdefinition), event.Warning("cannot update TraitDefinition Status", err))
+		return ctrl.Result{}, util.PatchCondition(ctx, r, &(traitdefinition),
+			cpv1alpha1.ReconcileError(fmt.Errorf(util.ErrUpdateTraitDefinition, traitdefinition.Name, err)))
 	}
 
-	if err := coredef.CleanUpDefinitionRevision(ctx, r.Client, &def.TraitDefinition, r.defRevLimit); err != nil {
+	if err := coredef.CleanUpDefinitionRevision(ctx, r.Client, &traitdefinition, r.defRevLimit); err != nil {
 		klog.Error("[Garbage collection]")
-		r.record.Event(&def.TraitDefinition, event.Warning("failed to garbage collect DefinitionRevision of type TraitDefinition", err))
+		r.record.Event(&traitdefinition, event.Warning("failed to garbage collect DefinitionRevision of type TraitDefinition", err))
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controller/utils/capability_integrate_test.go
+++ b/pkg/controller/utils/capability_integrate_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
@@ -102,21 +102,17 @@ spec:
         }
 
 `
-			var componentDefinition v1alpha2.ComponentDefinition
+			var componentDefinition v1beta1.ComponentDefinition
 			Expect(yaml.Unmarshal([]byte(validComponentDefinition), &componentDefinition)).Should(BeNil())
 			Expect(k8sClient.Create(ctx, &componentDefinition)).Should(Succeed())
 
 			By("Test GetCapabilityObject")
-			def := &CapabilityComponentDefinition{Name: componentDefinitionName}
-			capability, err := def.GetCapabilityObject(ctx, k8sClient, namespace, componentDefinitionName)
-			Expect(err).Should(BeNil())
-			Expect(capability).Should(Not(BeNil()))
+			def := &CapabilityComponentDefinition{Name: componentDefinitionName, ComponentDefinition: *componentDefinition.DeepCopy()}
 
 			By("Test GetOpenAPISchema")
-			schema, err := def.GetOpenAPISchema(ctx, k8sClient, pd, namespace, componentDefinitionName)
+			schema, err := def.GetOpenAPISchema(pd, namespace)
 			Expect(err).Should(BeNil())
 			Expect(schema).Should(Not(BeNil()))
-
 		})
 	})
 
@@ -166,19 +162,15 @@ spec:
         }
 `
 
-			var traitDefinition v1alpha2.TraitDefinition
+			var traitDefinition v1beta1.TraitDefinition
 			Expect(yaml.Unmarshal([]byte(validTraitDefinition), &traitDefinition)).Should(BeNil())
 			Expect(k8sClient.Create(ctx, &traitDefinition)).Should(Succeed())
 
-			By("Test GetCapabilityObject")
-			def := &CapabilityTraitDefinition{Name: traitDefinitionName}
-			capability, err := def.GetCapabilityObject(ctx, k8sClient, namespace, traitDefinitionName)
-			Expect(err).Should(BeNil())
-			Expect(capability).Should(Not(BeNil()))
+			def := &CapabilityTraitDefinition{Name: traitDefinitionName, TraitDefinition: *traitDefinition.DeepCopy()}
 
 			By("Test GetOpenAPISchema")
 			var expectedSchema = "{\"properties\":{\"replicas\":{\"default\":1,\"description\":\"Replicas of the workload\",\"title\":\"replicas\",\"type\":\"integer\"}},\"required\":[\"replicas\"],\"type\":\"object\"}"
-			schema, err := def.GetOpenAPISchema(ctx, k8sClient, pd, namespace, traitDefinitionName)
+			schema, err := def.GetOpenAPISchema(pd, traitDefinitionName)
 			Expect(err).Should(BeNil())
 			Expect(string(schema)).Should(Equal(expectedSchema))
 		})


### PR DESCRIPTION
Refactor the way of get Open-API-Schema in trait/component definition controller.

Previously, the Definition would be got twice in the controller.  

1. this PR refactor function `GetOpenAPISchema`, only get the Definition once.
2. fix some unstable e2e-tests