### PR TITLE
add chart debug value

### DIFF
--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -107,6 +107,9 @@ spec:
           args:
             - "--metrics-addr=:8080"
             - "--enable-leader-election"
+            {{ if .Values.logDebug }}
+            - "--log-debug=true"
+            {{ end }}
             {{ if .Values.admissionWebhooks.enabled }}
             - "--use-webhook=true"
             - "--webhook-port={{ .Values.webhookService.port }}"

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -78,6 +78,8 @@ admissionWebhooks:
   certManager:
     enabled: false
 
+#Enable debug logs for development purpose
+logDebug: true
 
 systemDefinitionNamespace: vela-system
 

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -79,7 +79,7 @@ admissionWebhooks:
     enabled: false
 
 #Enable debug logs for development purpose
-logDebug: true
+logDebug: false
 
 systemDefinitionNamespace: vela-system
 


### PR DESCRIPTION
### some import error logs use log.debug print error message, example cannot apply workload like :
```
2021-05-26T15:36:24.326+0800    DEBUG   kubevela        Cannot apply workload   {"controller": "oam/applicationcontext.core.oam.dev", "uid": "0daa7c7f-93fa-4b79-b445-21bf857b5816", "version": "", "error": "cannot apply trait \"apps/v1\" \"StatefulSet\" \"redis-replicas\": cannot create object: StatefulSet.apps \"redis-replicas\" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{\"app.kubernetes.io/component\":\"replica\", \"app.kubernetes.io/name\":\"redis-dev\"}: `selector` does not match template `labels`", "errorVerbose": "StatefulSet.apps \"redis-replicas\" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{\"app.kubernetes.io/component\":\"replica\", \"app.kubernetes.io/name\":\"redis-dev\"}: `selector` does not match template `labels`\ncannot create object\ngithub.com/oam-dev/kubevela/pkg/utils/apply.createOrGetExisting.func1\n\t/Users/lixudong/code/golang/src/kubevela/pkg/utils/apply/apply.go:136\ngithub.com/oam-dev/kubevela/pkg/utils/apply.createOrGetExisting\n\t/Users/lixudong/code/golang/src/kubevela/pkg/utils/apply/apply.go:148\ngithub.com/oam-dev/kubevela/pkg/utils/apply.creatorFn.createOrGetExisting\n\t/Users/lixudong/code/golang/src/kubevela/pkg/utils/apply/apply.go:67\ngithub.com/oam-dev/kubevela/pkg/utils/apply.(*APIApplicator).Apply\n\t/Users/

```
### i think add a debug value , user can set it when helm install maybe batter 
