### PR TITLE
Add more optional paramters to built-in component

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -29,10 +29,77 @@ spec:
         				if parameter["cmd"] != _|_ {
         					command: parameter.cmd
         				}
+        
+        				if parameter["env"] != _|_ {
+        					env: parameter.env
+        				}
+        
+        				if parameter["cpu"] != _|_ {
+        					resources: {
+        						limits:
+        							cpu: parameter.cpu
+        						requests:
+        							cpu: parameter.cpu
+        					}
+        				}
+        
+        				if parameter["memory"] != _|_ {
+        					resources: {
+        						limits:
+        							memory: parameter.memory
+        						requests:
+        							memory: parameter.memory
+        					}
+        				}
+        
+        				if parameter["volumes"] != _|_ {
+        					volumeMounts: [ for v in parameter.volumes {
+        						{
+        							mountPath: v.mountPath
+        							name:      v.name
+        						}}]
+        				}
         			}]
+        
+        		if parameter["volumes"] != _|_ {
+        			volumes: [ for v in parameter.volumes {
+        				{
+        					name: v.name
+        					if v.type == "pvc" {
+        						persistentVolumeClaim: {
+        							claimName: v.claimName
+        						}
+        					}
+        					if v.type == "configMap" {
+        						configMap: {
+        							defaultMode: v.defaultMode
+        							name:        v.cmName
+        							if v.items != _|_ {
+        								items: v.items
+        							}
+        						}
+        					}
+        					if v.type == "secret" {
+        						secret: {
+        							defaultMode: v.defaultMode
+        							secretName:  v.secretName
+        							if v.items != _|_ {
+        								items: v.items
+        							}
+        						}
+        					}
+        					if v.type == "emptyDir" {
+        						emptyDir: {
+        							medium: v.medium
+        						}
+        					}
+        				}}]
         		}
+        
         	}
         }
+        }
+        
         parameter: {
         	// +usage=Specify number of tasks to run in parallel
         	// +short=c
@@ -47,5 +114,109 @@ spec:
         
         	// +usage=Commands to run in the container
         	cmd?: [...string]
+        
+        	// +usage=Define arguments by using environment variables
+        	env?: [...{
+        		// +usage=Environment variable name
+        		name: string
+        		// +usage=The value of the environment variable
+        		value?: string
+        		// +usage=Specifies a source the value of this var should come from
+        		valueFrom?: {
+        			// +usage=Selects a key of a secret in the pod's namespace
+        			secretKeyRef: {
+        				// +usage=The name of the secret in the pod's namespace to select from
+        				name: string
+        				// +usage=The key of the secret to select from. Must be a valid secret key
+        				key: string
+        			}
+        		}
+        	}]
+        
+        	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
+        	cpu?: string
+        
+        	// +usage=Specifies the attributes of the memory resource required for the container.
+        	memory?: string
+        
+        	// +usage=Declare volumes and volumeMounts
+        	volumes?: [...{
+        		name:      string
+        		mountPath: string
+        		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
+        		type: "pvc" | "configMap" | "secret" | "emptyDir"
+        		if type == "pvc" {
+        			claimName: string
+        		}
+        		if type == "configMap" {
+        			defaultMode: *420 | int
+        			cmName:      string
+        			items?: [...{
+        				key:  string
+        				path: string
+        				mode: *511 | int
+        			}]
+        		}
+        		if type == "secret" {
+        			defaultMode: *420 | int
+        			secretName:  string
+        			items?: [...{
+        				key:  string
+        				path: string
+        				mode: *511 | int
+        			}]
+        		}
+        		if type == "emptyDir" {
+        			medium: *"" | "Memory"
+        		}
+        	}]
+        
+        	// +usage=Instructions for assessing whether the container is alive.
+        	livenessProbe?: #HealthProbe
+        
+        	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
+        	readinessProbe?: #HealthProbe
+        }
+        
+        #HealthProbe: {
+        
+        	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+        	exec?: {
+        		// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+        		command: [...string]
+        	}
+        
+        	// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+        	httpGet?: {
+        		// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+        		path: string
+        		// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+        		port: int
+        		httpHeaders?: [...{
+        			name:  string
+        			value: string
+        		}]
+        	}
+        
+        	// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+        	tcpSocket?: {
+        		// +usage=The TCP socket within the container that should be probed to assess container health.
+        		port: int
+        	}
+        
+        	// +usage=Number of seconds after the container is started before the first probe is initiated.
+        	initialDelaySeconds: *0 | int
+        
+        	// +usage=How often, in seconds, to execute the probe.
+        	periodSeconds: *10 | int
+        
+        	// +usage=Number of seconds after which the probe times out.
+        	timeoutSeconds: *1 | int
+        
+        	// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+        	successThreshold: *1 | int
+        
+        	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+        	failureThreshold: *3 | int
         }
         

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -198,52 +198,52 @@ spec:
         		}
         	}]
         
-        	#HealthProbe: {
-        
-        		// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
-        		exec?: {
-        			// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
-        			command: [...string]
-        		}
-        
-        		// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
-        		httpGet?: {
-        			// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
-        			path: string
-        			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
-        			port: int
-        			httpHeaders?: [...{
-        				name:  string
-        				value: string
-        			}]
-        		}
-        
-        		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
-        		tcpSocket?: {
-        			// +usage=The TCP socket within the container that should be probed to assess container health.
-        			port: int
-        		}
-        
-        		// +usage=Number of seconds after the container is started before the first probe is initiated.
-        		initialDelaySeconds: *0 | int
-        
-        		// +usage=How often, in seconds, to execute the probe.
-        		periodSeconds: *10 | int
-        
-        		// +usage=Number of seconds after which the probe times out.
-        		timeoutSeconds: *1 | int
-        
-        		// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
-        		successThreshold: *1 | int
-        
-        		// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
-        		failureThreshold: *3 | int
-        	}
-        
         	// +usage=Instructions for assessing whether the container is alive.
         	livenessProbe?: #HealthProbe
         
         	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
         	readinessProbe?: #HealthProbe
