### PR TITLE
Add validating webhook for AppDeployment

### DIFF
--- a/apis/core.oam.dev/v1beta1/register.go
+++ b/apis/core.oam.dev/v1beta1/register.go
@@ -111,10 +111,10 @@ var (
 
 // AppDeployment type metadata.
 var (
-	AppDeploymentKind            = reflect.TypeOf(AppDeployment{}).Name()
-	AppDeploymentGroupKind       = schema.GroupKind{Group: Group, Kind: AppDeploymentKind}.String()
-	AppDeploymentKindAPIVersion  = AppDeploymentKind + "." + SchemeGroupVersion.String()
-	AppDeploymentKindVersionKind = SchemeGroupVersion.WithKind(AppDeploymentKind)
+	AppDeploymentKind             = reflect.TypeOf(AppDeployment{}).Name()
+	AppDeploymentGroupKind        = schema.GroupKind{Group: Group, Kind: AppDeploymentKind}.String()
+	AppDeploymentKindAPIVersion   = AppDeploymentKind + "." + SchemeGroupVersion.String()
+	AppDeploymentGroupVersionKind = SchemeGroupVersion.WithKind(AppDeploymentKind)
 )
 
 // Cluster type metadata.

--- a/charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -188,5 +188,30 @@ webhooks:
           - UPDATE
         resources:
           - componentdefinitions
-          
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: {{ template "kubevela.name" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /validating-core-oam-dev-v1beta1-appdeployments
+    {{- if .Values.admissionWebhooks.patch.enabled  }}
+    failurePolicy: Ignore
+    {{- else }}
+    failurePolicy: Fail
+    {{- end }}
+    name: validating.core.oam-dev.v1beta1.appdeployments
+    sideEffects: None
+    admissionReviewVersions:
+      - v1beta1
+    rules:
+      - apiGroups:
+          - core.oam.dev
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - appdeployments
+
 {{- end -}}

--- a/pkg/controller/core.oam.dev/v1alpha2/appdeployment/appdeployment_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/appdeployment/appdeployment_controller.go
@@ -539,7 +539,7 @@ func (r *Reconciler) applyTraffic(ctx context.Context, appd *oamcore.AppDeployme
 
 func addAppDeploymentAsOwner(child, appd metav1.Object) {
 	child.SetOwnerReferences(append(child.GetOwnerReferences(),
-		*metav1.NewControllerRef(appd, oamcore.AppDeploymentKindVersionKind)))
+		*metav1.NewControllerRef(appd, oamcore.AppDeploymentGroupVersionKind)))
 }
 
 func removeString(slice []string, s string) (result []string) {

--- a/pkg/webhook/core.oam.dev/register.go
+++ b/pkg/webhook/core.oam.dev/register.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
 	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/appdeployment"
 	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/application"
 	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration"
 	"github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev/v1alpha2/applicationrollout"
@@ -41,6 +42,7 @@ func Register(mgr manager.Manager, args controller.Args) {
 	applicationrollout.RegisterValidatingHandler(mgr)
 	component.RegisterMutatingHandler(mgr, args)
 	component.RegisterValidatingHandler(mgr)
+	appdeployment.RegisterValidatingHandler(mgr)
 
 	server := mgr.GetWebhookServer()
 	server.Register("/convert", &conversion.Webhook{})

--- a/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/suite_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/suite_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package appdeployment
 
 import (

--- a/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/suite_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/suite_test.go
@@ -1,0 +1,70 @@
+package appdeployment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/scale/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var decoder *admission.Decoder
+var testScheme = runtime.NewScheme()
+var testEnv *envtest.Environment
+var cfg *rest.Config
+var k8sClient client.Client
+var handler *ValidatingHandler
+
+func TestAppDeployment(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AppDeployment Suite")
+}
+
+var _ = BeforeSuite(func(done Done) {
+	var err error
+	var yamlPath string
+	if _, set := os.LookupEnv("COMPATIBILITY_TEST"); set {
+		yamlPath = "../../../../../test/compatibility-test/testdata"
+	} else {
+		yamlPath = filepath.Join("../../../../..", "charts", "vela-core", "crds")
+	}
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{yamlPath},
+	}
+
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	err = v1beta1.SchemeBuilder.AddToScheme(testScheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = scheme.AddToScheme(testScheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	decoder, err = admission.NewDecoder(testScheme)
+	Expect(err).Should(BeNil())
+	handler = &ValidatingHandler{}
+	Expect(handler.InjectDecoder(decoder)).Should(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+	Expect(handler.InjectClient(k8sClient)).Should(BeNil())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/validating_handler.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net/http"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -100,8 +102,10 @@ func (h *ValidatingHandler) validateRevisions(appDeployment *v1beta1.AppDeployme
 			targetAppRevision := &v1beta1.ApplicationRevision{}
 			if err := h.Get(context.Background(), ktypes.NamespacedName{Namespace: appDeployment.Namespace, Name: appRevisionName},
 				targetAppRevision); err != nil {
-				allErrs = append(allErrs, field.NotFound(fldPath.Child("revisionName"), appRevisionName))
-				continue
+				// Other errors will be handled in the Reconcile
+				if apierrors.IsNotFound(err) {
+					allErrs = append(allErrs, field.NotFound(fldPath.Child("revisionName"), appRevisionName))
+				}
 			}
 		}
 	}

--- a/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/validating_handler.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appdeployment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// ValidatingHandler handles AppDeployment
+type ValidatingHandler struct {
+	client.Client
+
+	// Decoder decodes objects
+	Decoder *admission.Decoder
+}
+
+var _ admission.Handler = &ValidatingHandler{}
+
+// Handle handles admission requests.
+func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	obj := &v1beta1.AppDeployment{}
+	if err := h.Decoder.Decode(req, obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if req.Operation == admissionv1beta1.Create || req.Operation == admissionv1beta1.Update {
+		if allErrs := h.validateRevisions(obj); len(allErrs) > 0 {
+			return admission.Denied(allErrs.ToAggregate().Error())
+		}
+	}
+	return admission.ValidationResponse(true, "")
+}
+
+var _ inject.Client = &ValidatingHandler{}
+
+// InjectClient injects the client into the ValidatingHandler
+func (h *ValidatingHandler) InjectClient(c client.Client) error {
+	h.Client = c
+	return nil
+}
+
+var _ admission.DecoderInjector = &ValidatingHandler{}
+
+// InjectDecoder injects the decoder into the ValidatingHandler
+func (h *ValidatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.Decoder = d
+	return nil
+}
+
+// RegisterValidatingHandler will register AppDeployment validation to webhook
+func RegisterValidatingHandler(mgr manager.Manager) {
+	server := mgr.GetWebhookServer()
+	server.Register("/validating-core-oam-dev-v1beta1-appdeployments",
+		&webhook.Admission{Handler: &ValidatingHandler{}})
+}
+
+// ValidateRevisions validates whether the ApplicationRevisions referenced by the RevisionName field are valid
+func (h *ValidatingHandler) validateRevisions(appDeployment *v1beta1.AppDeployment) field.ErrorList {
+	allErrs := apimachineryvalidation.ValidateObjectMeta(&appDeployment.ObjectMeta, true,
+		apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
+
+	if appDeployment.DeletionTimestamp.IsZero() {
+		fldPath := field.NewPath("spec").Child("apprevisions")
+		for i, appRevision := range appDeployment.Spec.AppRevisions {
+			appRevisionName := appRevision.RevisionName
+			if len(appRevisionName) == 0 {
+				allErrs = append(allErrs, field.Required(fldPath.Child(fmt.Sprintf("[%d]", i)),
+					"target application revision name cannot be empty"))
+				continue
+			}
+
+			targetAppRevision := &v1beta1.ApplicationRevision{}
+			if err := h.Get(context.Background(), ktypes.NamespacedName{Namespace: appDeployment.Namespace, Name: appRevisionName},
+				targetAppRevision); err != nil {
+				allErrs = append(allErrs, field.NotFound(fldPath.Child("revisionName"), appRevisionName))
+				continue
+			}
+		}
+	}
+	return allErrs
+}

--- a/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/validating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/appdeployment/validating_handler_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appdeployment
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ = Describe("Test AppDeployment validating handler", func() {
+	appDeploymentResource := metav1.GroupVersionResource{
+		Group:    v1beta1.Group,
+		Version:  v1beta1.Version,
+		Resource: "appdeployments",
+	}
+
+	It("Test wrong resource of admission request", func() {
+		resp := handler.Handle(context.Background(), admission.Request{
+			AdmissionRequest: admissionv1beta1.AdmissionRequest{
+				Operation: admissionv1beta1.Create,
+				Resource: metav1.GroupVersionResource{
+					Group:    v1beta1.Group,
+					Version:  v1beta1.Version,
+					Resource: "foos",
+				},
+				Object: runtime.RawExtension{Raw: []byte("")},
+			},
+		})
+		Expect(resp.Allowed).Should(BeFalse())
+	})
+
+	It("Test wrong object of admission request", func() {
+		resp := handler.Handle(context.Background(), admission.Request{
+			AdmissionRequest: admissionv1beta1.AdmissionRequest{
+				Operation: admissionv1beta1.Create,
+				Resource:  appDeploymentResource,
+				Object:    runtime.RawExtension{Raw: []byte("bad object")},
+			},
+		})
+		Expect(resp.Allowed).Should(BeFalse())
+	})
+
+	Context("Test wrong application revision name", func() {
+		It("Test empty application revision name", func() {
+			ad := v1beta1.AppDeployment{}
+			ad.SetGroupVersionKind(v1beta1.AppDeploymentGroupVersionKind)
+			ad.Name = "empty"
+			ad.Namespace = "namespace"
+			ad.Spec.AppRevisions = []v1beta1.AppRevision{{RevisionName: ""}}
+			raw, _ := json.Marshal(ad)
+
+			resp := handler.Handle(context.Background(), admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					Resource:  appDeploymentResource,
+					Object:    runtime.RawExtension{Raw: raw},
+				},
+			})
+			Expect(resp.Allowed).Should(BeFalse())
+			Expect(resp.Result.Reason).Should(Equal(metav1.StatusReason("spec.apprevisions.[0]: Required value: target application revision name cannot be empty")))
+		})
+
+		It("Test non-existent application revision name", func() {
+			ad := v1beta1.AppDeployment{}
+			ad.SetGroupVersionKind(v1beta1.AppDeploymentGroupVersionKind)
+			ad.Name = "nonexistent"
+			ad.Namespace = "namespace"
+			ad.Spec.AppRevisions = []v1beta1.AppRevision{{RevisionName: "none"}}
+			raw, _ := json.Marshal(ad)
+
+			resp := handler.Handle(context.Background(), admission.Request{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					Resource:  appDeploymentResource,
+					Object:    runtime.RawExtension{Raw: raw},
+				},
+			})
+			Expect(resp.Allowed).Should(BeFalse())
+			Expect(resp.Result.Reason).Should(Equal(metav1.StatusReason(`spec.apprevisions.revisionName: Not found: "none"`)))
+		})
+	})
+})

--- a/test/e2e-test/appdeployment_test.go
+++ b/test/e2e-test/appdeployment_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	oamcomm "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+)
+
+var _ = Describe("ComponentDefinition Normal tests", func() {
+	ctx := context.Background()
+
+	var namespace string
+	var ns corev1.Namespace
+	var app v1beta1.Application
+
+	BeforeEach(func() {
+		namespace = randomNamespaceName("app-dep-e2e-test")
+		ns = corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+
+		Eventually(func() error {
+			return k8sClient.Create(ctx, &ns)
+		}, time.Second*3, time.Microsecond*300).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+	})
+
+	AfterEach(func() {
+		By("Clean up resources after a test")
+		k8sClient.DeleteAllOf(ctx, &v1beta1.Application{}, client.InNamespace(namespace))
+		k8sClient.DeleteAllOf(ctx, &v1beta1.AppDeployment{}, client.InNamespace(namespace))
+
+		By(fmt.Sprintf("Delete the entire namespaceName %s", ns.Name))
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(Succeed())
+	})
+
+	applyApp := func(source string) {
+		By("Apply an application")
+		var newApp v1beta1.Application
+		Expect(common.ReadYamlToObject("testdata/appdeployment/"+source, &newApp)).Should(BeNil())
+		newApp.Namespace = namespace
+		Expect(k8sClient.Create(ctx, &newApp)).Should(Succeed())
+
+		By("Get Application latest status")
+		Eventually(
+			func() *oamcomm.Revision {
+				k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: newApp.Name}, &app)
+				if app.Status.LatestRevision != nil {
+					return app.Status.LatestRevision
+				}
+				return nil
+			},
+			time.Second*30, time.Millisecond*500).ShouldNot(BeNil())
+	}
+
+	Context("Test validating admission control for appDeployment", func() {
+		It("Test appDeployment which only set appRevisions", func() {
+			applyApp("application.yaml")
+
+			var appDeployment v1beta1.AppDeployment
+			Expect(common.ReadYamlToObject("testdata/appdeployment/appdeployment-1.yaml", &appDeployment)).Should(BeNil())
+			appDeployment.Namespace = namespace
+			Expect(k8sClient.Create(ctx, &appDeployment)).Should(Succeed())
+			Eventually(
+				func() *v1beta1.AppDeploymentPhase {
+					k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: appDeployment.Name}, &appDeployment)
+					if appDeployment.Status.Phase != v1beta1.PhaseCompleted {
+						return &appDeployment.Status.Phase
+					}
+					return nil
+				},
+				time.Second*30, time.Millisecond*500).ShouldNot(BeNil())
+		})
+
+		It("Test appDeployment when not applied application", func() {
+			var appDeployment v1beta1.AppDeployment
+			Expect(common.ReadYamlToObject("testdata/appdeployment/appdeployment-1.yaml", &appDeployment)).Should(BeNil())
+			appDeployment.Namespace = namespace
+			Expect(k8sClient.Create(ctx, &appDeployment)).Should(HaveOccurred())
+		})
+	})
+})

--- a/test/e2e-test/testdata/appdeployment/appdeployment-1.yaml
+++ b/test/e2e-test/testdata/appdeployment/appdeployment-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: core.oam.dev/v1beta1
+kind: AppDeployment
+metadata:
+  name: app-deployment-e2e
+spec:
+  appRevisions:
+    - revisionName: appdeployment-app-e2e-v1
+      placement:
+        - distribution:
+            replicas: 2

--- a/test/e2e-test/testdata/appdeployment/application.yaml
+++ b/test/e2e-test/testdata/appdeployment/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: appdeployment-app-e2e
+  annotations:
+    app.oam.dev/revision-only: "true"
+spec:
+  components:
+    - name: myweb
+      type: worker
+      properties:
+        image: "stefanprodan/podinfo:4.0.3"
+        cmd:
+          - ./podinfo
+          - stress-cpu=1


### PR DESCRIPTION
fix #1681 

Current validation logic:
1. spec.apprevisions.[].RevisionName cannot be empty.
2. spec.apprevisions.[].RevisionName locate target must exist.

anything else to add?