### PR TITLE
Add Logging Convention in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,8 +131,44 @@ Start to test.
 ```
 make e2e-test
 ```
+## Logging Conventions
 
-### Contribute Docs
+
+### Structured logging
+
+We recommend using `klog.InfoS` to structure the log, the `message` argument need start from a capital letter.
+and name arguments should always use lowerCamelCase.
+
+```golang
+klog.InfoS("Reconcile traitDefinition", "traitDefinition", klog.KRef(req.Namespace, req.Name))
+// output:
+// I0605 10:10:57.308074   22276 traitdefinition_controller.go:59] "Reconcile traitDefinition" traitDefinition="vela-system/expose"
+```
+
+### Use `klog.KObj` and `klog.KRef` for Kubernetes objects
+
+`klog.KObj` and `klog.KRef` can unify the output of kubernetes object.
+
+```golang
+// KObj is used to create ObjectRef when logging information about Kubernetes objects
+klog.InfoS("Start to reconcile", "appDeployment", klog.KObj(appDeployment))
+// KRef is used to create ObjectRef when logging information about Kubernetes objects without access to metav1.Object
+klog.InfoS("Reconcile application", "application", klog.KRef(req.Namespace, req.Name))
+```
+
+### Logging Level
+
+[This file](https://github.com/oam-dev/kubevela/blob/master/pkg/controller/common/logs.go) contains KubeVela's log level,
+you can set the log level by `klog.V(level)`.
+
+```golang
+// you can use klog.V(common.LogDebug) to print debug log
+klog.V(common.LogDebug).InfoS("Successfully applied components", "workloads", len(workloads))
+```
+
+more detail in [Structured Logging Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#structured-logging-in-kubernetes).
+
+## Contribute Docs
 
 Please read [the documentation](https://github.com/oam-dev/kubevela/tree/master/docs/README.md) before contributing to the docs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,10 +136,11 @@ make e2e-test
 
 ### Structured logging
 
-We recommend using `klog.InfoS` to structure the log, the `message` argument need start from a capital letter.
+We recommend using `klog.InfoS` to structure the log. The `msg` argument need start from a capital letter.
 and name arguments should always use lowerCamelCase.
 
 ```golang
+// func InfoS(msg string, keysAndValues ...interface{})
 klog.InfoS("Reconcile traitDefinition", "traitDefinition", klog.KRef(req.Namespace, req.Name))
 // output:
 // I0605 10:10:57.308074   22276 traitdefinition_controller.go:59] "Reconcile traitDefinition" traitDefinition="vela-system/expose"

--- a/pkg/controller/common/rollout/rollout_webhook.go
+++ b/pkg/controller/common/rollout/rollout_webhook.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/oam-dev/kubevela/apis/standard.oam.dev/v1alpha1"
-	"github.com/oam-dev/kubevela/pkg/controller/common"
 )
 
 // issue an http call to the an end ponit
@@ -125,7 +124,7 @@ func callWebhook(ctx context.Context, resource klog.KMetadata, phase string, rw 
 	}
 	if !accepted {
 		err := fmt.Errorf("http request to the webhook not accepeted, http status = %d", status)
-		klog.V(common.LogDebug).InfoS("the status is not expected", "expected status", rw.ExpectedStatus)
+		klog.ErrorS(err, "The status is not expected", "expected status", rw.ExpectedStatus)
 		return err
 	}
 	return nil

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/applicationconfiguration.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration/applicationconfiguration.go
@@ -225,7 +225,7 @@ func (r *OAMApplicationReconciler) Reconcile(req reconcile.Request) (reconcile.R
 		}
 	} else {
 		if err := r.workloads.Finalize(ctx, ac); err != nil {
-			klog.V(common.LogDebug).InfoS("Failed to finalize workloads", "workloads status", ac.Status.Workloads,
+			klog.InfoS("Failed to finalize workloads", "workloads status", ac.Status.Workloads,
 				"err", err)
 			r.record.Event(ac, event.Warning(reasonCannotFinalizeWorkloads, err))
 			ac.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errFinalizeWorkloads)))
@@ -254,7 +254,7 @@ func (r *OAMApplicationReconciler) ACReconcile(ctx context.Context, ac *v1alpha2
 		for name, hook := range r.postHooks {
 			exeResult, err := hook.Exec(ctx, ac)
 			if err != nil {
-				klog.V(common.LogDebug).InfoS("Failed to execute post-hooks", "hook name", name, "error", err,
+				klog.InfoS("Failed to execute post-hooks", "hook name", name, "err", err,
 					"requeue-after", result.RequeueAfter)
 				r.record.Event(ac, event.Warning(reasonCannotExecutePosthooks, err))
 				ac.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errExecutePosthooks)))
@@ -270,7 +270,7 @@ func (r *OAMApplicationReconciler) ACReconcile(ctx context.Context, ac *v1alpha2
 	for name, hook := range r.preHooks {
 		result, err := hook.Exec(ctx, ac)
 		if err != nil {
-			klog.V(common.LogDebug).InfoS("Failed to execute pre-hooks", "hook name", name, "error", err, "requeue-after", result.RequeueAfter)
+			klog.InfoS("Failed to execute pre-hooks", "hook name", name, "requeue-after", result.RequeueAfter, "err", err)
 			r.record.Event(ac, event.Warning(reasonCannotExecutePrehooks, err))
 			ac.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errExecutePrehooks)))
 			return result
@@ -306,7 +306,7 @@ func (r *OAMApplicationReconciler) ACReconcile(ctx context.Context, ac *v1alpha2
 
 	applyOpts := []apply.ApplyOption{apply.MustBeControllableBy(ac.GetUID()), applyOnceOnly(ac, r.applyOnceOnlyMode)}
 	if err := r.workloads.Apply(ctx, ac.Status.Workloads, workloads, applyOpts...); err != nil {
-		klog.V(common.LogDebug).InfoS("Cannot apply workload", "err", err)
+		klog.InfoS("Cannot apply workload", "err", err)
 		r.record.Event(ac, event.Warning(reasonCannotApplyComponents, err))
 		ac.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errApplyComponents)))
 		return reconcile.Result{}
@@ -334,13 +334,13 @@ func (r *OAMApplicationReconciler) ACReconcile(ctx context.Context, ac *v1alpha2
 
 		err := r.confirmDeleteOnApplyOnceMode(ctx, ac.GetNamespace(), &e)
 		if err != nil {
-			klog.V(common.LogDebug).InfoS("Confirm component can't be garbage collected", "err", err)
+			klog.InfoS("Confirm component can't be garbage collected", "err", err)
 			record.Event(ac, event.Warning(reasonCannotGGComponents, err))
 			ac.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errGCComponent)))
 			return reconcile.Result{}
 		}
 		if err := r.client.Delete(ctx, &e); resource.IgnoreNotFound(err) != nil {
-			klog.V(common.LogDebug).InfoS("Cannot garbage collect component", "err", err)
+			klog.InfoS("Cannot garbage collect component", "err", err)
 			record.Event(ac, event.Warning(reasonCannotGGComponents, err))
 			ac.SetConditions(v1alpha1.ReconcileError(errors.Wrap(err, errGCComponent)))
 			return reconcile.Result{}


### PR DESCRIPTION
https://github.com/oam-dev/kubevela/pull/1735 and https://github.com/oam-dev/kubevela/pull/1758 refactored vela's log system using `klog`.  In order to unify the log style, we refer to these guides:[Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md), [Structured Logging Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#structured-logging-in-kubernetes) and sum up a few basic conventions.

- [x] this PR added the most basic convention in CONTRIBUTING.md. more details in [Structured Logging Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#structured-logging-in-kubernetes).
- [x] Add more output logs in key locations