### PR TITLE
Improve the logging system

### DIFF
--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -109,6 +109,7 @@ spec:
             - "--enable-leader-election"
             {{ if ne .Values.logFilePath "" }}
             - "--log-file-path={{ .Values.logFilePath }}"
+            - "--log-file-max-size={{ .Values.logFileMaxSize }}"
             {{ end }}
             {{ if .Values.logDebug }}
             - "--log-debug=true"

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -107,6 +107,9 @@ spec:
           args:
             - "--metrics-addr=:8080"
             - "--enable-leader-election"
+            {{ if ne .Values.logFilePath "" }}
+            - "--log-file-path={{ .Values.logFilePath }}"
+            {{ end }}
             {{ if .Values.logDebug }}
             - "--log-debug=true"
             {{ end }}

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -81,7 +81,12 @@ admissionWebhooks:
 #Enable debug logs for development purpose
 logDebug: false
 
+#If non-empty, write log files in this path
 logFilePath: ""
+
+#Defines the maximum size a log file can grow to. Unit is megabytes.
+#If the value is 0, the maximum file size is unlimited.
+logFileMaxSize: 1024
 
 systemDefinitionNamespace: vela-system
 

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -81,6 +81,8 @@ admissionWebhooks:
 #Enable debug logs for development purpose
 logDebug: false
 
+logFilePath: ""
+
 systemDefinitionNamespace: vela-system
 
 applicationRevisionLimit: 10

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -126,17 +126,17 @@ func main() {
 		SyncPeriod:              &syncPeriod,
 	})
 	if err != nil {
-		klog.Error(err, "unable to create a controller manager")
+		klog.ErrorS(err, "Unable to create a controller manager")
 		os.Exit(1)
 	}
 
 	if err := registerHealthChecks(mgr); err != nil {
-		klog.Error(err, "unable to register ready/health checks")
+		klog.ErrorS(err, "Unable to register ready/health checks")
 		os.Exit(1)
 	}
 
 	if err := utils.CheckDisabledCapabilities(disableCaps); err != nil {
-		klog.Error(err, "unable to get enabled capabilities")
+		klog.ErrorS(err, "Unable to get enabled capabilities")
 		os.Exit(1)
 	}
 
