### PR TITLE
Add securityContext for containers

### DIFF
--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -28,13 +28,11 @@ serviceAccount:
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  runAsUser: 60000
+  runAsGroup: 60001
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
 
 resources:
   limits:


### PR DESCRIPTION
In order make it more secure for KubeVela core running container, add `securityContext`.

runAsUser：# The UID to run the entrypoint of the container process.
runAsGroup: # The GID to run the entrypoint of the container process.
fsGroup: # The GID of creating files
allowPrivilegeEscalation: false  # // AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process.
readOnlyRootFilesystem: true # Whether this container has a read-only root filesystem. Here is a demo on why should we use read-only root file system in a container https://securek8s.dev/exercise/10-ro-fs/

For a more detailed explanation, please refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod

Fix the issue of installing kubevela in OpenShift #1694