### PR TITLE
arrange docs for kubectl plugin，fix #1721

### DIFF
--- a/docs/en/advanced-install.mdx
+++ b/docs/en/advanced-install.mdx
@@ -1,6 +1,8 @@
 ---
 title:  Other Install Topics
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 ## Install KubeVela with cert-manager
 
@@ -47,7 +49,44 @@ REVISION: 1
 NOTES:
 Welcome to use the KubeVela! Enjoy your shipping application journey!
 ```
+## Install Kubectl Vela Plugin
 
+Install vela kubectl plugin can help you to ship applications more easily!
+
+<Tabs
+className="unique-tabs"
+defaultValue="krew"
+values={[
+{label: 'Krew', value: 'krew'},
+{label: 'Script', value: 'script'},
+]}>
+<TabItem value="krew">
+
+1. [Install and set up](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) Krew on your machine.
+2. Discover plugins available on Krew:
+```shell
+kubectl krew update
+```
+3. install kubectl vela:
+```shell script
+kubectl krew install vela
+```
+
+</TabItem>
+<TabItem value="script">
+
+**macOS/Linux**
+```shell script
+curl -fsSl https://kubevela.io/script/install-kubectl-vela.sh | bash
+```
+
+You can also download the binary from [release pages ( >= v1.0.3)](https://github.com/oam-dev/kubevela/releases) manually.
+Kubectl will discover it from your system path automatically.
+
+</TabItem>
+</Tabs>
+
+For more usage please reference [kubectl plugin](./developers/references/kubectl-plugin).
 ## Upgrade
 
 ### Step 1. Update Helm repo

--- a/docs/en/developers/references/kubectl-plugin.mdx
+++ b/docs/en/developers/references/kubectl-plugin.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install kubectl plugin
+title: Kubectl plugin
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -57,7 +57,7 @@ Usage:
 
 Available Commands:
 
-    comp        Show components in cap center
+    comp        Show components in capability registry
     dry-run     Dry Run an application, and output the K8s resources as
                 result to stdout, only CUE template supported for now
     live-diff   Dry-run an application, and do diff on a specific app
@@ -66,7 +66,7 @@ Available Commands:
                 found in the provided ones, it will try to find from
                 cluster.
     show        Show the reference doc for a workload type or trait
-    trait       Show traits in cap center
+    trait       Show traits in capability registry
     version     Prints out build version information
 
 Flags:

--- a/docs/en/developers/references/kubectl-plugin.mdx
+++ b/docs/en/developers/references/kubectl-plugin.mdx
@@ -8,42 +8,7 @@ Install vela kubectl plugin can help you to ship applications more easily!
 
 ## Installation
 
-You can install kubectl plugin `kubectl vela` by:
-
-<Tabs
-className="unique-tabs"
-defaultValue="krew"
-values={[
-    {label: 'Krew', value: 'krew'},
-    {label: 'Script', value: 'script'},
-]}>
-<TabItem value="krew">
-
-1. [Install and set up](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) Krew on your machine.
-2. Discover plugins available on Krew:
-```shell
-kubectl krew update
-```
-3. install kubectl vela:
-```shell script
-kubectl krew install vela
-```
-
-</TabItem>
-<TabItem value="script">
-
-**macOS/Linux**
-```shell script
-curl -fsSl https://kubevela.io/script/install-kubectl-vela.sh | bash
-```
-
-You can also download the binary from [release pages ( >= v1.0.3)](https://github.com/oam-dev/kubevela/releases) manually.
-Kubectl will discover it from your system path automatically.
-
-</TabItem>
-</Tabs>
-
-
+See [advanced-install](../../advanced-install#install-kubectl-vela-plugin)
 
 ## Usage
 

--- a/docs/en/end-user/components/more.md
+++ b/docs/en/end-user/components/more.md
@@ -9,8 +9,7 @@ Components in KubeVela are designed to be brought by users.
 KubeVela allows you to explore capabilities maintained by platform team.
 There are two commands in kubectl vela plugin: `comp` and `trait`.
 
-In case you haven't installed kubectl vela plugin: see [this](../../kubectl-plugin).
-
+In case you haven't installed kubectl vela plugin: see [this](../../developers/references/kubectl-plugin#install-kubectl-vela-plugin).
 ### 1. list
 
 For example, let's try to list all available components in a registry:

--- a/docs/en/end-user/traits/more.md
+++ b/docs/en/end-user/traits/more.md
@@ -9,7 +9,7 @@ Traits in KubeVela are designed as modularized building blocks, they are fully c
 KubeVela allows you to explore capabilities maintained by platform team. There are two commands in kubectl vela
 plugin: `comp` and `trait`.
 
-In case you haven't installed kubectl vela plugin: see [this](../../kubectl-plugin).
+In case you haven't installed kubectl vela plugin: see [this](../../developers/references/kubectl-plugin#install-kubectl-vela-plugin).
 
 ### 1. list
 

--- a/docs/en/install.mdx
+++ b/docs/en/install.mdx
@@ -132,7 +132,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/mast
 
 KubeVela CLI gives you a simplified workflow to manage applications with optimized output. It is not mandatory though.
 
-KubeVela CLI could be [installed as kubectl plugin](./kubectl-plugin.mdx), or install as standalone binary.
+KubeVela CLI could be [installed as kubectl plugin](./advanced-install#install-kubectl-vela-plugin), or install as standalone binary.
 
 <Tabs
     className="unique-tabs"

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -170,6 +170,7 @@ module.exports = {
           ],
         },
         'developers/references/restful-api/rest',
+        'developers/references/kubectl-plugin'
       ],
     },
     {

--- a/pkg/plugin/cli/trait.go
+++ b/pkg/plugin/cli/trait.go
@@ -30,8 +30,8 @@ func NewTraitCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 	cmd := &cobra.Command{
 		Use:                   "trait",
 		DisableFlagsInUseLine: true,
-		Short:                 "Show traits",
-		Long:                  "Show installed and remote trait",
+		Short:                 "Show traits in capability registry",
+		Long:                  "Show traits in capability registry",
 		Example:               "kubectl vela trait",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			isDiscover, _ := cmd.Flags().GetBool("discover")


### PR DESCRIPTION
To fix #1721 
1. add `Kubectl plugin` in sidebar under the `References`.
2. mention the installation about kubectl plugin in `Other Install Topics`
3. fix some outdate docs