+        }
+        
+        #HealthProbe: {
+        
+        	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+        	exec?: {
+        		// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+        		command: [...string]
+        	}
+        
+        	// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+        	httpGet?: {
+        		// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+        		path: string
+        		// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+        		port: int
+        		httpHeaders?: [...{
+        			name:  string
+        			value: string
+        		}]
+        	}
+        
+        	// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+        	tcpSocket?: {
+        		// +usage=The TCP socket within the container that should be probed to assess container health.
+        		port: int
+        	}
+        
+        	// +usage=Number of seconds after the container is started before the first probe is initiated.
+        	initialDelaySeconds: *0 | int
+        
+        	// +usage=How often, in seconds, to execute the probe.
+        	periodSeconds: *10 | int
+        
+        	// +usage=Number of seconds after which the probe times out.
+        	timeoutSeconds: *1 | int
+        
+        	// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+        	successThreshold: *1 | int
+        
+        	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+        	failureThreshold: *3 | int
         }
         

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -63,6 +63,15 @@ spec:
         						}
         					}
         
+        					if parameter["memory"] != _|_ {
+        						resources: {
+        							limits:
+        								memory: parameter.memory
+        							requests:
+        								memory: parameter.memory
+        						}
+        					}
+        
         					if parameter["volumes"] != _|_ {
         						volumeMounts: [ for v in parameter.volumes {
         							{
@@ -70,6 +79,15 @@ spec:
         								name:      v.name
         							}}]
         					}
+        
+        					if parameter["livenessProbe"] != _|_ {
+        						livenessProbe: parameter.livenessProbe
+        					}
+        
+        					if parameter["readinessProbe"] != _|_ {
+        						readinessProbe: parameter.readinessProbe
+        					}
+        
         				}]
         
         			if parameter["volumes"] != _|_ {
@@ -107,8 +125,8 @@ spec:
         					}}]
         			}
         		}
-        		}
         	}
+        }
         }
         parameter: {
         	// +usage=Which image would you like to use for your service
@@ -138,8 +156,12 @@ spec:
         			}
         		}
         	}]
+        
         	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
         	cpu?: string
+        
+        	// +usage=Specifies the attributes of the memory resource required for the container.
+        	memory?: string
         
         	// If addRevisionLabel is true, the appRevision label will be added to the underlying pods 
         	addRevisionLabel: *false | bool
@@ -175,5 +197,53 @@ spec:
         			medium: *"" | "Memory"
         		}
         	}]
