### PR TITLE
add param to minikube start

### DIFF
--- a/docs/en/install.mdx
+++ b/docs/en/install.mdx
@@ -31,7 +31,7 @@ Follow the minikube [installation guide](https://minikube.sigs.k8s.io/docs/start
 Then spins up a minikube cluster
 
 ```shell script
-minikube start
+minikube start --driver=hyperkit
 ```
 
 Install ingress:


### PR DESCRIPTION
for this issue:
```
Exiting due to MK_USAGE: Due to networking limitations of driver docker on darwin, ingress addon is not supported.
Alternatively to use this addon you can use a vm-based driver:

	'minikube start --vm=true'

To track the update on this work in progress feature please check:
https://github.com/kubernetes/minikube/issues/7332
```