@@ -151,21 +151,21 @@ func main() {
 		controllerArgs.ApplyMode = oamcontroller.ApplyOnceOnlyForce
 		klog.Info("ApplyOnceOnlyForce is enabled, that means workload or trait only apply once if no spec change even they are changed or deleted by others")
 	default:
-		klog.Error(fmt.Errorf("invalid apply-once-only value: %s", applyOnceOnly),
-			"unable to setup the vela core controller",
-			"valid apply-once-only value:", "on/off/force, by default it's off")
+		klog.ErrorS(fmt.Errorf("invalid apply-once-only value: %s", applyOnceOnly),
+			"Unable to setup the vela core controller",
+			"valid apply-once-only value", "on/off/force, by default it's off")
 		os.Exit(1)
 	}
 
 	dm, err := discoverymapper.New(mgr.GetConfig())
 	if err != nil {
-		klog.Error(err, "failed to create CRD discovery client")
+		klog.ErrorS(err, "Failed to create CRD discovery client")
 		os.Exit(1)
 	}
 	controllerArgs.DiscoveryMapper = dm
 	pd, err := packages.NewPackageDiscover(mgr.GetConfig())
 	if err != nil {
-		klog.Error(err, "failed to create CRD discovery for CUE package client")
+		klog.Error(err, "Failed to create CRD discovery for CUE package client")
 		if !definition.IsCUEParseErr(err) {
 			os.Exit(1)
 		}
@@ -173,29 +173,29 @@ func main() {
 	controllerArgs.PackageDiscover = pd
 
 	if useWebhook {
-		klog.InfoS("Vela enable webhook", "server port", strconv.Itoa(webhookPort))
+		klog.InfoS("Enable webhook", "server port", strconv.Itoa(webhookPort))
 		oamwebhook.Register(mgr, controllerArgs)
 		velawebhook.Register(mgr, disableCaps)
 		if err := waitWebhookSecretVolume(certDir, waitSecretTimeout, waitSecretInterval); err != nil {
-			klog.Error(err, "unable to get webhook secret")
+			klog.ErrorS(err, "Unable to get webhook secret")
 			os.Exit(1)
 		}
 	}
 
 	if err = oamv1alpha2.Setup(mgr, controllerArgs, logging.NewLogrLogger(setupLog)); err != nil {
-		klog.Error(err, "unable to setup the oam core controller")
+		klog.ErrorS(err, "Unable to setup the oam core controller")
 		os.Exit(1)
 	}
 
 	if err = standardcontroller.Setup(mgr, disableCaps); err != nil {
-		klog.Error(err, "unable to setup the vela core controller")
+		klog.ErrorS(err, "Unable to setup the vela core controller")
 		os.Exit(1)
 	}
 	if driver := os.Getenv(system.StorageDriverEnv); len(driver) == 0 {
 		// first use system environment,
 		err := os.Setenv(system.StorageDriverEnv, storageDriver)
 		if err != nil {
-			klog.Error(err, "unable to setup the vela core controller")
+			klog.ErrorS(err, "Unable to setup the vela core controller")
 			os.Exit(1)
 		}
 	}
@@ -204,15 +204,15 @@ func main() {
 	klog.Info("Start the vela controller manager")
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		klog.Error(err, "problem running manager")
+		klog.ErrorS(err, "Failed to run manager")
 		os.Exit(1)
 	}
-	klog.Info("Program safely stops...")
+	klog.Info("Safely stops Program...")
 }
 
 // registerHealthChecks is used to create readiness&liveness probes
 func registerHealthChecks(mgr ctrl.Manager) error {
-	klog.Info("creating readiness/health check")
+	klog.Info("Creating readiness/health check")
 	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -107,9 +107,9 @@ func main() {
 	}
 	flag.Parse()
 
-	klog.Infof("KubeVela Version: %s, GIT Revision: %s.", version.VelaVersion, version.GitRevision)
-	klog.Infof("Disable Capabilities: %s.", disableCaps)
-	klog.Infof("core init with definition namespace %s", oam.SystemDefinitonNamespace)
+	klog.InfoS("KubeVela", "version", version.VelaVersion, "revision", version.GitRevision)
+	klog.InfoS("Disable", "capabilities", disableCaps)
+	klog.InfoS("Vela-Core init", "definitionNamespace", oam.SystemDefinitonNamespace)
 
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = kubevelaName + "/" + version.GitRevision
@@ -173,7 +173,7 @@ func main() {
 	controllerArgs.PackageDiscover = pd
 
 	if useWebhook {
-		klog.Info("vela webhook enabled, will serving at :" + strconv.Itoa(webhookPort))
+		klog.InfoS("Vela enable webhook", "server port", strconv.Itoa(webhookPort))
 		oamwebhook.Register(mgr, controllerArgs)
 		velawebhook.Register(mgr, disableCaps)
 		if err := waitWebhookSecretVolume(certDir, waitSecretTimeout, waitSecretInterval); err != nil {
@@ -199,15 +199,15 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	klog.Info("use storage driver", "storageDriver", os.Getenv(system.StorageDriverEnv))
+	klog.InfoS("Use storage driver", "storageDriver", os.Getenv(system.StorageDriverEnv))
 
-	klog.Info("starting the vela controller manager")
+	klog.Info("Start the vela controller manager")
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		klog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-	klog.Info("program safely stops...")
+	klog.Info("Program safely stops...")
 }
 
 // registerHealthChecks is used to create readiness&liveness probes
@@ -231,8 +231,8 @@ func waitWebhookSecretVolume(certDir string, timeout, interval time.Duration) er
 		if time.Since(start) > timeout {
 			return fmt.Errorf("getting webhook secret timeout after %s", timeout.String())
 		}
-		klog.Info(fmt.Sprintf("waiting webhook secret, time consumed: %d/%d seconds ...",
-			int64(time.Since(start).Seconds()), int64(timeout.Seconds())))
+		klog.InfoS("Wait webhook secret", "time consumed(second)", int64(time.Since(start).Seconds()),
+			"timeout(second)", int64(timeout.Seconds()))
 		if _, err := os.Stat(certDir); !os.IsNotExist(err) {
 			ready := func() bool {
 				f, err := os.Open(filepath.Clean(certDir))
@@ -254,8 +254,8 @@ func waitWebhookSecretVolume(certDir string, timeout, interval time.Duration) er
 					return nil
 				})
 				if err == nil {
-					klog.Info(fmt.Sprintf("webhook secret is ready (time consumed: %d seconds)",
-						int64(time.Since(start).Seconds())))
+					klog.InfoS("Webhook secret is ready", "time consumed(second)",
+						int64(time.Since(start).Seconds()))
 					return true
 				}
 				return false

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -107,9 +107,9 @@ func main() {
 	}
 	flag.Parse()
 
-	klog.InfoS("KubeVela", "version", version.VelaVersion, "revision", version.GitRevision)
-	klog.InfoS("Disable", "capabilities", disableCaps)
-	klog.InfoS("Vela-Core init", "definitionNamespace", oam.SystemDefinitonNamespace)
+	klog.InfoS("KubeVela information", "version", version.VelaVersion, "revision", version.GitRevision)
+	klog.InfoS("Disable capabilities", "name", disableCaps)
+	klog.InfoS("Vela-Core init", "definition namespace", oam.SystemDefinitonNamespace)
 
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = kubevelaName + "/" + version.GitRevision
@@ -153,7 +153,7 @@ func main() {
 	default:
 		klog.ErrorS(fmt.Errorf("invalid apply-once-only value: %s", applyOnceOnly),
 			"Unable to setup the vela core controller",
-			"valid apply-once-only value", "on/off/force, by default it's off")
+			"apply-once-only", "on/off/force, by default it's off")
 		os.Exit(1)
 	}
 
@@ -212,7 +212,7 @@ func main() {
 
 // registerHealthChecks is used to create readiness&liveness probes
 func registerHealthChecks(mgr ctrl.Manager) error {
-	klog.Info("Creating readiness/health check")
+	klog.Info("Create readiness/health check")
 	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -59,8 +59,7 @@ var (
 
 func main() {
 	var metricsAddr, logFilePath, leaderElectionNamespace string
-	var enableLeaderElection, logCompress, logDebug bool
-	var logRetainDate int
+	var enableLeaderElection, logDebug bool
 	var certDir string
 	var webhookPort int
 	var useWebhook bool
@@ -80,9 +79,6 @@ func main() {
 	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "",
 		"Determines the namespace in which the leader election configmap will be created.")
 	flag.StringVar(&logFilePath, "log-file-path", "", "The file to write logs to.")
-	// TODO add more option
-	flag.IntVar(&logRetainDate, "log-retain-date", 7, "The number of days of logs history to retain.")
-	flag.BoolVar(&logCompress, "log-compress", true, "Enable compression on the rotated logs.")
 	flag.BoolVar(&logDebug, "log-debug", false, "Enable debug logs for development purpose")
 	flag.IntVar(&controllerArgs.RevisionLimit, "revision-limit", 50,
 		"RevisionLimit is the maximum number of revisions that will be maintained. The default value is 50.")
@@ -181,7 +177,7 @@ func main() {
 		oamwebhook.Register(mgr, controllerArgs)
 		velawebhook.Register(mgr, disableCaps)
 		if err := waitWebhookSecretVolume(certDir, waitSecretTimeout, waitSecretInterval); err != nil {
-			setupLog.Error(err, "unable to get webhook secret")
+			klog.Error(err, "unable to get webhook secret")
 			os.Exit(1)
 		}
 	}

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	standardcontroller "github.com/oam-dev/kubevela/pkg/controller"
+	commonconfig "github.com/oam-dev/kubevela/pkg/controller/common"
 	oamcontroller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	oamv1alpha2 "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
@@ -101,6 +102,10 @@ func main() {
 
 	// setup logging
 	klog.InitFlags(nil)
+	if logDebug {
+		_ = flag.Set("v", strconv.Itoa(int(commonconfig.LogDebug)))
+	}
+
 	if logFilePath != "" {
 		_ = flag.Set("logtostderr", "false")
 		_ = flag.Set("log_file", logFilePath)
@@ -207,6 +212,7 @@ func main() {
 		klog.ErrorS(err, "Failed to run manager")
 		os.Exit(1)
 	}
+	klog.Flush()
 	klog.Info("Safely stops Program...")
 }
 

--- a/pkg/controller/common/logs.go
+++ b/pkg/controller/common/logs.go
@@ -18,6 +18,12 @@ package common
 
 import "k8s.io/klog/v2"
 
+// klog has multiple levels, you can set the log levels by klog.V()
+// Basic examples:
+//
+//	klog.V(1).Info("Prepare to repel boarders")
+//
+//	klog.V(2).ErrorS(err, "Initialization failed")
 const (
 	// LogInfo level is for most info logs, this is the default
 	// One should just call Info directly.

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -102,7 +102,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			return reconcile.Result{}, errors.Wrap(r.UpdateStatus(ctx, app), errUpdateApplicationStatus)
 		}
 		if needUpdate {
-			klog.InfoS("remove finalizer of application", "application", app.Namespace+"/"+app.Name, "finalizers", app.ObjectMeta.Finalizers)
+			klog.InfoS("Remove finalizer of application", "application", app.Namespace+"/"+app.Name, "finalizers", app.ObjectMeta.Finalizers)
 			return ctrl.Result{}, errors.Wrap(r.Update(ctx, app), errUpdateApplicationFinalizer)
 		}
 		// deleting and no need to handle finalizer
@@ -113,7 +113,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	app.Status.Phase = common.ApplicationRendering
 
-	klog.Info("parse template")
+	klog.Info("Parse template")
 	// parse template
 	appParser := appfile.NewApplicationParser(r.Client, r.dm, r.pd)
 
@@ -140,7 +140,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// Record the revision so it can be used to render data in context.appRevision
 	generatedAppfile.RevisionName = appRev.Name
 
-	klog.Info("build template")
+	klog.Info("Build template")
 	// build template to applicationconfig & component
 	ac, comps, err := generatedAppfile.GenerateApplicationConfiguration()
 	if err != nil {
@@ -163,7 +163,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	app.Status.SetConditions(readyCondition("Built"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonRendered, velatypes.MessageRendered))
-	klog.Info("apply application revision & component to the cluster")
+	klog.Info("Apply application revision & component to the cluster")
 	// apply application revision & component to the cluster
 	if err := handler.apply(ctx, appRev, ac, comps); err != nil {
 		klog.Error(err, "[Handle apply]")
@@ -191,14 +191,14 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		// there is no need reconcile immediately, that means the rollout operation have finished
 		r.Recorder.Event(app, event.Normal(velatypes.ReasonRollout, velatypes.MessageRollout))
 		app.Status.SetConditions(readyCondition("Rollout"))
-		klog.Info("rollout finished")
+		klog.Info("Rollout finished")
 	}
 
 	// The following logic will be skipped if rollout have not finished
 	app.Status.SetConditions(readyCondition("Applied"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonFailedApply, velatypes.MessageApplied))
 	app.Status.Phase = common.ApplicationHealthChecking
-	klog.Info("check application health status")
+	klog.Info("Check application health status")
 	// check application health status
 	appCompStatus, healthy, err := handler.statusAggregate(generatedAppfile)
 	if err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -24,13 +24,13 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -58,8 +58,7 @@ const (
 type Reconciler struct {
 	client.Client
 	dm               discoverymapper.DiscoveryMapper
-	pd               *packages.PackageDiscover
-	Log              logr.Logger
+	pd               *definition.PackageDiscover
 	Scheme           *runtime.Scheme
 	Recorder         event.Recorder
 	applicator       apply.Applicator
@@ -72,7 +71,8 @@ type Reconciler struct {
 // Reconcile process app event
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
-	applog := r.Log.WithValues("application", req.NamespacedName)
+	klog.InfoS("Reconciling", "application", req.NamespacedName)
+
 	app := new(v1beta1.Application)
 	if err := r.Get(ctx, client.ObjectKey{
 		Name:      req.Name,
@@ -85,43 +85,42 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	handler := &appHandler{
-		r:      r,
-		app:    app,
-		logger: applog,
+		r:   r,
+		app: app,
 	}
 
 	if app.ObjectMeta.DeletionTimestamp.IsZero() {
 		if registerFinalizers(app) {
-			applog.Info("Register new finalizer", "application", app.Namespace+"/"+app.Name, "finalizers", app.ObjectMeta.Finalizers)
+			klog.InfoS("Register new finalizer", "application", app.Namespace+"/"+app.Name, "finalizers", app.ObjectMeta.Finalizers)
 			return reconcile.Result{}, errors.Wrap(r.Client.Update(ctx, app), errUpdateApplicationFinalizer)
 		}
 	} else {
 		needUpdate, err := handler.removeResourceTracker(ctx)
 		if err != nil {
-			applog.Error(err, "Failed to remove application resourceTracker")
+			klog.Error(err, "Failed to remove application resourceTracker")
 			app.Status.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, "error to  remove finalizer")))
 			return reconcile.Result{}, errors.Wrap(r.UpdateStatus(ctx, app), errUpdateApplicationStatus)
 		}
 		if needUpdate {
-			applog.Info("remove finalizer of application", "application", app.Namespace+"/"+app.Name, "finalizers", app.ObjectMeta.Finalizers)
+			klog.InfoS("remove finalizer of application", "application", app.Namespace+"/"+app.Name, "finalizers", app.ObjectMeta.Finalizers)
 			return ctrl.Result{}, errors.Wrap(r.Update(ctx, app), errUpdateApplicationFinalizer)
 		}
 		// deleting and no need to handle finalizer
 		return reconcile.Result{}, nil
 	}
 
-	applog.Info("Start Rendering")
+	klog.Info("Start Rendering")
 
 	app.Status.Phase = common.ApplicationRendering
 
-	applog.Info("parse template")
+	klog.Info("parse template")
 	// parse template
 	appParser := appfile.NewApplicationParser(r.Client, r.dm, r.pd)
 
 	ctx = oamutil.SetNamespaceInCtx(ctx, app.Namespace)
 	generatedAppfile, err := appParser.GenerateAppFile(ctx, app)
 	if err != nil {
-		applog.Error(err, "[Handle Parse]")
+		klog.Error(err, "[Handle Parse]")
 		app.Status.SetConditions(errorCondition("Parsed", err))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedParse, err))
 		return handler.handleErr(err)
@@ -132,7 +131,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	appRev, err := handler.GenerateAppRevision(ctx)
 	if err != nil {
-		applog.Error(err, "[Handle Calculate Revision]")
+		klog.Error(err, "[Handle Calculate Revision]")
 		app.Status.SetConditions(errorCondition("Parsed", err))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedParse, err))
 		return handler.handleErr(err)
@@ -141,11 +140,11 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// Record the revision so it can be used to render data in context.appRevision
 	generatedAppfile.RevisionName = appRev.Name
 
-	applog.Info("build template")
+	klog.Info("build template")
 	// build template to applicationconfig & component
 	ac, comps, err := generatedAppfile.GenerateApplicationConfiguration()
 	if err != nil {
-		applog.Error(err, "[Handle GenerateApplicationConfiguration]")
+		klog.Error(err, "[Handle GenerateApplicationConfiguration]")
 		app.Status.SetConditions(errorCondition("Built", err))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRender, err))
 		return handler.handleErr(err)
@@ -153,7 +152,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	err = handler.handleResourceTracker(ctx, comps, ac)
 	if err != nil {
-		applog.Error(err, "[Handle resourceTracker]")
+		klog.Error(err, "[Handle resourceTracker]")
 		app.Status.SetConditions(errorCondition("Handle resourceTracker", err))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRender, err))
 		return handler.handleErr(err)
@@ -164,10 +163,10 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	app.Status.SetConditions(readyCondition("Built"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonRendered, velatypes.MessageRendered))
-	applog.Info("apply application revision & component to the cluster")
+	klog.Info("apply application revision & component to the cluster")
 	// apply application revision & component to the cluster
 	if err := handler.apply(ctx, appRev, ac, comps); err != nil {
-		applog.Error(err, "[Handle apply]")
+		klog.Error(err, "[Handle apply]")
 		app.Status.SetConditions(errorCondition("Applied", err))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedApply, err))
 		return handler.handleErr(err)
@@ -177,7 +176,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if handler.app.Spec.RolloutPlan != nil {
 		res, err := handler.handleRollout(ctx)
 		if err != nil {
-			applog.Error(err, "[handle rollout]")
+			klog.Error(err, "[handle rollout]")
 			app.Status.SetConditions(errorCondition("Rollout", err))
 			r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRollout, err))
 			return handler.handleErr(err)
@@ -192,18 +191,18 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		// there is no need reconcile immediately, that means the rollout operation have finished
 		r.Recorder.Event(app, event.Normal(velatypes.ReasonRollout, velatypes.MessageRollout))
 		app.Status.SetConditions(readyCondition("Rollout"))
-		applog.Info("rollout finished")
+		klog.Info("rollout finished")
 	}
 
 	// The following logic will be skipped if rollout have not finished
 	app.Status.SetConditions(readyCondition("Applied"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonFailedApply, velatypes.MessageApplied))
 	app.Status.Phase = common.ApplicationHealthChecking
-	applog.Info("check application health status")
+	klog.Info("check application health status")
 	// check application health status
 	appCompStatus, healthy, err := handler.statusAggregate(generatedAppfile)
 	if err != nil {
-		applog.Error(err, "[status aggregate]")
+		klog.Error(err, "[status aggregate]")
 		app.Status.SetConditions(errorCondition("HealthCheck", err))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedHealthCheck, err))
 		return handler.handleErr(err)
@@ -222,7 +221,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	err = garbageCollection(ctx, handler)
 	if err != nil {
-		applog.Error(err, "[Garbage collection]")
+		klog.Error(err, "[Garbage collection]")
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedGC, err))
 	}
 
@@ -274,7 +273,6 @@ func (r *Reconciler) UpdateStatus(ctx context.Context, app *v1beta1.Application,
 func Setup(mgr ctrl.Manager, args core.Args, _ logging.Logger) error {
 	reconciler := Reconciler{
 		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("Application"),
 		Scheme:           mgr.GetScheme(),
 		Recorder:         event.NewAPIRecorder(mgr.GetEventRecorderFor("Application")),
 		dm:               args.DiscoveryMapper,

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -58,7 +58,7 @@ const (
 type Reconciler struct {
 	client.Client
 	dm               discoverymapper.DiscoveryMapper
-	pd               *definition.PackageDiscover
+	pd               *packages.PackageDiscover
 	Scheme           *runtime.Scheme
 	Recorder         event.Recorder
 	applicator       apply.Applicator

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -71,7 +71,7 @@ type Reconciler struct {
 // Reconcile process app event
 func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
-	klog.InfoS("Reconciling", "application", req.NamespacedName)
+	klog.InfoS("Reconcile application", "application", klog.KRef(req.Namespace, req.Name))
 
 	app := new(v1beta1.Application)
 	if err := r.Get(ctx, client.ObjectKey{
@@ -91,7 +91,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	if app.ObjectMeta.DeletionTimestamp.IsZero() {
 		if registerFinalizers(app) {
-			klog.InfoS("Register new finalizer", "application", app.Namespace+"/"+app.Name, "finalizers", app.ObjectMeta.Finalizers)
+			klog.InfoS("Register new finalizer for application", "application", klog.KObj(app), "finalizers", app.ObjectMeta.Finalizers)
 			return reconcile.Result{}, errors.Wrap(r.Client.Update(ctx, app), errUpdateApplicationFinalizer)
 		}
 	} else {
@@ -191,7 +191,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		// there is no need reconcile immediately, that means the rollout operation have finished
 		r.Recorder.Event(app, event.Normal(velatypes.ReasonRollout, velatypes.MessageRollout))
 		app.Status.SetConditions(readyCondition("Rollout"))
-		klog.Info("Rollout finished")
+		klog.Info("Finished rollout ")
 	}
 
 	// The following logic will be skipped if rollout have not finished

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_finalizer_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_finalizer_test.go
@@ -283,9 +283,8 @@ var _ = Describe("Test finalizer related func", func() {
 			UID:        rt.UID}
 		meta.AddFinalizer(&app.ObjectMeta, resourceTrackerFinalizer)
 		handler = appHandler{
-			r:      reconciler,
-			app:    app,
-			logger: reconciler.Log.WithValues("application", "finalizer-func-test"),
+			r:   reconciler,
+			app: app,
 		}
 		need, err := handler.removeResourceTracker(ctx)
 		Expect(err).Should(BeNil())
@@ -304,9 +303,8 @@ var _ = Describe("Test finalizer related func", func() {
 	It("Test finalizeResourceTracker func without need ", func() {
 		app := getApp("app-4", namespace, "worker")
 		handler = appHandler{
-			r:      reconciler,
-			app:    app,
-			logger: reconciler.Log.WithValues("application", "finalizer-func-test"),
+			r:   reconciler,
+			app: app,
 		}
 		need, err := handler.removeResourceTracker(ctx)
 		Expect(err).Should(BeNil())

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -359,12 +359,12 @@ func (h *appHandler) createOrUpdateComponent(ctx context.Context, comp *v1alpha2
 				preRevisionName))
 		}
 		if !needNewRevision {
-			klog.InfoS("no need to wait for a new component revision", "component name", updatedComp.GetName(),
+			klog.InfoS("No need to wait for a new component revision", "component name", updatedComp.GetName(),
 				"revision", preRevisionName)
 			return preRevisionName, nil
 		}
 	}
-	klog.InfoS("wait for a new component revision", "component name", compName,
+	klog.InfoS("Wait for a new component revision", "component name", compName,
 		"previous revision", preRevisionName)
 	// get the new component revision that contains the component with retry
 	checkForRevision := func() (bool, error) {
@@ -386,7 +386,7 @@ func (h *appHandler) createOrUpdateComponent(ctx context.Context, comp *v1alpha2
 		// end the loop if we find the revision
 		if !needNewRevision {
 			curRevisionName = curComp.Status.LatestRevision.Name
-			klog.InfoS("get a matching component revision", "component name", compName,
+			klog.InfoS("Get a matching component revision", "component name", compName,
 				"current revision", curRevisionName)
 		}
 		return !needNewRevision, nil
@@ -434,13 +434,13 @@ func (h *appHandler) createOrUpdateAppContext(ctx context.Context, owners []meta
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
-		klog.InfoS("create a new appContext", "application name",
+		klog.InfoS("Create a new appContext", "application name",
 			appContext.GetName(), "revision it points to", appContext.Spec.ApplicationRevisionName)
 		return h.r.Create(ctx, &appContext)
 	}
 
 	// we don't need to create another appConfig
-	klog.InfoS("replace the existing appContext", "application name", appContext.GetName(),
+	klog.InfoS("Replace the existing appContext", "application name", appContext.GetName(),
 		"revision it points to", appContext.Spec.ApplicationRevisionName)
 	appContext.ResourceVersion = curAppContext.ResourceVersion
 	return h.r.Update(ctx, &appContext)
@@ -562,7 +562,7 @@ func (h *appHandler) removeResourceTracker(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	klog.Info("delete application resourceTracker")
+	klog.Info("Delete application resourceTracker")
 	meta.RemoveFinalizer(h.app, resourceTrackerFinalizer)
 	h.app.Status.ResourceTracker = nil
 	return true, nil

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -97,7 +97,7 @@ func (h *appHandler) handleErr(err error) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 	if nerr != nil {
-		klog.Error(nerr, "[Update] application status")
+		klog.InfoS("Failed to update application status", "err", nerr)
 	}
 	return ctrl.Result{
 		RequeueAfter: time.Second * 10,
@@ -332,7 +332,7 @@ func (h *appHandler) createOrUpdateComponent(ctx context.Context, comp *v1alpha2
 		if err = h.r.Create(ctx, comp); err != nil {
 			return "", err
 		}
-		klog.InfoS("Created a new component", "component name", comp.GetName())
+		klog.InfoS("Created a new component", "component", klog.KObj(comp))
 	} else {
 		// remember the revision if there is a previous component
 		if curComp.Status.LatestRevision != nil {
@@ -342,7 +342,7 @@ func (h *appHandler) createOrUpdateComponent(ctx context.Context, comp *v1alpha2
 		if err := h.r.Update(ctx, comp); err != nil {
 			return "", err
 		}
-		klog.InfoS("Updated a component", "component name", comp.GetName())
+		klog.InfoS("Updated a component", "component", klog.KObj(comp))
 	}
 	// remove the object from the raw extension before we can compare with the existing componentRevision whose
 	// object is persisted as Raw data after going through api server
@@ -359,7 +359,7 @@ func (h *appHandler) createOrUpdateComponent(ctx context.Context, comp *v1alpha2
 				preRevisionName))
 		}
 		if !needNewRevision {
-			klog.InfoS("No need to wait for a new component revision", "component name", updatedComp.GetName(),
+			klog.InfoS("No need to wait for a new component revision", "component", klog.KObj(updatedComp),
 				"revision", preRevisionName)
 			return preRevisionName, nil
 		}
@@ -440,7 +440,7 @@ func (h *appHandler) createOrUpdateAppContext(ctx context.Context, owners []meta
 	}
 
 	// we don't need to create another appConfig
-	klog.InfoS("Replace the existing appContext", "application name", appContext.GetName(),
+	klog.InfoS("Replace the existing appContext", "appContext", klog.KObj(&appContext),
 		"revision it points to", appContext.Spec.ApplicationRevisionName)
 	appContext.ResourceVersion = curAppContext.ResourceVersion
 	return h.r.Update(ctx, &appContext)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/ghodss/yaml"
 	terraformtypes "github.com/oam-dev/terraform-controller/api/types"
 	terraformapi "github.com/oam-dev/terraform-controller/api/v1beta1"
@@ -121,9 +120,8 @@ var _ = Describe("Test Application apply", func() {
 			}},
 		}
 		handler = appHandler{
-			r:      reconciler,
-			app:    app,
-			logger: reconciler.Log.WithValues("application", "unit-test"),
+			r:   reconciler,
+			app: app,
 		}
 		By("Create the Namespace for test")
 		Expect(k8sClient.Create(ctx, &ns)).Should(Succeed())
@@ -184,7 +182,7 @@ var _ = Describe("Test Application apply", func() {
 		By("verify that the revision is the set correctly and newRevision is true")
 		Expect(err).ShouldNot(HaveOccurred())
 		// verify the revision actually contains the right component
-		Expect(utils.CompareWithRevision(ctx, handler.r, logging.NewLogrLogger(handler.logger), component.GetName(),
+		Expect(utils.CompareWithRevision(ctx, handler.r, component.GetName(),
 			component.GetNamespace(), revision, &component.Spec)).Should(BeTrue())
 		preRevision := revision
 
@@ -203,7 +201,7 @@ var _ = Describe("Test Application apply", func() {
 		By("verify that the revision is changed and newRevision is true")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(revision).ShouldNot(BeIdenticalTo(preRevision))
-		Expect(utils.CompareWithRevision(ctx, handler.r, logging.NewLogrLogger(handler.logger), component.GetName(),
+		Expect(utils.CompareWithRevision(ctx, handler.r, component.GetName(),
 			component.GetNamespace(), revision, &component.Spec)).Should(BeTrue())
 		// revision increased
 		Expect(strings.Compare(revision, preRevision) > 0).Should(BeTrue())
@@ -251,9 +249,8 @@ var _ = Describe("Test applyHelmModuleResources", func() {
 		ctx = context.TODO()
 		app = &v1beta1.Application{}
 		handler = appHandler{
-			r:      reconciler,
-			app:    app,
-			logger: reconciler.Log.WithValues("application", "unit-test"),
+			r:   reconciler,
+			app: app,
 		}
 		handler.r.applicator = apply.NewAPIApplicator(reconciler.Client)
 	})

--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -54,11 +54,11 @@ func (h *appHandler) UpdateRevisionStatus(ctx context.Context, revName, hash str
 	}
 	// make sure that we persist the latest revision first
 	if err := h.r.UpdateStatus(ctx, h.app); err != nil {
-		klog.Error(err, "update the latest appConfig revision to status", "application name", h.app.GetName(),
+		klog.InfoS("Failed to update the latest appConfig revision to status", "err", err, "application name", h.app.GetName(),
 			"latest revision", revName)
 		return err
 	}
-	klog.Info("Recorded the latest appConfig revision", "application name", h.app.GetName(),
+	klog.InfoS("Recorded the latest appConfig revision", "application name", h.app.GetName(),
 		"latest revision", revName)
 	return nil
 }
@@ -131,7 +131,7 @@ func (h *appHandler) gatherRevisionSpec() (*v1beta1.ApplicationRevision, string,
 	}
 	appRevisionHash, err := ComputeAppRevisionHash(appRev)
 	if err != nil {
-		klog.Error(err, "compute hash of appRevision for application", "application name", h.app.GetName())
+		klog.InfoS("Failed to compute hash of appRevision for application", "err", err, "application name", h.app.GetName())
 		return appRev, "", err
 	}
 	return appRev, appRevisionHash, nil
@@ -154,7 +154,7 @@ func (h *appHandler) compareWithLastRevisionSpec(ctx context.Context, newAppRevi
 	lastAppRevision := &v1beta1.ApplicationRevision{}
 	if err := h.r.Get(ctx, client.ObjectKey{Name: h.app.Status.LatestRevision.Name,
 		Namespace: h.app.Namespace}, lastAppRevision); err != nil {
-		klog.Error(err, "get the last appRevision from K8s", "application name",
+		klog.InfoS("Failed to get the last appRevision from K8s", "err", err, "application name",
 			h.app.GetName(), "revision", h.app.Status.LatestRevision.Name)
 		return false, errors.Wrapf(err, "fail to get applicationRevision %s", h.app.Status.LatestRevision.Name)
 	}
@@ -316,7 +316,7 @@ func cleanUpApplicationRevision(ctx context.Context, h *appHandler) error {
 	if needKill <= 0 {
 		return nil
 	}
-	klog.Info("Application controller cleanup old appRevisions", "needKillNum", needKill)
+	klog.InfoS("Application controller cleanup old appRevisions", "needKillNum", needKill)
 	sortedRevision := appRevisionList.Items
 	sort.Sort(historiesByRevision(sortedRevision))
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -58,7 +58,7 @@ func (h *appHandler) UpdateRevisionStatus(ctx context.Context, revName, hash str
 			"latest revision", revName)
 		return err
 	}
-	klog.Info("recorded the latest appConfig revision", "application name", h.app.GetName(),
+	klog.Info("Recorded the latest appConfig revision", "application name", h.app.GetName(),
 		"latest revision", revName)
 	return nil
 }
@@ -316,7 +316,7 @@ func cleanUpApplicationRevision(ctx context.Context, h *appHandler) error {
 	if needKill <= 0 {
 		return nil
 	}
-	klog.Info("application controller cleanup old appRevisions", "needKillNum", needKill)
+	klog.Info("Application controller cleanup old appRevisions", "needKillNum", needKill)
 	sortedRevision := appRevisionList.Items
 	sort.Sort(historiesByRevision(sortedRevision))
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -24,6 +24,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -53,11 +54,11 @@ func (h *appHandler) UpdateRevisionStatus(ctx context.Context, revName, hash str
 	}
 	// make sure that we persist the latest revision first
 	if err := h.r.UpdateStatus(ctx, h.app); err != nil {
-		h.logger.Error(err, "update the latest appConfig revision to status", "application name", h.app.GetName(),
+		klog.Error(err, "update the latest appConfig revision to status", "application name", h.app.GetName(),
 			"latest revision", revName)
 		return err
 	}
-	h.logger.Info("recorded the latest appConfig revision", "application name", h.app.GetName(),
+	klog.Info("recorded the latest appConfig revision", "application name", h.app.GetName(),
 		"latest revision", revName)
 	return nil
 }
@@ -130,7 +131,7 @@ func (h *appHandler) gatherRevisionSpec() (*v1beta1.ApplicationRevision, string,
 	}
 	appRevisionHash, err := ComputeAppRevisionHash(appRev)
 	if err != nil {
-		h.logger.Error(err, "compute hash of appRevision for application", "application name", h.app.GetName())
+		klog.Error(err, "compute hash of appRevision for application", "application name", h.app.GetName())
 		return appRev, "", err
 	}
 	return appRev, appRevisionHash, nil
@@ -153,7 +154,7 @@ func (h *appHandler) compareWithLastRevisionSpec(ctx context.Context, newAppRevi
 	lastAppRevision := &v1beta1.ApplicationRevision{}
 	if err := h.r.Get(ctx, client.ObjectKey{Name: h.app.Status.LatestRevision.Name,
 		Namespace: h.app.Namespace}, lastAppRevision); err != nil {
-		h.logger.Error(err, "get the last appRevision from K8s", "application name",
+		klog.Error(err, "get the last appRevision from K8s", "application name",
 			h.app.GetName(), "revision", h.app.Status.LatestRevision.Name)
 		return false, errors.Wrapf(err, "fail to get applicationRevision %s", h.app.Status.LatestRevision.Name)
 	}
@@ -315,7 +316,7 @@ func cleanUpApplicationRevision(ctx context.Context, h *appHandler) error {
 	if needKill <= 0 {
 		return nil
 	}
-	h.logger.Info("application controller cleanup old appRevisions", "needKillNum", needKill)
+	klog.Info("application controller cleanup old appRevisions", "needKillNum", needKill)
 	sortedRevision := appRevisionList.Items
 	sort.Sort(historiesByRevision(sortedRevision))
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -54,11 +54,11 @@ func (h *appHandler) UpdateRevisionStatus(ctx context.Context, revName, hash str
 	}
 	// make sure that we persist the latest revision first
 	if err := h.r.UpdateStatus(ctx, h.app); err != nil {
-		klog.InfoS("Failed to update the latest appConfig revision to status", "err", err, "application name", h.app.GetName(),
-			"latest revision", revName)
+		klog.InfoS("Failed to update the latest appConfig revision to status", "application", klog.KObj(h.app),
+			"latest revision", revName, "err", err)
 		return err
 	}
-	klog.InfoS("Recorded the latest appConfig revision", "application name", h.app.GetName(),
+	klog.InfoS("Recorded the latest appConfig revision", "application", klog.KObj(h.app),
 		"latest revision", revName)
 	return nil
 }
@@ -131,7 +131,8 @@ func (h *appHandler) gatherRevisionSpec() (*v1beta1.ApplicationRevision, string,
 	}
 	appRevisionHash, err := ComputeAppRevisionHash(appRev)
 	if err != nil {
-		klog.InfoS("Failed to compute hash of appRevision for application", "err", err, "application name", h.app.GetName())
+		klog.InfoS("Failed to compute hash of appRevision for application", "application", klog.KObj(h.app),
+			"err", err)
 		return appRev, "", err
 	}
 	return appRev, appRevisionHash, nil
@@ -154,8 +155,8 @@ func (h *appHandler) compareWithLastRevisionSpec(ctx context.Context, newAppRevi
 	lastAppRevision := &v1beta1.ApplicationRevision{}
 	if err := h.r.Get(ctx, client.ObjectKey{Name: h.app.Status.LatestRevision.Name,
 		Namespace: h.app.Namespace}, lastAppRevision); err != nil {
-		klog.InfoS("Failed to get the last appRevision from K8s", "err", err, "application name",
-			h.app.GetName(), "revision", h.app.Status.LatestRevision.Name)
+		klog.InfoS("Failed to get the last appRevision from K8s", "application",
+			klog.KObj(h.app), "revision", h.app.Status.LatestRevision.Name, "err", err)
 		return false, errors.Wrapf(err, "fail to get applicationRevision %s", h.app.Status.LatestRevision.Name)
 	}
 	if DeepEqualRevision(lastAppRevision, newAppRevision) {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision_clean_up_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision_clean_up_test.go
@@ -387,9 +387,8 @@ var _ = Describe("Test gatherUsingAppRevision func", func() {
 		}
 		Expect(k8sClient.Create(ctx, appContext)).Should(BeNil())
 		handler := appHandler{
-			r:      reconciler,
-			app:    app,
-			logger: reconciler.Log.WithValues("application", "gatherUsingAppRevision-func-test"),
+			r:   reconciler,
+			app: app,
 		}
 		Eventually(func() error {
 			using, err := gatherUsingAppRevision(ctx, &handler)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision_test.go
@@ -146,9 +146,8 @@ var _ = Describe("test generate revision ", func() {
 		appRevision2.Name = "appRevision2"
 
 		handler = appHandler{
-			r:      reconciler,
-			app:    &app,
-			logger: reconciler.Log.WithValues("apply", "unit-test"),
+			r:   reconciler,
+			app: &app,
 		}
 
 	})

--- a/pkg/controller/core.oam.dev/v1alpha2/application/suite_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/suite_test.go
@@ -131,7 +131,6 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).To(BeNil())
 	reconciler = &Reconciler{
 		Client:           k8sClient,
-		Log:              ctrl.Log.WithName("Application-Test"),
 		Scheme:           testScheme,
 		dm:               dm,
 		pd:               pd,

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/component.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/component.go
@@ -126,7 +126,7 @@ func (c *ComponentHandler) IsRevisionDiff(mt klog.KMetadata, curComp *v1alpha2.C
 
 	// client in controller-runtime will use informer cache
 	// use client will be more efficient
-	needNewRevision, err := utils.CompareWithRevision(context.TODO(), c.Client, c.Logger, mt.GetName(), mt.GetNamespace(),
+	needNewRevision, err := utils.CompareWithRevision(context.TODO(), c.Client, mt.GetName(), mt.GetNamespace(),
 		curComp.Status.LatestRevision.Name, &curComp.Spec)
 	// TODO: this might be a bug that we treat all errors getting from k8s as a new revision
 	// but the client go event handler doesn't handle an error. We need to see if we can retry this

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationcontext/applicationcontext_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationcontext/applicationcontext_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ktype "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -61,7 +62,7 @@ type Reconciler struct {
 
 // Reconcile reconcile an application context
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	r.log.Debug("Reconciling")
+	klog.InfoS("Reconciling", "applicationContext", request.NamespacedName)
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()
 	// fetch the app context

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationcontext/applicationcontext_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationcontext/applicationcontext_controller.go
@@ -62,7 +62,7 @@ type Reconciler struct {
 
 // Reconcile reconcile an application context
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	klog.InfoS("Reconciling", "applicationContext", request.NamespacedName)
+	klog.InfoS("Reconcile", "applicationContext", klog.KRef(request.Namespace, request.Name))
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()
 	// fetch the app context

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/manualscalertrait/manualscalertrait_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/manualscalertrait/manualscalertrait_controller.go
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		eventObj = &manualScalar
 	}
 	// Fetch the workload instance this trait is referring to
-	workload, err := util.FetchWorkload(ctx, r, mLog, &manualScalar)
+	workload, err := util.FetchWorkload(ctx, r, &manualScalar)
 	if err != nil {
 		r.record.Event(eventObj, event.Warning(util.ErrLocateWorkload, err))
 		return util.ReconcileWaitResult, util.PatchCondition(
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// Fetch the child resources list from the corresponding workload
-	resources, err := util.FetchWorkloadChildResources(ctx, mLog, r, r.dm, workload)
+	resources, err := util.FetchWorkloadChildResources(ctx, r, r.dm, workload)
 	if err != nil {
 		mLog.Error(err, "Error while fetching the workload child resources", "workload", workload.UnstructuredContent())
 		r.record.Event(eventObj, event.Warning(util.ErrFetchChildResources, err))

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -27,7 +27,6 @@ import (
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	mapset "github.com/deckarep/golang-set"
 	"github.com/mitchellh/hashstructure/v2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -40,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commontypes "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
@@ -217,14 +217,14 @@ func ExtractRevision(revisionName string) (int, error) {
 }
 
 // CompareWithRevision compares a component's spec with the component's latest revision content
-func CompareWithRevision(ctx context.Context, c client.Client, logger logging.Logger, componentName, nameSpace,
+func CompareWithRevision(ctx context.Context, c client.Client, componentName, nameSpace,
 	latestRevision string, curCompSpec *v1alpha2.ComponentSpec) (bool, error) {
 	oldRev := &appsv1.ControllerRevision{}
 	// retry on NotFound since we update the component last revision first
 	err := wait.ExponentialBackoff(retry.DefaultBackoff, func() (bool, error) {
 		err := c.Get(ctx, client.ObjectKey{Namespace: nameSpace, Name: latestRevision}, oldRev)
 		if err != nil && !kerrors.IsNotFound(err) {
-			logger.Info(fmt.Sprintf("get old controllerRevision %s error %v",
+			klog.InfoS(fmt.Sprintf("get old controllerRevision %s error %v",
 				latestRevision, err), "componentName", componentName)
 			return false, err
 		}
@@ -235,8 +235,7 @@ func CompareWithRevision(ctx context.Context, c client.Client, logger logging.Lo
 	}
 	oldComp, err := util.UnpackRevisionData(oldRev)
 	if err != nil {
-		logger.Info(fmt.Sprintf("Unmarshal old controllerRevision %s error %v",
-			latestRevision, err), "componentName", componentName)
+		klog.InfoS("Unmarshal old controllerRevision", latestRevision, "error", err, "componentName", componentName)
 		return true, err
 	}
 	if reflect.DeepEqual(curCompSpec, &oldComp.Spec) {

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -25,14 +25,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/stretchr/testify/assert"
 	v12 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
@@ -95,7 +93,6 @@ func TestConstructExtract(t *testing.T) {
 
 func TestCompareWithRevision(t *testing.T) {
 	ctx := context.TODO()
-	logger := logging.NewLogrLogger(controllerruntime.Log.WithName("util-test"))
 	componentName := "testComp"
 	nameSpace := "namespace"
 	latestRevision := "revision"
@@ -194,7 +191,7 @@ func TestCompareWithRevision(t *testing.T) {
 			tclient := test.MockClient{
 				MockGet: test.NewMockGetFn(nil, tt.getFunc),
 			}
-			same, err := CompareWithRevision(ctx, &tclient, logger, componentName, nameSpace, latestRevision,
+			same, err := CompareWithRevision(ctx, &tclient, componentName, nameSpace, latestRevision,
 				tt.curCompSpec)
 			if err != tt.expectedErr {
 				t.Errorf("CompareWithRevision() error = %v, wantErr %v", err, tt.expectedErr)

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -30,7 +30,6 @@ import (
 
 	cpv1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -190,23 +190,23 @@ func LocateParentAppConfig(ctx context.Context, client client.Client, oamObject 
 }
 
 // FetchWorkload fetch the workload that a trait refers to
-func FetchWorkload(ctx context.Context, c client.Client, mLog logr.Logger, oamTrait oam.Trait) (
+func FetchWorkload(ctx context.Context, c client.Client, oamTrait oam.Trait) (
 	*unstructured.Unstructured, error) {
 	var workload unstructured.Unstructured
 	workloadRef := oamTrait.GetWorkloadReference()
 	if len(workloadRef.Kind) == 0 || len(workloadRef.APIVersion) == 0 || len(workloadRef.Name) == 0 {
 		err := errors.New("no workload reference")
-		mLog.Error(err, ErrLocateWorkload)
+		klog.Error(err, ErrLocateWorkload)
 		return nil, err
 	}
 	workload.SetAPIVersion(workloadRef.APIVersion)
 	workload.SetKind(workloadRef.Kind)
 	wn := client.ObjectKey{Name: workloadRef.Name, Namespace: oamTrait.GetNamespace()}
 	if err := c.Get(ctx, wn, &workload); err != nil {
-		mLog.Error(err, "Workload not find", "kind", workloadRef.Kind, "workload name", workloadRef.Name)
+		klog.Error(err, "Workload not find", "kind", workloadRef.Kind, "workload name", workloadRef.Name)
 		return nil, err
 	}
-	mLog.Info("Get the workload the trait is pointing to", "workload name", workload.GetName(),
+	klog.InfoS("Get the workload the trait is pointing to", "workload name", workload.GetName(),
 		"workload APIVersion", workload.GetAPIVersion(), "workload Kind", workload.GetKind(), "workload UID",
 		workload.GetUID())
 	return &workload, nil
@@ -399,7 +399,7 @@ func checkRequestNamespaceError(err error) bool {
 }
 
 // FetchWorkloadChildResources fetch corresponding child resources given a workload
-func FetchWorkloadChildResources(ctx context.Context, mLog logr.Logger, r client.Reader,
+func FetchWorkloadChildResources(ctx context.Context, r client.Reader,
 	dm discoverymapper.DiscoveryMapper, workload *unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
 	// Fetch the corresponding workloadDefinition CR
 	workloadDefinition, err := FetchWorkloadDefinition(ctx, r, dm, workload)
@@ -410,10 +410,10 @@ func FetchWorkloadChildResources(ctx context.Context, mLog logr.Logger, r client
 		}
 		return nil, err
 	}
-	return fetchChildResources(ctx, mLog, r, workload, workloadDefinition.Spec.ChildResourceKinds)
+	return fetchChildResources(ctx, r, workload, workloadDefinition.Spec.ChildResourceKinds)
 }
 
-func fetchChildResources(ctx context.Context, mLog logr.Logger, r client.Reader, workload *unstructured.Unstructured,
+func fetchChildResources(ctx context.Context, r client.Reader, workload *unstructured.Unstructured,
 	wcrl []common.ChildResourceKind) ([]*unstructured.Unstructured, error) {
 	var childResources []*unstructured.Unstructured
 	// list by each child resource type with namespace and possible label selector
@@ -421,18 +421,18 @@ func fetchChildResources(ctx context.Context, mLog logr.Logger, r client.Reader,
 		crs := unstructured.UnstructuredList{}
 		crs.SetAPIVersion(wcr.APIVersion)
 		crs.SetKind(wcr.Kind)
-		mLog.Info("List child resource kind", "APIVersion", wcr.APIVersion, "Type", wcr.Kind, "owner UID",
+		klog.InfoS("List child resource kind", "APIVersion", wcr.APIVersion, "Type", wcr.Kind, "owner UID",
 			workload.GetUID())
 		if err := r.List(ctx, &crs, client.InNamespace(workload.GetNamespace()),
 			client.MatchingLabels(wcr.Selector)); err != nil {
-			mLog.Error(err, "failed to list object", "api version", crs.GetAPIVersion(), "kind", crs.GetKind())
+			klog.Error(err, "failed to list object", "api version", crs.GetAPIVersion(), "kind", crs.GetKind())
 			return nil, err
 		}
 		// pick the ones that is owned by the workload
 		for _, cr := range crs.Items {
 			for _, owner := range cr.GetOwnerReferences() {
 				if owner.UID == workload.GetUID() {
-					mLog.Info("Find a child resource we are looking for",
+					klog.InfoS("Find a child resource we are looking for",
 						"APIVersion", cr.GetAPIVersion(), "Kind", cr.GetKind(),
 						"Name", cr.GetName(), "owner", owner.UID)
 					or := cr // have to do a copy as the range variable is a reference and will change

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -196,14 +196,14 @@ func FetchWorkload(ctx context.Context, c client.Client, oamTrait oam.Trait) (
 	workloadRef := oamTrait.GetWorkloadReference()
 	if len(workloadRef.Kind) == 0 || len(workloadRef.APIVersion) == 0 || len(workloadRef.Name) == 0 {
 		err := errors.New("no workload reference")
-		klog.Error(err, ErrLocateWorkload)
+		klog.InfoS(ErrLocateWorkload, "err", err)
 		return nil, err
 	}
 	workload.SetAPIVersion(workloadRef.APIVersion)
 	workload.SetKind(workloadRef.Kind)
 	wn := client.ObjectKey{Name: workloadRef.Name, Namespace: oamTrait.GetNamespace()}
 	if err := c.Get(ctx, wn, &workload); err != nil {
-		klog.Error(err, "Workload not find", "kind", workloadRef.Kind, "workload name", workloadRef.Name)
+		klog.InfoS("Failed to find workload", "err", err, "kind", workloadRef.Kind, "workload name", workloadRef.Name)
 		return nil, err
 	}
 	klog.InfoS("Get the workload the trait is pointing to", "workload name", workload.GetName(),
@@ -425,7 +425,7 @@ func fetchChildResources(ctx context.Context, r client.Reader, workload *unstruc
 			workload.GetUID())
 		if err := r.List(ctx, &crs, client.InNamespace(workload.GetNamespace()),
 			client.MatchingLabels(wcr.Selector)); err != nil {
-			klog.Error(err, "failed to list object", "api version", crs.GetAPIVersion(), "kind", crs.GetKind())
+			klog.InfoS("Failed to list object", "err", err, "apiVersion", crs.GetAPIVersion(), "kind", crs.GetKind())
 			return nil, err
 		}
 		// pick the ones that is owned by the workload

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -179,7 +178,6 @@ func TestLocateParentAppConfig(t *testing.T) {
 func TestFetchWorkloadTraitReference(t *testing.T) {
 
 	t.Log("Setting up variables")
-	log := ctrl.Log.WithName("ManualScalarTraitReconciler")
 	noRefNameTrait := v1alpha2.ManualScalerTrait{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha2.SchemeGroupVersion.String(),
@@ -258,7 +256,7 @@ func TestFetchWorkloadTraitReference(t *testing.T) {
 	for name, tc := range cases {
 		tclient := test.NewMockClient()
 		tclient.MockGet = test.NewMockGetFn(nil, tc.fields.getFunc)
-		gotWL, err := util.FetchWorkload(ctx, tclient, log, tc.fields.trait)
+		gotWL, err := util.FetchWorkload(ctx, tclient, tc.fields.trait)
 		t.Log(fmt.Sprint("Running test: ", name))
 		if tc.want.err == nil {
 			assert.NoError(t, err)
@@ -585,7 +583,6 @@ func TestChildResources(t *testing.T) {
 		},
 	}
 
-	log := ctrl.Log.WithName("ManualScalarTraitReconciler")
 	crkl := []common.ChildResourceKind{
 		{
 			Kind:       "Deployment",
@@ -727,7 +724,7 @@ func TestChildResources(t *testing.T) {
 			MockGet:  test.NewMockGetFn(nil, tc.fields.getFunc),
 			MockList: test.NewMockListFn(nil, tc.fields.listFunc),
 		}
-		got, err := util.FetchWorkloadChildResources(ctx, log, &tclient, mock.NewMockDiscoveryMapper(), unstructuredWorkload)
+		got, err := util.FetchWorkloadChildResources(ctx, &tclient, mock.NewMockDiscoveryMapper(), unstructuredWorkload)
 		t.Log(fmt.Sprint("Running test: ", name))
 		assert.Equal(t, tc.want.err, err)
 		assert.Equal(t, tc.want.crks, got)

--- a/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/mutating_handler.go
@@ -66,7 +66,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 	// mutate the object
 	if err := h.Mutate(obj); err != nil {
-		klog.Error(err, "failed to mutate the applicationConfiguration", "name", obj.Name)
+		klog.InfoS("Failed to mutate the applicationConfiguration", "err", err, "name", obj.Name)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	klog.InfoS("Print the mutated obj", "obj name", obj.Name, "mutated obj", string(util.JSONMarshal(obj.Spec)))

--- a/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/mutating_handler.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -54,9 +54,6 @@ type MutatingHandler struct {
 	Decoder *admission.Decoder
 }
 
-// log is for logging in this package.
-var mutatelog = logf.Log.WithName("applicationconfiguration mutate webhook")
-
 var _ admission.Handler = &MutatingHandler{}
 
 // Handle handles admission requests.
@@ -69,10 +66,10 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 	// mutate the object
 	if err := h.Mutate(obj); err != nil {
-		mutatelog.Error(err, "failed to mutate the applicationConfiguration", "name", obj.Name)
+		klog.Error(err, "failed to mutate the applicationConfiguration", "name", obj.Name)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	mutatelog.Info("Print the mutated obj", "obj name", obj.Name, "mutated obj", string(util.JSONMarshal(obj.Spec)))
+	klog.InfoS("Print the mutated obj", "obj name", obj.Name, "mutated obj", string(util.JSONMarshal(obj.Spec)))
 
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
@@ -81,7 +78,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 	resp := admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
 	if len(resp.Patches) > 0 {
-		mutatelog.Info("admit ApplicationConfiguration",
+		klog.InfoS("admit ApplicationConfiguration",
 			"namespace", obj.Namespace, "name", obj.Name, "patches", util.JSONMarshal(resp.Patches))
 	}
 	return resp
@@ -89,7 +86,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 // Mutate sets all the default value for the Component
 func (h *MutatingHandler) Mutate(obj *v1alpha2.ApplicationConfiguration) error {
-	mutatelog.Info("mutate", "name", obj.Name)
+	klog.InfoS("mutate", "name", obj.Name)
 
 	for compIdx, comp := range obj.Spec.Components {
 		var updated bool
@@ -125,7 +122,7 @@ func (h *MutatingHandler) mutateTrait(content map[string]interface{}, compName s
 	if !ok {
 		return nil, false, fmt.Errorf("name of trait should be string instead of %s", reflect.TypeOf(content[TraitTypeField]))
 	}
-	mutatelog.Info("the trait refers to traitDefinition by name", "compName", compName, "trait name", traitType)
+	klog.InfoS("the trait refers to traitDefinition by name", "compName", compName, "trait name", traitType)
 	// Fetch the corresponding traitDefinition CR, the traitDefinition crd is cluster scoped
 	traitDefinition := &v1alpha2.TraitDefinition{}
 	if err := h.Client.Get(context.TODO(), types.NamespacedName{Name: traitType}, traitDefinition); err != nil {
@@ -154,7 +151,7 @@ func (h *MutatingHandler) mutateTrait(content map[string]interface{}, compName s
 	}.String()
 	trait.SetAPIVersion(apiVersion)
 	trait.SetKind(customResourceDefinition.Spec.Names.Kind)
-	mutatelog.Info("Set the trait GVK", "trait api version", trait.GetAPIVersion(), "trait Kind", trait.GetKind())
+	klog.InfoS("Set the trait GVK", "trait api version", trait.GetAPIVersion(), "trait Kind", trait.GetKind())
 	// add traitType label
 	trait.SetLabels(util.MergeMapOverrideWithDst(trait.GetLabels(), map[string]string{oam.TraitTypeLabel: traitType}))
 	// copy back the object

--- a/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/mutating_handler.go
@@ -78,7 +78,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 	resp := admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
 	if len(resp.Patches) > 0 {
-		klog.InfoS("admit ApplicationConfiguration",
+		klog.InfoS("Admit ApplicationConfiguration",
 			"namespace", obj.Namespace, "name", obj.Name, "patches", util.JSONMarshal(resp.Patches))
 	}
 	return resp
@@ -86,7 +86,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 // Mutate sets all the default value for the Component
 func (h *MutatingHandler) Mutate(obj *v1alpha2.ApplicationConfiguration) error {
-	klog.InfoS("mutate", "name", obj.Name)
+	klog.InfoS("Mutate ApplicationConfiguration", "name", obj.Name)
 
 	for compIdx, comp := range obj.Spec.Components {
 		var updated bool
@@ -122,7 +122,7 @@ func (h *MutatingHandler) mutateTrait(content map[string]interface{}, compName s
 	if !ok {
 		return nil, false, fmt.Errorf("name of trait should be string instead of %s", reflect.TypeOf(content[TraitTypeField]))
 	}
-	klog.InfoS("the trait refers to traitDefinition by name", "compName", compName, "trait name", traitType)
+	klog.InfoS("Trait refers to traitDefinition by name", "compName", compName, "trait name", traitType)
 	// Fetch the corresponding traitDefinition CR, the traitDefinition crd is cluster scoped
 	traitDefinition := &v1alpha2.TraitDefinition{}
 	if err := h.Client.Get(context.TODO(), types.NamespacedName{Name: traitType}, traitDefinition); err != nil {
@@ -151,7 +151,7 @@ func (h *MutatingHandler) mutateTrait(content map[string]interface{}, compName s
 	}.String()
 	trait.SetAPIVersion(apiVersion)
 	trait.SetKind(customResourceDefinition.Spec.Names.Kind)
-	klog.InfoS("Set the trait GVK", "trait api version", trait.GetAPIVersion(), "trait Kind", trait.GetKind())
+	klog.InfoS("Set the trait GVK", "trait apiVersion", trait.GetAPIVersion(), "trait Kind", trait.GetKind())
 	// add traitType label
 	trait.SetLabels(util.MergeMapOverrideWithDst(trait.GetLabels(), map[string]string{oam.TraitTypeLabel: traitType}))
 	// copy back the object

--- a/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/applicationconfiguration/mutating_handler.go
@@ -66,10 +66,12 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 	// mutate the object
 	if err := h.Mutate(obj); err != nil {
-		klog.InfoS("Failed to mutate the applicationConfiguration", "err", err, "name", obj.Name)
+		klog.InfoS("Failed to mutate the applicationConfiguration", "applicationConfiguration", klog.KObj(obj),
+			"err", err)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	klog.InfoS("Print the mutated obj", "obj name", obj.Name, "mutated obj", string(util.JSONMarshal(obj.Spec)))
+	klog.InfoS("Print the mutated applicationConfiguration", "applicationConfiguration",
+		klog.KObj(obj), "mutated applicationConfiguration", string(util.JSONMarshal(obj.Spec)))
 
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
@@ -78,15 +80,15 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 	resp := admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
 	if len(resp.Patches) > 0 {
-		klog.InfoS("Admit ApplicationConfiguration",
-			"namespace", obj.Namespace, "name", obj.Name, "patches", util.JSONMarshal(resp.Patches))
+		klog.InfoS("Admit applicationConfiguration", "applicationConfiguration", klog.KObj(obj),
+			"patches", util.JSONMarshal(resp.Patches))
 	}
 	return resp
 }
 
 // Mutate sets all the default value for the Component
 func (h *MutatingHandler) Mutate(obj *v1alpha2.ApplicationConfiguration) error {
-	klog.InfoS("Mutate ApplicationConfiguration", "name", obj.Name)
+	klog.InfoS("Mutate applicationConfiguration", "applicationConfiguration", klog.KObj(obj))
 
 	for compIdx, comp := range obj.Spec.Components {
 		var updated bool

--- a/pkg/webhook/core.oam.dev/v1alpha2/applicationrollout/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/applicationrollout/mutating_handler.go
@@ -60,8 +60,8 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 	resp := admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
 	if len(resp.Patches) > 0 {
-		klog.V(common.LogDebugWithContent).Infof("Admit AppRollout %s/%s patches: %v", obj.Namespace, obj.Name,
-			util.DumpJSON(resp.Patches))
+		klog.V(common.LogDebugWithContent).InfoS("Admit appRollout", "appRollout", klog.KObj(obj),
+			"patches", util.DumpJSON(resp.Patches))
 	}
 	return resp
 }

--- a/pkg/webhook/core.oam.dev/v1alpha2/component/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/component/mutating_handler.go
@@ -65,7 +65,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 	// mutate the object
 	if err := h.Mutate(obj); err != nil {
-		klog.Error(err, "failed to mutate the component", "name", obj.Name)
+		klog.InfoS("Failed to mutate the component", "err", err, "name", obj.Name)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	klog.InfoS("Print the mutated obj", "obj name", obj.Name, "mutated obj", string(obj.Spec.Workload.Raw))

--- a/pkg/webhook/core.oam.dev/v1alpha2/component/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/component/mutating_handler.go
@@ -25,8 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -53,9 +53,6 @@ type MutatingHandler struct {
 	Decoder *admission.Decoder
 }
 
-// log is for logging in this package.
-var mutatelog = logf.Log.WithName("component mutate webhook")
-
 var _ admission.Handler = &MutatingHandler{}
 
 // Handle handles admission requests.
@@ -68,10 +65,10 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 	// mutate the object
 	if err := h.Mutate(obj); err != nil {
-		mutatelog.Error(err, "failed to mutate the component", "name", obj.Name)
+		klog.Error(err, "failed to mutate the component", "name", obj.Name)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	mutatelog.Info("Print the mutated obj", "obj name", obj.Name, "mutated obj", string(obj.Spec.Workload.Raw))
+	klog.InfoS("Print the mutated obj", "obj name", obj.Name, "mutated obj", string(obj.Spec.Workload.Raw))
 
 	marshalled, err := json.Marshal(obj)
 	if err != nil {
@@ -80,7 +77,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 	resp := admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
 	if len(resp.Patches) > 0 {
-		mutatelog.Info("admit Component",
+		klog.InfoS("admit Component",
 			"namespace", obj.Namespace, "name", obj.Name, "patches", util.JSONMarshal(resp.Patches))
 	}
 	return resp
@@ -88,7 +85,7 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 // Mutate sets all the default value for the Component
 func (h *MutatingHandler) Mutate(obj *v1alpha2.Component) error {
-	mutatelog.Info("mutate", "name", obj.Name)
+	klog.InfoS("mutate", "name", obj.Name)
 	var content map[string]interface{}
 	if err := json.Unmarshal(obj.Spec.Workload.Raw, &content); err != nil {
 		return err
@@ -98,7 +95,7 @@ func (h *MutatingHandler) Mutate(obj *v1alpha2.Component) error {
 		if !ok {
 			return fmt.Errorf("workload content has an unknown type field")
 		}
-		mutatelog.Info("the component refers to workoadDefinition by type", "name", obj.Name, "workload type", workloadType)
+		klog.InfoS("the component refers to workoadDefinition by type", "name", obj.Name, "workload type", workloadType)
 		// Fetch the corresponding workloadDefinition CR, the workloadDefinition crd is cluster scoped
 		workloadDefinition := &v1alpha2.WorkloadDefinition{}
 		if err := h.Client.Get(context.TODO(), types.NamespacedName{Name: workloadType}, workloadDefinition); err != nil {
@@ -120,7 +117,7 @@ func (h *MutatingHandler) Mutate(obj *v1alpha2.Component) error {
 		}.String()
 		workload.SetAPIVersion(apiVersion)
 		workload.SetKind(gvk.Kind)
-		mutatelog.Info("Set the component workload GVK", "workload api version", workload.GetAPIVersion(), "workload Kind", workload.GetKind())
+		klog.InfoS("Set the component workload GVK", "workload api version", workload.GetAPIVersion(), "workload Kind", workload.GetKind())
 		// copy namespace/label/annotation to the workload and add workloadType label
 		workload.SetNamespace(obj.GetNamespace())
 		workload.SetLabels(util.MergeMapOverrideWithDst(obj.GetLabels(), map[string]string{oam.WorkloadTypeLabel: workloadType}))

--- a/pkg/webhook/core.oam.dev/v1alpha2/component/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/component/validating_handler.go
@@ -53,7 +53,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 	err := h.Decoder.Decode(req, obj)
 	if err != nil {
-		klog.Error(err, "decoder failed", "req operation", req.AdmissionRequest.Operation, "req",
+		klog.InfoS("Failed to decode", "err", err, "req operation", req.AdmissionRequest.Operation, "req",
 			req.AdmissionRequest)
 		return admission.Denied(err.Error())
 	}

--- a/pkg/webhook/core.oam.dev/v1alpha2/component/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/component/validating_handler.go
@@ -53,20 +53,20 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 	err := h.Decoder.Decode(req, obj)
 	if err != nil {
-		klog.InfoS("Failed to decode", "err", err, "req operation", req.AdmissionRequest.Operation, "req",
-			req.AdmissionRequest)
+		klog.InfoS("Failed to decode component", "req operation", req.AdmissionRequest.Operation, "req",
+			req.AdmissionRequest, "err", err)
 		return admission.Denied(err.Error())
 	}
 
 	switch req.AdmissionRequest.Operation { //nolint:exhaustive
 	case admissionv1beta1.Create:
 		if allErrs := ValidateComponentObject(obj); len(allErrs) > 0 {
-			klog.InfoS("Create component failed", "name", obj.Name, "errMsg", allErrs.ToAggregate().Error())
+			klog.InfoS("Failed to create component", "component", klog.KObj(obj), "err", allErrs.ToAggregate().Error())
 			return admission.Denied(allErrs.ToAggregate().Error())
 		}
 	case admissionv1beta1.Update:
 		if allErrs := ValidateComponentObject(obj); len(allErrs) > 0 {
-			klog.InfoS("Update component failed", "name", obj.Name, "errMsg", allErrs.ToAggregate().Error())
+			klog.InfoS("Failed to update component", "component", klog.KObj(obj), "err", allErrs.ToAggregate().Error())
 			return admission.Denied(allErrs.ToAggregate().Error())
 		}
 	}
@@ -76,7 +76,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 // ValidateComponentObject validates the Component on creation
 func ValidateComponentObject(obj *v1alpha2.Component) field.ErrorList {
-	klog.InfoS("Validate component", "name", obj.Name)
+	klog.InfoS("Validate component", "component", klog.KObj(obj))
 	allErrs := apimachineryvalidation.ValidateObjectMeta(&obj.ObjectMeta, true,
 		apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
 	fldPath := field.NewPath("spec")

--- a/pkg/webhook/core.oam.dev/v1alpha2/component/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/component/validating_handler.go
@@ -61,12 +61,12 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 	switch req.AdmissionRequest.Operation { //nolint:exhaustive
 	case admissionv1beta1.Create:
 		if allErrs := ValidateComponentObject(obj); len(allErrs) > 0 {
-			klog.InfoS("create failed", "name", obj.Name, "errMsg", allErrs.ToAggregate().Error())
+			klog.InfoS("Create component failed", "name", obj.Name, "errMsg", allErrs.ToAggregate().Error())
 			return admission.Denied(allErrs.ToAggregate().Error())
 		}
 	case admissionv1beta1.Update:
 		if allErrs := ValidateComponentObject(obj); len(allErrs) > 0 {
-			klog.InfoS("update failed", "name", obj.Name, "errMsg", allErrs.ToAggregate().Error())
+			klog.InfoS("Update component failed", "name", obj.Name, "errMsg", allErrs.ToAggregate().Error())
 			return admission.Denied(allErrs.ToAggregate().Error())
 		}
 	}
@@ -76,7 +76,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 // ValidateComponentObject validates the Component on creation
 func ValidateComponentObject(obj *v1alpha2.Component) field.ErrorList {
-	klog.InfoS("validate component", "name", obj.Name)
+	klog.InfoS("Validate component", "name", obj.Name)
 	allErrs := apimachineryvalidation.ValidateObjectMeta(&obj.ObjectMeta, true,
 		apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
 	fldPath := field.NewPath("spec")

--- a/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/mutating_handler.go
+++ b/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/mutating_handler.go
@@ -57,14 +57,14 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 	resp := admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
 	if len(resp.Patches) > 0 {
-		klog.V(5).InfoS("Admit PodSpecWorkload", "PodSpecWorkload", klog.KObj(obj), "patches", util.DumpJSON(resp.Patches))
+		klog.V(5).InfoS("Admit PodSpecWorkload", "podSpecWorkload", klog.KObj(obj), "patches", util.DumpJSON(resp.Patches))
 	}
 	return resp
 }
 
 // DefaultPodSpecWorkload will set the default value for the PodSpecWorkload
 func DefaultPodSpecWorkload(obj *v1alpha1.PodSpecWorkload) {
-	klog.InfoS("Set the default value for the PodSpecWorkload", "name", obj.Name)
+	klog.InfoS("Set the default value for the PodSpecWorkload", "podSpecWorkload", klog.KObj(obj))
 	if obj.Spec.Replicas == nil {
 		klog.InfoS("Set default replicas as 1")
 		obj.Spec.Replicas = pointer.Int32Ptr(1)

--- a/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/mutating_handler.go
+++ b/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/mutating_handler.go
@@ -57,16 +57,16 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 	}
 	resp := admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshalled)
 	if len(resp.Patches) > 0 {
-		klog.V(5).Infof("Admit PodSpecWorkload %s/%s patches: %v", obj.Namespace, obj.Name, util.DumpJSON(resp.Patches))
+		klog.V(5).InfoS("Admit PodSpecWorkload", "PodSpecWorkload", klog.KObj(obj), "patches", util.DumpJSON(resp.Patches))
 	}
 	return resp
 }
 
 // DefaultPodSpecWorkload will set the default value for the PodSpecWorkload
 func DefaultPodSpecWorkload(obj *v1alpha1.PodSpecWorkload) {
-	klog.InfoS("default", "name", obj.Name)
+	klog.InfoS("Set the default value for the PodSpecWorkload", "name", obj.Name)
 	if obj.Spec.Replicas == nil {
-		klog.InfoS("default replicas as 1")
+		klog.InfoS("Set default replicas as 1")
 		obj.Spec.Replicas = pointer.Int32Ptr(1)
 	}
 }

--- a/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/mutating_handler.go
+++ b/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/mutating_handler.go
@@ -21,10 +21,9 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -39,9 +38,6 @@ type MutatingHandler struct {
 	// Decoder decodes objects
 	Decoder *admission.Decoder
 }
-
-// log is for logging in this package.
-var mutatelog = logf.Log.WithName("PodSpecWorkload-mutate")
 
 var _ admission.Handler = &MutatingHandler{}
 
@@ -68,9 +64,9 @@ func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) adm
 
 // DefaultPodSpecWorkload will set the default value for the PodSpecWorkload
 func DefaultPodSpecWorkload(obj *v1alpha1.PodSpecWorkload) {
-	mutatelog.Info("default", "name", obj.Name)
+	klog.InfoS("default", "name", obj.Name)
 	if obj.Spec.Replicas == nil {
-		mutatelog.Info("default replicas as 1")
+		klog.InfoS("default replicas as 1")
 		obj.Spec.Replicas = pointer.Int32Ptr(1)
 	}
 }

--- a/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/validating_handler.go
+++ b/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/validating_handler.go
@@ -23,8 +23,8 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -39,9 +39,6 @@ type ValidatingHandler struct {
 	Decoder *admission.Decoder
 }
 
-// log is for logging in this package.
-var validatelog = logf.Log.WithName("PodSpecWorkload-validate")
-
 var _ admission.Handler = &ValidatingHandler{}
 
 // Handle handles admission requests.
@@ -50,7 +47,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 	err := h.Decoder.Decode(req, obj)
 	if err != nil {
-		validatelog.Error(err, "decoder failed", "req operation", req.AdmissionRequest.Operation, "req",
+		klog.Error(err, "decoder failed", "req operation", req.AdmissionRequest.Operation, "req",
 			req.AdmissionRequest)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
@@ -78,7 +75,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 // ValidateCreate validates the PodSpecWorkload on creation
 func ValidateCreate(r *v1alpha1.PodSpecWorkload) field.ErrorList {
-	validatelog.Info("validate create", "name", r.Name)
+	klog.InfoS("validate create", "name", r.Name)
 	allErrs := apimachineryvalidation.ValidateObjectMeta(&r.ObjectMeta, true,
 		apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
 
@@ -97,13 +94,13 @@ func ValidateCreate(r *v1alpha1.PodSpecWorkload) field.ErrorList {
 
 // ValidateUpdate validates the PodSpecWorkload on update
 func ValidateUpdate(r *v1alpha1.PodSpecWorkload, _ *v1alpha1.PodSpecWorkload) field.ErrorList {
-	validatelog.Info("validate update", "name", r.Name)
+	klog.InfoS("validate update", "name", r.Name)
 	return ValidateCreate(r)
 }
 
 // ValidateDelete validates the PodSpecWorkload on delete
 func ValidateDelete(r *v1alpha1.PodSpecWorkload) field.ErrorList {
-	validatelog.Info("validate delete", "name", r.Name)
+	klog.InfoS("validate delete", "name", r.Name)
 	return nil
 }
 

--- a/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/validating_handler.go
+++ b/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/validating_handler.go
@@ -47,8 +47,8 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 	err := h.Decoder.Decode(req, obj)
 	if err != nil {
-		klog.InfoS("Failed to decode", "err", err, "req operation", req.AdmissionRequest.Operation, "req",
-			req.AdmissionRequest)
+		klog.InfoS("Failed to decode", "req operation", req.AdmissionRequest.Operation, "req",
+			req.AdmissionRequest, "err", err)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
@@ -75,7 +75,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 // ValidateCreate validates the PodSpecWorkload on creation
 func ValidateCreate(r *v1alpha1.PodSpecWorkload) field.ErrorList {
-	klog.InfoS("Validate create PodSpecWorkload", "name", r.Name)
+	klog.InfoS("Validate create podSpecWorkload", "podSpecWorkload", klog.KObj(r))
 	allErrs := apimachineryvalidation.ValidateObjectMeta(&r.ObjectMeta, true,
 		apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
 
@@ -94,13 +94,13 @@ func ValidateCreate(r *v1alpha1.PodSpecWorkload) field.ErrorList {
 
 // ValidateUpdate validates the PodSpecWorkload on update
 func ValidateUpdate(r *v1alpha1.PodSpecWorkload, _ *v1alpha1.PodSpecWorkload) field.ErrorList {
-	klog.InfoS("Validate update PodSpecWorkload", "name", r.Name)
+	klog.InfoS("Validate update podSpecWorkload", "podSpecWorkload", klog.KObj(r))
 	return ValidateCreate(r)
 }
 
 // ValidateDelete validates the PodSpecWorkload on delete
 func ValidateDelete(r *v1alpha1.PodSpecWorkload) field.ErrorList {
-	klog.InfoS("Validate delete PodSpecWorkload", "name", r.Name)
+	klog.InfoS("Validate delete PodSpecWorkload", "podSpecWorkload", klog.KObj(r))
 	return nil
 }
 

--- a/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/validating_handler.go
+++ b/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/validating_handler.go
@@ -47,7 +47,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 	err := h.Decoder.Decode(req, obj)
 	if err != nil {
-		klog.Error(err, "decoder failed", "req operation", req.AdmissionRequest.Operation, "req",
+		klog.InfoS("Failed to decode", "err", err, "req operation", req.AdmissionRequest.Operation, "req",
 			req.AdmissionRequest)
 		return admission.Errored(http.StatusBadRequest, err)
 	}

--- a/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/validating_handler.go
+++ b/pkg/webhook/standard.oam.dev/v1alpha1/podspecworkload/validating_handler.go
@@ -75,7 +75,7 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 
 // ValidateCreate validates the PodSpecWorkload on creation
 func ValidateCreate(r *v1alpha1.PodSpecWorkload) field.ErrorList {
-	klog.InfoS("validate create", "name", r.Name)
+	klog.InfoS("Validate create PodSpecWorkload", "name", r.Name)
 	allErrs := apimachineryvalidation.ValidateObjectMeta(&r.ObjectMeta, true,
 		apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
 
@@ -94,13 +94,13 @@ func ValidateCreate(r *v1alpha1.PodSpecWorkload) field.ErrorList {
 
 // ValidateUpdate validates the PodSpecWorkload on update
 func ValidateUpdate(r *v1alpha1.PodSpecWorkload, _ *v1alpha1.PodSpecWorkload) field.ErrorList {
-	klog.InfoS("validate update", "name", r.Name)
+	klog.InfoS("Validate update PodSpecWorkload", "name", r.Name)
 	return ValidateCreate(r)
 }
 
 // ValidateDelete validates the PodSpecWorkload on delete
 func ValidateDelete(r *v1alpha1.PodSpecWorkload) field.ErrorList {
-	klog.InfoS("validate delete", "name", r.Name)
+	klog.InfoS("Validate delete PodSpecWorkload", "name", r.Name)
 	return nil
 }
 


### PR DESCRIPTION
refer to https://github.com/oam-dev/kubevela/issues/378

using klog/v2 as log system which can print out the file and line numbers

- [x] add logfilepath option for helm chart
- [x] align with [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md), [Migration Instructions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#structured-logging-in-kubernetes)
- [x] set logdebug level

### Following record the step to migration log system:
1. Remove string formatting from log message. refer to [Migration Instructions-**Remove string formatting from log message**](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#remove-string-formatting-from-log-message)
    1. improve messages to comply with good practices:
        * Start from a capital letter.
        * Do not end the message with a period.
        * Use active voice. Use complete sentences when there is an acting subject ("A could not do B") or omit the subject if
        the subject would be the program itself ("Could not do B").
        * Use past tense ("Could not delete B" instead of "Cannot delete B")
        * When referring to an object, state what type of object it is. ("Deleted pod" instead of "Deleted")
     2. Name arguments in `klog.InfoS`
        * Always use lowerCamelCase

2. Using ErrorS refer to [Migration Instructions-**Using ErrorS**](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#using-errors)

    ```golang
    // ErrorS structured logs to the ERROR, WARNING, and INFO logs.
    // the err argument used as "err" field of log line.
    // The msg argument used to add constant description to the log line.
    // The key/value pairs would be join by "=" ; a newline is always appended.
    //
    // Examples:
    // >> klog.ErrorS(err, "Failed to update pod status")
    // output:
    // >> E1025 00:15:15.525108       1 controller_utils.go:114] "Failed to update pod status" err="timeout"
    func ErrorS(err error, msg string, keysAndValues ...interface{})
    ```
    1. For expected errors (errors that can happen during routine operations) use `klog.InfoS` and pass error in `err` key instead. 

3. Use klog.KObj and klog.KRef for Kubernetes objects. refer to [Migration Instructions-**Use klog.KObj and klog.KRef**](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#use-klogkobj-and-klogkref-for-kubernetes-objects)