+        
+        	#HealthProbe: {
+        
+        		// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+        		exec?: {
+        			// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+        			command: [...string]
+        		}
+        
+        		// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+        		httpGet?: {
+        			// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+        			path: string
+        			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+        			port: int
+        			httpHeaders?: [...{
+        				name:  string
+        				value: string
+        			}]
+        		}
+        
+        		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+        		tcpSocket?: {
+        			// +usage=The TCP socket within the container that should be probed to assess container health.
+        			port: int
+        		}
+        
+        		// +usage=Number of seconds after the container is started before the first probe is initiated.
+        		initialDelaySeconds: *0 | int
+        
+        		// +usage=How often, in seconds, to execute the probe.
+        		periodSeconds: *10 | int
+        
+        		// +usage=Number of seconds after which the probe times out.
+        		timeoutSeconds: *1 | int
+        
+        		// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+        		successThreshold: *1 | int
+        
+        		// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+        		failureThreshold: *3 | int
+        	}
+        
+        	// +usage=Instructions for assessing whether the container is alive.
+        	livenessProbe?: #HealthProbe
+        
+        	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
+        	readinessProbe?: #HealthProbe
         }
         

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -37,6 +37,9 @@ spec:
         				containers: [{
         					name:  context.name
         					image: parameter.image
+        					ports: [{
+        						containerPort: parameter.port
+        					}]
         
         					if parameter["cmd"] != _|_ {
         						command: parameter.cmd
@@ -49,10 +52,6 @@ spec:
         					if context["config"] != _|_ {
         						env: context.config
         					}
-        
-        					ports: [{
-        						containerPort: parameter.port
-        					}]
         
         					if parameter["cpu"] != _|_ {
         						resources: {
@@ -133,12 +132,16 @@ spec:
         	// +short=i
         	image: string
         
-        	// +usage=Commands to run in the container
-        	cmd?: [...string]
-        
         	// +usage=Which port do you want customer traffic sent to
         	// +short=p
         	port: *80 | int
+        
+        	// If addRevisionLabel is true, the appRevision label will be added to the underlying pods
+        	addRevisionLabel: *false | bool
+        
+        	// +usage=Commands to run in the container
+        	cmd?: [...string]
+        
         	// +usage=Define arguments by using environment variables
         	env?: [...{
         		// +usage=Environment variable name
@@ -162,9 +165,6 @@ spec:
         
         	// +usage=Specifies the attributes of the memory resource required for the container.
         	memory?: string
-        
-        	// If addRevisionLabel is true, the appRevision label will be added to the underlying pods 
-        	addRevisionLabel: *false | bool
         
         	// +usage=Declare volumes and volumeMounts
         	volumes?: [...{

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -36,12 +36,8 @@ spec:
         						command: parameter.cmd
         					}
         
-        					if parameter["volumes"] != _|_ {
-        						volumeMounts: [ for v in parameter.volumes {
-        							{
-        								mountPath: v.mountPath
-        								name:      v.name
-        							}}]
+        					if parameter["env"] != _|_ {
+        						env: parameter.env
         					}
         
         					if parameter["cpu"] != _|_ {
@@ -60,6 +56,14 @@ spec:
         							requests:
         								memory: parameter.memory
         						}
+        					}
+        
+        					if parameter["volumes"] != _|_ {
+        						volumemounts: [ for v in parameter.volumes {
+        							{
+        								mountPath: v.mountPath
+        								name:      v.name
+        							}}]
         					}
         
         					if parameter["livenessProbe"] != _|_ {
@@ -115,8 +119,34 @@ spec:
         	// +usage=Which image would you like to use for your service
         	// +short=i
         	image: string
+        
         	// +usage=Commands to run in the container
         	cmd?: [...string]
+        
+        	// +usage=Define arguments by using environment variables
+        	env?: [...{
+        		// +usage=Environment variable name
+        		name: string
+        		// +usage=The value of the environment variable
+        		value?: string
+        		// +usage=Specifies a source the value of this var should come from
+        		valueFrom?: {
+        			// +usage=Selects a key of a secret in the pod's namespace
+        			secretKeyRef: {
+        				// +usage=The name of the secret in the pod's namespace to select from
+        				name: string
+        				// +usage=The key of the secret to select from. Must be a valid secret key
+        				key: string
+        			}
+        		}
+        	}]
+        
+        	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
+        	cpu?: string
+        
+        	// +usage=Specifies the attributes of the memory resource required for the container.
+        	memory?: string
+        
         	// +usage=Declare volumes and volumeMounts
         	volumes?: [...{
         		name:      string
@@ -148,12 +178,6 @@ spec:
         			medium: *"" | "Memory"
         		}
         	}]
-        
-        	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
-        	cpu?: string
-        
-        	// +usage=Specifies the attributes of the memory resource required for the container.
-        	memory?: string
         
         	// +usage=Instructions for assessing whether the container is alive.
         	livenessProbe?: #HealthProbe

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -43,45 +43,72 @@ spec:
         								name:      v.name
         							}}]
         					}
+        
+        					if parameter["cpu"] != _|_ {
+        						resources: {
+        							limits:
+        								cpu: parameter.cpu
+        							requests:
+        								cpu: parameter.cpu
+        						}
+        					}
+        
+        					if parameter["memory"] != _|_ {
+        						resources: {
+        							limits:
+        								memory: parameter.memory
+        							requests:
+        								memory: parameter.memory
+        						}
+        					}
+        
+        					if parameter["livenessProbe"] != _|_ {
+        						livenessProbe: parameter.livenessProbe
+        					}
+        
+        					if parameter["readinessProbe"] != _|_ {
+        						readinessProbe: parameter.readinessProbe
+        					}
+        
         				}]
         
-        				if parameter["volumes"] != _|_ {
-        					volumes: [ for v in parameter.volumes {
-        						{
-        							name: v.name
-        							if v.type == "pvc" {
-        								persistentVolumeClaim: {
-        									claimName: v.claimName
+        			if parameter["volumes"] != _|_ {
+        				volumes: [ for v in parameter.volumes {
+        					{
+        						name: v.name
+        						if v.type == "pvc" {
+        							persistentVolumeClaim: {
+        								claimName: v.claimName
+        							}
+        						}
+        						if v.type == "configMap" {
+        							configMap: {
+        								defaultMode: v.defaultMode
+        								name:        v.cmName
+        								if v.items != _|_ {
+        									items: v.items
         								}
         							}
-        							if v.type == "configMap" {
-        								configMap: {
-        									defaultMode: v.defaultMode
-        									name:        v.cmName
-        									if v.items != _|_ {
-        										items: v.items
-        									}
+        						}
+        						if v.type == "secret" {
+        							secret: {
+        								defaultMode: v.defaultMode
+        								secretName:  v.secretName
+        								if v.items != _|_ {
+        									items: v.items
         								}
         							}
-        							if v.type == "secret" {
-        								secret: {
-        									defaultMode: v.defaultMode
-        									secretName:  v.secretName
-        									if v.items != _|_ {
-        										items: v.items
-        									}
-        								}
+        						}
+        						if v.type == "emptyDir" {
+        							emptyDir: {
+        								medium: v.medium
         							}
-        							if v.type == "emptyDir" {
-        								emptyDir: {
-        									medium: v.medium
-        								}
-        							}
-        						}}]
-        				}
+        						}
+        					}}]
         			}
         		}
         	}
+        }
         }
         
         parameter: {
@@ -121,5 +148,58 @@ spec:
         			medium: *"" | "Memory"
         		}
         	}]
+        
+        	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
+        	cpu?: string
+        
+        	// +usage=Specifies the attributes of the memory resource required for the container.
+        	memory?: string
+        	#HealthProbe: {
+        
+        		// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+        		exec?: {
+        			// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+        			command: [...string]
+        		}
+        
+        		// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+        		httpGet?: {
+        			// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+        			path: string
+        			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+        			port: int
+        			httpHeaders?: [...{
+        				name:  string
+        				value: string
+        			}]
+        		}
+        
+        		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+        		tcpSocket?: {
+        			// +usage=The TCP socket within the container that should be probed to assess container health.
+        			port: int
+        		}
+        
+        		// +usage=Number of seconds after the container is started before the first probe is initiated.
+        		initialDelaySeconds: *0 | int
+        
+        		// +usage=How often, in seconds, to execute the probe.
+        		periodSeconds: *10 | int
+        
+        		// +usage=Number of seconds after which the probe times out.
+        		timeoutSeconds: *1 | int
+        
+        		// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+        		successThreshold: *1 | int
+        
+        		// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+        		failureThreshold: *3 | int
+        	}
+        
+        	// +usage=Instructions for assessing whether the container is alive.
+        	livenessProbe?: #HealthProbe
+        
+        	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
+        	readinessProbe?: #HealthProbe
         }
         

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -154,52 +154,53 @@ spec:
         
         	// +usage=Specifies the attributes of the memory resource required for the container.
         	memory?: string
-        	#HealthProbe: {
-        
-        		// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
-        		exec?: {
-        			// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
-        			command: [...string]
-        		}
-        
-        		// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
-        		httpGet?: {
-        			// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
-        			path: string
-        			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
-        			port: int
-        			httpHeaders?: [...{
-        				name:  string
-        				value: string
-        			}]
-        		}
-        
-        		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
-        		tcpSocket?: {
-        			// +usage=The TCP socket within the container that should be probed to assess container health.
-        			port: int
-        		}
-        
-        		// +usage=Number of seconds after the container is started before the first probe is initiated.
-        		initialDelaySeconds: *0 | int
-        
-        		// +usage=How often, in seconds, to execute the probe.
-        		periodSeconds: *10 | int
-        
-        		// +usage=Number of seconds after which the probe times out.
-        		timeoutSeconds: *1 | int
-        
-        		// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
-        		successThreshold: *1 | int
-        
-        		// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
-        		failureThreshold: *3 | int
-        	}
         
         	// +usage=Instructions for assessing whether the container is alive.
         	livenessProbe?: #HealthProbe
         
         	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
         	readinessProbe?: #HealthProbe
