### PR TITLE
fix show annotations

### DIFF
--- a/e2e/plugin/plugin_test.go
+++ b/e2e/plugin/plugin_test.go
@@ -140,6 +140,12 @@ var _ = Describe("Test Kubectl Plugin", func() {
 			Expect(output).Should(ContainSubstring("targetPort"))
 			Expect(output).Should(ContainSubstring("target port num for service provider."))
 		})
+		It("Test show traitDefinition def with cue single map parameter", func() {
+			tdName := "annotations"
+			output, err := e2e.Exec(fmt.Sprintf("kubectl-vela show %s", tdName))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).Should(ContainSubstring("map[string]string"))
+		})
 	})
 
 	Context("Test kubectl vela comp discover", func() {

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -541,31 +541,8 @@ func (ref *ParseReference) parseParameters(paraValue cue.Value, paramKey string,
 			param.Name = "undefined"
 			param.Required = true
 			tl := paraValue.Template()
-			if tl == nil {
-				sourceStr := paraValue.Source() // original node string for this value
-				typeContain := fmt.Sprintf("%s", sourceStr)
-				switch {
-				case strings.Contains(typeContain, "string"):
-					param.PrintableType = "string"
-				case strings.Contains(typeContain, "int"):
-					param.PrintableType = "int"
-				case strings.Contains(typeContain, "bool"):
-					param.PrintableType = "bool"
-				default:
-					return fmt.Errorf("fail to get cue parameter type ")
-				}
-			} else { // is map type
-				typeContain := fmt.Sprintf("map type %s", tl("").IncompleteKind())
-				switch {
-				case strings.Contains(typeContain, "string"):
-					param.PrintableType = "map[string]string"
-				case strings.Contains(typeContain, "int"):
-					param.PrintableType = "map[string]int"
-				case strings.Contains(typeContain, "bool"):
-					param.PrintableType = "map[string]bool"
-				default:
-					return fmt.Errorf("fail to get cue parameter type ")
-				}
+			if tl != nil { // is map type
+				param.PrintableType = fmt.Sprintf("map[string]%s", tl("").IncompleteKind().String())
 			}
 			params = append(params, param)
 		}

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -536,6 +536,40 @@ func (ref *ParseReference) parseParameters(paraValue cue.Value, paramKey string,
 		if err != nil {
 			return fmt.Errorf("arguments not defined as struct %w", err)
 		}
+		if arguments.Len() == 0 {
+			var param ReferenceParameter
+			param.Name = "undefined"
+			param.Required = true
+			tl := paraValue.Template()
+			if tl == nil {
+				sourceStr := paraValue.Source() // original node string for this value
+				typeContain := fmt.Sprintf("%s", sourceStr)
+				switch {
+				case strings.Contains(typeContain, "string"):
+					param.PrintableType = "string"
+				case strings.Contains(typeContain, "int"):
+					param.PrintableType = "int"
+				case strings.Contains(typeContain, "bool"):
+					param.PrintableType = "bool"
+				default:
+					return fmt.Errorf("fail to get cue parameter type ")
+				}
+			} else { // is map type
+				typeContain := fmt.Sprintf("map type %s", tl("").IncompleteKind())
+				switch {
+				case strings.Contains(typeContain, "string"):
+					param.PrintableType = "map[string]string"
+				case strings.Contains(typeContain, "int"):
+					param.PrintableType = "map[string]int"
+				case strings.Contains(typeContain, "bool"):
+					param.PrintableType = "map[string]bool"
+				default:
+					return fmt.Errorf("fail to get cue parameter type ")
+				}
+			}
+			params = append(params, param)
+		}
+
 		for i := 0; i < arguments.Len(); i++ {
 			var param ReferenceParameter
 			fi := arguments.Field(i)


### PR DESCRIPTION
###New
Only fix map type parameter (the resolution for cue parameter need to be struct kind ), for  single string , int and bool type  we need to fix in  pkg/cue/convert.go  and add  non-struct kind logic.

We should declare the parameter name and ”+usage"  in cue template
fix #1618 
![image](https://user-images.githubusercontent.com/35907099/119541237-f7946480-bdc0-11eb-910b-5304ed8913ad.png)
the resolution for cue template in function GetCUEParameterValue has no problem

example for two parameter declare and resolution：
![image](https://user-images.githubusercontent.com/35907099/119600754-49b5a400-be1a-11eb-8dd3-930a0f101f45.png)