+        }
+        
+        #HealthProbe: {
+        
+        	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+        	exec?: {
+        		// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+        		command: [...string]
+        	}
+        
+        	// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+        	httpGet?: {
+        		// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+        		path: string
+        		// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+        		port: int
+        		httpHeaders?: [...{
+        			name:  string
+        			value: string
+        		}]
+        	}
+        
+        	// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+        	tcpSocket?: {
+        		// +usage=The TCP socket within the container that should be probed to assess container health.
+        		port: int
+        	}
+        
+        	// +usage=Number of seconds after the container is started before the first probe is initiated.
+        	initialDelaySeconds: *0 | int
+        
+        	// +usage=How often, in seconds, to execute the probe.
+        	periodSeconds: *10 | int
+        
+        	// +usage=Number of seconds after which the probe times out.
+        	timeoutSeconds: *1 | int
+        
+        	// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+        	successThreshold: *1 | int
+        
+        	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+        	failureThreshold: *3 | int
         }
         

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -59,7 +59,7 @@ spec:
         					}
         
         					if parameter["volumes"] != _|_ {
-        						volumemounts: [ for v in parameter.volumes {
+        						volumeMounts: [ for v in parameter.volumes {
         							{
         								mountPath: v.mountPath
         								name:      v.name

--- a/docs/examples/app-with-probe/README.md
+++ b/docs/examples/app-with-probe/README.md
@@ -1,0 +1,42 @@
+# How to probe application's status
+
+In this section, I'll illustrate by an example how to declare a probe to test if an application is alive.
+
+## Prerequisite
+
+1. You can access a cluster(remotely or locally like `kind` or `minikube`)
+2. You have installed KubeVela
+
+## Steps
+
+### Check application yaml
+
+in [app-with-probe.yaml](./app-with-probe.yaml), you'll see a `livenessProbe` field in `properties`, which shows how to test if a component is alive.
+
+`path` is the health check path your web server exposed and `port` are your server is listening.
+
+In this example, we use `httpGet` method to check the application. It's a common method in web service. Besides the `httpGet` probe method, you can also change it into `exec` or `tcpSocket` method.
+
+### Apply the application
+
+Just apply the file in cluster.
+```shell
+kubectl apply -f app-with-probe.yaml
+```
+
+### Check the status
+
+Actually Applications in cluster are rendered into resources like `pod`.
+
+Try to describe pod:
+```shell
+$ kubectl get pod
+NAME                        READY   STATUS    RESTARTS   AGE
+frontend-86bc89d8f5-xgrnc   1/1     Running   0          18s
+
+$ kubectl describe pod frontend-86bc89d8f5-xgrnc
+...
+Liveness:     http-get http://:8080/ delay=0s timeout=1s period=10s #success=1 #failure=3
+...(other infomation)
+```
+You'll see pod is running without any error. If this component is unusable reported by livenessProbe, it will restart automatically.

--- a/docs/examples/app-with-probe/README.md
+++ b/docs/examples/app-with-probe/README.md
@@ -2,9 +2,9 @@
 
 In this section, I'll illustrate by an example how to declare a probe to test if an application is alive.
 
-## Prerequisite
+## Prerequisites
 
-1. You can access a cluster(remotely or locally like `kind` or `minikube`)
+1. You can access a Kubernetes cluster(remotely or locally like `kind` or `minikube`)
 2. You have installed KubeVela
 
 ## Steps
@@ -13,7 +13,7 @@ In this section, I'll illustrate by an example how to declare a probe to test if
 
 in [app-with-probe.yaml](./app-with-probe.yaml), you'll see a `livenessProbe` field in `properties`, which shows how to test if a component is alive.
 
-`path` is the health check path your web server exposed and `port` are your server is listening.
+`path` is the health check path your web server is exposed and `port` is the port your server is listening to.
 
 In this example, we use `httpGet` method to check the application. It's a common method in web service. Besides the `httpGet` probe method, you can also change it into `exec` or `tcpSocket` method.
 
@@ -26,9 +26,9 @@ kubectl apply -f app-with-probe.yaml
 
 ### Check the status
 
-Actually Applications in cluster are rendered into resources like `pod`.
+the application in the cluster is rendered into resources like `pod`.
 
-Try to describe pod:
+Try to describe the pod:
 ```shell
 $ kubectl get pod
 NAME                        READY   STATUS    RESTARTS   AGE
@@ -39,4 +39,4 @@ $ kubectl describe pod frontend-86bc89d8f5-xgrnc
 Liveness:     http-get http://:8080/ delay=0s timeout=1s period=10s #success=1 #failure=3
 ...(other infomation)
 ```
-You'll see pod is running without any error. If this component is unusable reported by livenessProbe, it will restart automatically.
+You'll see the pod is running without any errors. If this component is unusable reported by livenessProbe, it will restart automatically.

--- a/docs/examples/app-with-probe/app-with-probe.yaml
+++ b/docs/examples/app-with-probe/app-with-probe.yaml
@@ -1,0 +1,16 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-website
+spec:
+  components:
+    - name: frontend
+      type: webservice
+      properties:
+        image: oamdev/testapp:v1
+        cmd: ["node", "server.js"]
+        port: 8080
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080

--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -172,6 +172,10 @@ var ApplicationInitIntercativeCliContext = func(context string, appName string, 
 						q: "Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core) (optional):",
 						a: "0.5",
 					},
+					{
+						q: "Specifies the attributes of the memory resource required for the container. (optional):",
+						a: "200M",
+					},
 				}
 				for _, qa := range data {
 					_, err := c.ExpectString(qa.q)

--- a/vela-templates/internal/cue/task.cue
+++ b/vela-templates/internal/cue/task.cue
@@ -13,10 +13,77 @@ output: {
 				if parameter["cmd"] != _|_ {
 					command: parameter.cmd
 				}
+
+				if parameter["env"] != _|_ {
+					env: parameter.env
+				}
+
+				if parameter["cpu"] != _|_ {
+					resources: {
+						limits:
+							cpu: parameter.cpu
+						requests:
+							cpu: parameter.cpu
+					}
+				}
+
+				if parameter["memory"] != _|_ {
+					resources: {
+						limits:
+							memory: parameter.memory
+						requests:
+							memory: parameter.memory
+					}
+				}
+
+				if parameter["volumes"] != _|_ {
+					volumeMounts: [ for v in parameter.volumes {
+						{
+							mountPath: v.mountPath
+							name:      v.name
+						}}]
+				}
 			}]
+
+		if parameter["volumes"] != _|_ {
+			volumes: [ for v in parameter.volumes {
+				{
+					name: v.name
+					if v.type == "pvc" {
+						persistentVolumeClaim: {
+							claimName: v.claimName
+						}
+					}
+					if v.type == "configMap" {
+						configMap: {
+							defaultMode: v.defaultMode
+							name:        v.cmName
+							if v.items != _|_ {
+								items: v.items
+							}
+						}
+					}
+					if v.type == "secret" {
+						secret: {
+							defaultMode: v.defaultMode
+							secretName:  v.secretName
+							if v.items != _|_ {
+								items: v.items
+							}
+						}
+					}
+					if v.type == "emptyDir" {
+						emptyDir: {
+							medium: v.medium
+						}
+					}
+				}}]
 		}
+
 	}
 }
+}
+
 parameter: {
 	// +usage=Specify number of tasks to run in parallel
 	// +short=c
@@ -31,4 +98,109 @@ parameter: {
 
 	// +usage=Commands to run in the container
 	cmd?: [...string]
+
+	// +usage=Define arguments by using environment variables
+	env?: [...{
+		// +usage=Environment variable name
+		name: string
+		// +usage=The value of the environment variable
+		value?: string
+		// +usage=Specifies a source the value of this var should come from
+		valueFrom?: {
+			// +usage=Selects a key of a secret in the pod's namespace
+			secretKeyRef: {
+				// +usage=The name of the secret in the pod's namespace to select from
+				name: string
+				// +usage=The key of the secret to select from. Must be a valid secret key
+				key: string
+			}
+		}
+	}]
+
+	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
+	cpu?: string
+
+	// +usage=Specifies the attributes of the memory resource required for the container.
+	memory?: string
+
+	// +usage=Declare volumes and volumeMounts
+	volumes?: [...{
+		name:      string
+		mountPath: string
+		// +usage=Specify volume type, options: "pvc","configMap","secret","emptyDir"
+		type: "pvc" | "configMap" | "secret" | "emptyDir"
+		if type == "pvc" {
+			claimName: string
+		}
+		if type == "configMap" {
+			defaultMode: *420 | int
+			cmName:      string
+			items?: [...{
+				key:  string
+				path: string
+				mode: *511 | int
+			}]
+		}
+		if type == "secret" {
+			defaultMode: *420 | int
+			secretName:  string
+			items?: [...{
+				key:  string
+				path: string
+				mode: *511 | int
+			}]
+		}
+		if type == "emptyDir" {
+			medium: *"" | "Memory"
+		}
+	}]
+
+	// +usage=Instructions for assessing whether the container is alive.
+	livenessProbe?: #HealthProbe
+
+	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
+	readinessProbe?: #HealthProbe
 }
+
+#HealthProbe: {
+
+	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+	exec?: {
+		// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+		command: [...string]
+	}
+
+	// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+	httpGet?: {
+		// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+		path: string
+		// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+		port: int
+		httpHeaders?: [...{
+			name:  string
+			value: string
+		}]
+	}
+
+	// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+	tcpSocket?: {
+		// +usage=The TCP socket within the container that should be probed to assess container health.
+		port: int
+	}
+
+	// +usage=Number of seconds after the container is started before the first probe is initiated.
+	initialDelaySeconds: *0 | int
+
+	// +usage=How often, in seconds, to execute the probe.
+	periodSeconds: *10 | int
+
+	// +usage=Number of seconds after which the probe times out.
+	timeoutSeconds: *1 | int
+
+	// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+	successThreshold: *1 | int
+
+	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+	failureThreshold: *3 | int
+}
+kk

--- a/vela-templates/internal/cue/task.cue
+++ b/vela-templates/internal/cue/task.cue
@@ -203,4 +203,3 @@ parameter: {
 	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
 	failureThreshold: *3 | int
 }
-kk

--- a/vela-templates/internal/cue/webservice.cue
+++ b/vela-templates/internal/cue/webservice.cue
@@ -109,8 +109,8 @@ output: {
 					}}]
 			}
 		}
-		}
 	}
+}
 }
 parameter: {
 	// +usage=Which image would you like to use for your service
@@ -141,11 +141,11 @@ parameter: {
 		}
 	}]
 
-		// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
-		cpu?: string
+	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
+	cpu?: string
 
-		// +usage=Specifies the attributes of the memory resource required for the container.
-		memory?: string
+	// +usage=Specifies the attributes of the memory resource required for the container.
+	memory?: string
 
 	// If addRevisionLabel is true, the appRevision label will be added to the underlying pods 
 	addRevisionLabel: *false | bool
@@ -196,10 +196,10 @@ parameter: {
 			path: string
 			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
 			port: int
-			httpHeaders: {
+			httpHeaders?: [...{
 				name:  string
 				value: string
-			}
+			}]
 		}
 
 		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.

--- a/vela-templates/internal/cue/webservice.cue
+++ b/vela-templates/internal/cue/webservice.cue
@@ -47,6 +47,15 @@ output: {
 						}
 					}
 
+					if parameter["memory"] != _|_ {
+						resources: {
+							limits:
+								memory: parameter.memory
+							requests:
+								memory: parameter.memory
+						}
+					}
+
 					if parameter["volumes"] != _|_ {
 						volumeMounts: [ for v in parameter.volumes {
 							{
@@ -54,6 +63,15 @@ output: {
 								name:      v.name
 							}}]
 					}
+
+					if parameter["livenessProbe"] != _|_ {
+						livenessProbe: parameter.livenessProbe
+					}
+
+					if parameter["readinessProbe"] != _|_ {
+						readinessProbe: parameter.readinessProbe
+					}
+
 				}]
 
 			if parameter["volumes"] != _|_ {
@@ -122,8 +140,12 @@ parameter: {
 			}
 		}
 	}]
-	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
-	cpu?: string
+
+		// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
+		cpu?: string
+
+		// +usage=Specifies the attributes of the memory resource required for the container.
+		memory?: string
 
 	// If addRevisionLabel is true, the appRevision label will be added to the underlying pods 
 	addRevisionLabel: *false | bool
@@ -159,4 +181,52 @@ parameter: {
 			medium: *"" | "Memory"
 		}
 	}]
+
+	#HealthProbe: {
+
+		// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+		exec?: {
+			// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+			command: [...string]
+		}
+
+		// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+		httpGet?: {
+			// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+			path: string
+			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+			port: int
+			httpHeaders: {
+				name:  string
+				value: string
+			}
+		}
+
+		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+		tcpSocket?: {
+			// +usage=The TCP socket within the container that should be probed to assess container health.
+			port: int
+		}
+
+		// +usage=Number of seconds after the container is started before the first probe is initiated.
+		initialDelaySeconds: *0 | int
+
+		// +usage=How often, in seconds, to execute the probe.
+		periodSeconds: *10 | int
+
+		// +usage=Number of seconds after which the probe times out.
+		timeoutSeconds: *1 | int
+
+		// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+		successThreshold: *1 | int
+
+		// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+		failureThreshold: *3 | int
+	}
+
+	// +usage=Instructions for assessing whether the container is alive.
+	livenessProbe?: #HealthProbe
+
+	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
+	readinessProbe?: #HealthProbe
 }

--- a/vela-templates/internal/cue/webservice.cue
+++ b/vela-templates/internal/cue/webservice.cue
@@ -21,6 +21,9 @@ output: {
 				containers: [{
 					name:  context.name
 					image: parameter.image
+					ports: [{
+						containerPort: parameter.port
+					}]
 
 					if parameter["cmd"] != _|_ {
 						command: parameter.cmd
@@ -33,10 +36,6 @@ output: {
 					if context["config"] != _|_ {
 						env: context.config
 					}
-
-					ports: [{
-						containerPort: parameter.port
-					}]
 
 					if parameter["cpu"] != _|_ {
 						resources: {
@@ -117,12 +116,16 @@ parameter: {
 	// +short=i
 	image: string
 
-	// +usage=Commands to run in the container
-	cmd?: [...string]
-
 	// +usage=Which port do you want customer traffic sent to
 	// +short=p
 	port: *80 | int
+
+	// If addRevisionLabel is true, the appRevision label will be added to the underlying pods
+	addRevisionLabel: *false | bool
+
+	// +usage=Commands to run in the container
+	cmd?: [...string]
+
 	// +usage=Define arguments by using environment variables
 	env?: [...{
 		// +usage=Environment variable name
@@ -146,9 +149,6 @@ parameter: {
 
 	// +usage=Specifies the attributes of the memory resource required for the container.
 	memory?: string
-
-	// If addRevisionLabel is true, the appRevision label will be added to the underlying pods 
-	addRevisionLabel: *false | bool
 
 	// +usage=Declare volumes and volumeMounts
 	volumes?: [...{

--- a/vela-templates/internal/cue/webservice.cue
+++ b/vela-templates/internal/cue/webservice.cue
@@ -182,51 +182,51 @@ parameter: {
 		}
 	}]
 
-	#HealthProbe: {
-
-		// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
-		exec?: {
-			// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
-			command: [...string]
-		}
-
-		// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
-		httpGet?: {
-			// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
-			path: string
-			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
-			port: int
-			httpHeaders?: [...{
-				name:  string
-				value: string
-			}]
-		}
-
-		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
-		tcpSocket?: {
-			// +usage=The TCP socket within the container that should be probed to assess container health.
-			port: int
-		}
-
-		// +usage=Number of seconds after the container is started before the first probe is initiated.
-		initialDelaySeconds: *0 | int
-
-		// +usage=How often, in seconds, to execute the probe.
-		periodSeconds: *10 | int
-
-		// +usage=Number of seconds after which the probe times out.
-		timeoutSeconds: *1 | int
-
-		// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
-		successThreshold: *1 | int
-
-		// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
-		failureThreshold: *3 | int
-	}
-
 	// +usage=Instructions for assessing whether the container is alive.
 	livenessProbe?: #HealthProbe
 
 	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
 	readinessProbe?: #HealthProbe
+}
+
+#HealthProbe: {
+
+	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+	exec?: {
+		// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+		command: [...string]
+	}
+
+	// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+	httpGet?: {
+		// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+		path: string
+		// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+		port: int
+		httpHeaders?: [...{
+			name:  string
+			value: string
+		}]
+	}
+
+	// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+	tcpSocket?: {
+		// +usage=The TCP socket within the container that should be probed to assess container health.
+		port: int
+	}
+
+	// +usage=Number of seconds after the container is started before the first probe is initiated.
+	initialDelaySeconds: *0 | int
+
+	// +usage=How often, in seconds, to execute the probe.
+	periodSeconds: *10 | int
+
+	// +usage=Number of seconds after which the probe times out.
+	timeoutSeconds: *1 | int
+
+	// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+	successThreshold: *1 | int
+
+	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+	failureThreshold: *3 | int
 }

--- a/vela-templates/internal/cue/worker.cue
+++ b/vela-templates/internal/cue/worker.cue
@@ -27,45 +27,72 @@ output: {
 								name:      v.name
 							}}]
 					}
+
+					if parameter["cpu"] != _|_ {
+						resources: {
+							limits:
+								cpu: parameter.cpu
+							requests:
+								cpu: parameter.cpu
+						}
+					}
+
+					if parameter["memory"] != _|_ {
+						resources: {
+							limits:
+								memory: parameter.memory
+							requests:
+								memory: parameter.memory
+						}
+					}
+
+					if parameter["livenessProbe"] != _|_ {
+						livenessProbe: parameter.livenessProbe
+					}
+
+					if parameter["readinessProbe"] != _|_ {
+						readinessProbe: parameter.readinessProbe
+					}
+
 				}]
 
-				if parameter["volumes"] != _|_ {
-					volumes: [ for v in parameter.volumes {
-						{
-							name: v.name
-							if v.type == "pvc" {
-								persistentVolumeClaim: {
-									claimName: v.claimName
+			if parameter["volumes"] != _|_ {
+				volumes: [ for v in parameter.volumes {
+					{
+						name: v.name
+						if v.type == "pvc" {
+							persistentVolumeClaim: {
+								claimName: v.claimName
+							}
+						}
+						if v.type == "configMap" {
+							configMap: {
+								defaultMode: v.defaultMode
+								name:        v.cmName
+								if v.items != _|_ {
+									items: v.items
 								}
 							}
-							if v.type == "configMap" {
-								configMap: {
-									defaultMode: v.defaultMode
-									name:        v.cmName
-									if v.items != _|_ {
-										items: v.items
-									}
+						}
+						if v.type == "secret" {
+							secret: {
+								defaultMode: v.defaultMode
+								secretName:  v.secretName
+								if v.items != _|_ {
+									items: v.items
 								}
 							}
-							if v.type == "secret" {
-								secret: {
-									defaultMode: v.defaultMode
-									secretName:  v.secretName
-									if v.items != _|_ {
-										items: v.items
-									}
-								}
+						}
+						if v.type == "emptyDir" {
+							emptyDir: {
+								medium: v.medium
 							}
-							if v.type == "emptyDir" {
-								emptyDir: {
-									medium: v.medium
-								}
-							}
-						}}]
-				}
+						}
+					}}]
 			}
 		}
 	}
+}
 }
 
 parameter: {
@@ -105,4 +132,57 @@ parameter: {
 			medium: *"" | "Memory"
 		}
 	}]
+
+	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
+	cpu?: string
+
+	// +usage=Specifies the attributes of the memory resource required for the container.
+	memory?: string
+	#HealthProbe: {
+
+		// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+		exec?: {
+			// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+			command: [...string]
+		}
+
+		// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+		httpGet?: {
+			// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+			path: string
+			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+			port: int
+			httpHeaders: {
+				name:  string
+				value: string
+			}
+		}
+
+		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+		tcpSocket?: {
+			// +usage=The TCP socket within the container that should be probed to assess container health.
+			port: int
+		}
+
+		// +usage=Number of seconds after the container is started before the first probe is initiated.
+		initialDelaySeconds: *0 | int
+
+		// +usage=How often, in seconds, to execute the probe.
+		periodSeconds: *10 | int
+
+		// +usage=Number of seconds after which the probe times out.
+		timeoutSeconds: *1 | int
+
+		// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+		successThreshold: *1 | int
+
+		// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+		failureThreshold: *3 | int
+	}
+
+	// +usage=Instructions for assessing whether the container is alive.
+	livenessProbe?: #HealthProbe
+
+	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
+	readinessProbe?: #HealthProbe
 }

--- a/vela-templates/internal/cue/worker.cue
+++ b/vela-templates/internal/cue/worker.cue
@@ -20,12 +20,8 @@ output: {
 						command: parameter.cmd
 					}
 
-					if parameter["volumes"] != _|_ {
-						volumeMounts: [ for v in parameter.volumes {
-							{
-								mountPath: v.mountPath
-								name:      v.name
-							}}]
+					if parameter["env"] != _|_ {
+						env: parameter.env
 					}
 
 					if parameter["cpu"] != _|_ {
@@ -44,6 +40,14 @@ output: {
 							requests:
 								memory: parameter.memory
 						}
+					}
+
+					if parameter["volumes"] != _|_ {
+						volumemounts: [ for v in parameter.volumes {
+							{
+								mountPath: v.mountPath
+								name:      v.name
+							}}]
 					}
 
 					if parameter["livenessProbe"] != _|_ {
@@ -99,8 +103,34 @@ parameter: {
 	// +usage=Which image would you like to use for your service
 	// +short=i
 	image: string
+
 	// +usage=Commands to run in the container
 	cmd?: [...string]
+
+	// +usage=Define arguments by using environment variables
+	env?: [...{
+		// +usage=Environment variable name
+		name: string
+		// +usage=The value of the environment variable
+		value?: string
+		// +usage=Specifies a source the value of this var should come from
+		valueFrom?: {
+			// +usage=Selects a key of a secret in the pod's namespace
+			secretKeyRef: {
+				// +usage=The name of the secret in the pod's namespace to select from
+				name: string
+				// +usage=The key of the secret to select from. Must be a valid secret key
+				key: string
+			}
+		}
+	}]
+
+	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
+	cpu?: string
+
+	// +usage=Specifies the attributes of the memory resource required for the container.
+	memory?: string
+
 	// +usage=Declare volumes and volumeMounts
 	volumes?: [...{
 		name:      string
@@ -132,12 +162,6 @@ parameter: {
 			medium: *"" | "Memory"
 		}
 	}]
-
-	// +usage=Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core)
-	cpu?: string
-
-	// +usage=Specifies the attributes of the memory resource required for the container.
-	memory?: string
 
 	// +usage=Instructions for assessing whether the container is alive.
 	livenessProbe?: #HealthProbe

--- a/vela-templates/internal/cue/worker.cue
+++ b/vela-templates/internal/cue/worker.cue
@@ -152,10 +152,10 @@ parameter: {
 			path: string
 			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
 			port: int
-			httpHeaders: {
+			httpHeaders?: [...{
 				name:  string
 				value: string
-			}
+			}]
 		}
 
 		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.

--- a/vela-templates/internal/cue/worker.cue
+++ b/vela-templates/internal/cue/worker.cue
@@ -138,51 +138,52 @@ parameter: {
 
 	// +usage=Specifies the attributes of the memory resource required for the container.
 	memory?: string
-	#HealthProbe: {
-
-		// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
-		exec?: {
-			// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
-			command: [...string]
-		}
-
-		// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
-		httpGet?: {
-			// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
-			path: string
-			// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
-			port: int
-			httpHeaders?: [...{
-				name:  string
-				value: string
-			}]
-		}
-
-		// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
-		tcpSocket?: {
-			// +usage=The TCP socket within the container that should be probed to assess container health.
-			port: int
-		}
-
-		// +usage=Number of seconds after the container is started before the first probe is initiated.
-		initialDelaySeconds: *0 | int
-
-		// +usage=How often, in seconds, to execute the probe.
-		periodSeconds: *10 | int
-
-		// +usage=Number of seconds after which the probe times out.
-		timeoutSeconds: *1 | int
-
-		// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
-		successThreshold: *1 | int
-
-		// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
-		failureThreshold: *3 | int
-	}
 
 	// +usage=Instructions for assessing whether the container is alive.
 	livenessProbe?: #HealthProbe
 
 	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
 	readinessProbe?: #HealthProbe
+}
+
+#HealthProbe: {
+
+	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.
+	exec?: {
+		// +usage=A command to be executed inside the container to assess its health. Each space delimited token of the command is a separate array element. Commands exiting 0 are considered to be successful probes, whilst all other exit codes are considered failures.
+		command: [...string]
+	}
+
+	// +usage=Instructions for assessing container health by executing an HTTP GET request. Either this attribute or the exec attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the tcpSocket attribute.
+	httpGet?: {
+		// +usage=The endpoint, relative to the port, to which the HTTP GET request should be directed.
+		path: string
+		// +usage=The TCP socket within the container to which the HTTP GET request should be directed.
+		port: int
+		httpHeaders?: [...{
+			name:  string
+			value: string
+		}]
+	}
+
+	// +usage=Instructions for assessing container health by probing a TCP socket. Either this attribute or the exec attribute or the httpGet attribute MUST be specified. This attribute is mutually exclusive with both the exec attribute and the httpGet attribute.
+	tcpSocket?: {
+		// +usage=The TCP socket within the container that should be probed to assess container health.
+		port: int
+	}
+
+	// +usage=Number of seconds after the container is started before the first probe is initiated.
+	initialDelaySeconds: *0 | int
+
+	// +usage=How often, in seconds, to execute the probe.
+	periodSeconds: *10 | int
+
+	// +usage=Number of seconds after which the probe times out.
+	timeoutSeconds: *1 | int
+
+	// +usage=Minimum consecutive successes for the probe to be considered successful after having failed.
+	successThreshold: *1 | int
+
+	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
+	failureThreshold: *3 | int
 }

--- a/vela-templates/internal/cue/worker.cue
+++ b/vela-templates/internal/cue/worker.cue
@@ -43,7 +43,7 @@ output: {
 					}
 
 					if parameter["volumes"] != _|_ {
-						volumemounts: [ for v in parameter.volumes {
+						volumeMounts: [ for v in parameter.volumes {
 							{
 								mountPath: v.mountPath
 								name:      v.name


### PR DESCRIPTION
1. I add just probe and memory limit.
2. make all internal component definition contain below alternative paramter: `cmd`,`env`,`cpu`,`memory`,`volumns`,`livenessProbe`,`readinessProbe`.
3. organize paramater's order to make code clean.
4. add docs/example for probe usage.

Now, I tried with application config below and it worked great.
```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: website
spec:
  components:
    - name: frontend
      type: webservice
      properties:
        image: oamdev/testapp:v1
        cmd: ["node", "server.js"]
        port: 8080
        cpu: "0.1"
        memory: "100M"
        livenessProbe: 
          httpGet: 
            path: /
            port: 8080
        readinessProbe: 
          httpGet: 
            path: /
            port: 8080
            httpHeaders:
              - name: aName
                value: bValue
```

And pod will be like
```yaml
$ k describe pod frontend-86bc89d8f5-rjljp
Name:         frontend-86bc89d8f5-rjljp
Namespace:    default
Priority:     0
Node:         kind-control-plane/172.18.0.2
Start Time:   Thu, 03 Jun 2021 14:35:31 +0800
Labels:       app.oam.dev/component=frontend
              pod-template-hash=86bc89d8f5
Annotations:  <none>
Status:       Running
IP:           10.244.0.20
IPs:
  IP:           10.244.0.20
Controlled By:  ReplicaSet/frontend-86bc89d8f5
Containers:
  frontend:
    Container ID:  containerd://e8afe10e958ea5b42228d41b33bf47d35fd69bd4a902f64a5e5b207a6adef068
    Image:         oamdev/testapp:v1
    Image ID:      docker.io/oamdev/testapp@sha256:8f8e7806b90c1932a404c5d2d5c07c00da6f1f0bbd77c77eda982c29851f352f
    Port:          8080/TCP
    Host Port:     0/TCP
    Command:
      node
      server.js
    State:          Running
      Started:      Thu, 03 Jun 2021 14:35:32 +0800
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     100m
      memory:  100M
    Requests:
      cpu:        100m
      memory:     100M
    Liveness:     http-get http://:8080/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Readiness:    http-get http://:8080/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:  <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-wwc4x (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  default-token-wwc4x:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-wwc4x
    Optional:    false
QoS Class:       Guaranteed
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  11m   default-scheduler  Successfully assigned default/frontend-86bc89d8f5-rjljp to kind-control-plane
  Normal  Pulled     11m   kubelet            Container image "oamdev/testapp:v1" already present on machine
  Normal  Created    11m   kubelet            Created container frontend
  Normal  Started    11m   kubelet            Started container frontend
```