### PR TITLE
refine assemble and dispatch

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/assemble/assemble.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/assemble/assemble.go
@@ -94,6 +94,10 @@ func (am *AppManifests) WithWorkloadOption(wo WorkloadOption) *AppManifests {
 }
 
 // AssembledManifests do assemble and merge all assembled resources(except referenced scopes) into one array
+// The result guarantee the order of resources as defined in application originally.
+// If it contains more than one component, the resources are well-orderred and also grouped.
+// For example, if app = comp1 (wl1 + trait1 + trait2) + comp2 (wl2 + trait3 +trait4),
+// the result is [wl1, trait1, trait2, wl2, trait3, trait4]
 func (am *AppManifests) AssembledManifests() ([]*unstructured.Unstructured, error) {
 	if !am.finalized {
 		am.assemble()
@@ -102,10 +106,9 @@ func (am *AppManifests) AssembledManifests() ([]*unstructured.Unstructured, erro
 		return nil, am.err
 	}
 	r := make([]*unstructured.Unstructured, 0)
-	for _, wl := range am.assembledWorkloads {
+	for compName, wl := range am.assembledWorkloads {
 		r = append(r, wl.DeepCopy())
-	}
-	for _, ts := range am.assembledTraits {
+		ts := am.assembledTraits[compName]
 		for _, t := range ts {
 			r = append(r, t.DeepCopy())
 		}
@@ -250,11 +253,12 @@ func (am *AppManifests) complete() {
 
 func (am *AppManifests) finalizeAssemble(err error) {
 	am.finalized = true
-	if err != nil {
-		klog.ErrorS(err, "Failed assembling manifests for application", "name", am.appName, "revision", am.AppRevision.GetName())
-		am.err = errors.WithMessagef(err, "cannot assemble resources' manifests for application %q", am.appName)
+	if err == nil {
+		klog.InfoS("Successfully assemble manifests for application", "name", am.appName, "revision", am.AppRevision.GetName(), "namespace", am.appNamespace)
+		return
 	}
-	klog.InfoS("Successfully assemble manifests for application", "name", am.appName, "revision", am.AppRevision.GetName(), "namespace", am.appNamespace)
+	klog.ErrorS(err, "Failed assembling manifests for application", "name", am.appName, "revision", am.AppRevision.GetName())
+	am.err = errors.WithMessagef(err, "cannot assemble resources' manifests for application %q", am.appName)
 }
 
 // AssembleOptions is highly coulped with AppRevision, should check the AppRevision provides all info

--- a/pkg/controller/core.oam.dev/v1alpha2/application/assemble/options.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/assemble/options.go
@@ -85,7 +85,7 @@ func discoverHelmModuleWorkload(ctx context.Context, c client.Reader, assembledW
 		}
 	}
 
-	workloadByHelm := &unstructured.Unstructured{}
+	workloadByHelm := assembledWorkload.DeepCopy()
 	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: qualifiedWorkloadName}, workloadByHelm); err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func discoverHelmModuleWorkload(ctx context.Context, c client.Reader, assembledW
 			"annotations", annots, "labels", labels)
 		return err
 	}
-	*assembledWorkload = *workloadByHelm
+	assembledWorkload.SetName(qualifiedWorkloadName)
 	return nil
 }
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/assemble/options_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/assemble/options_test.go
@@ -256,8 +256,13 @@ var _ = Describe("Test WorkloadOption", func() {
 				helm: &common.Helm{
 					Release: runtime.RawExtension{Raw: releaseRaw},
 				},
-				wantWorkload: wl.DeepCopy(),
-				wantErr:      nil,
+				wantWorkload: func() *unstructured.Unstructured {
+					r := &unstructured.Unstructured{}
+					r.SetNamespace(ns)
+					r.SetName("test-rls-test-chart")
+					return r
+				}(),
+				wantErr: nil,
 			}),
 		)
 	})

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/gc.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/gc.go
@@ -93,8 +93,8 @@ func (h *GCHandler) validate() error {
 	oldRTName := h.oldRT.Name
 	newRTName := h.newRT.Name
 	if strings.HasSuffix(oldRTName, h.namespace) && strings.HasSuffix(newRTName, h.namespace) {
-		if extractAppNameFromResourceTrackerName(oldRTName, h.namespace) ==
-			extractAppNameFromResourceTrackerName(newRTName, h.namespace) {
+		if ExtractAppName(oldRTName, h.namespace) ==
+			ExtractAppName(newRTName, h.namespace) {
 			return nil
 		}
 	}

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/name.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/name.go
@@ -28,7 +28,13 @@ func ConstructResourceTrackerName(appRevName, ns string) string {
 	return fmt.Sprintf("%s-%s", appRevName, ns)
 }
 
-func extractAppNameFromResourceTrackerName(name, ns string) string {
-	splits := strings.Split(strings.TrimSuffix(name, "-"+ns), "-")
+// ExtractAppName get application name from resource tracker name
+func ExtractAppName(resourceTrackerName, ns string) string {
+	splits := strings.Split(strings.TrimSuffix(resourceTrackerName, "-"+ns), "-")
 	return strings.Join(splits[0:len(splits)-1], "-")
+}
+
+// ExtractAppRevisionName get application revision name from resource tracker name
+func ExtractAppRevisionName(resourceTrackerName, ns string) string {
+	return strings.TrimSuffix(resourceTrackerName, "-"+ns)
 }

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/name_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/name_test.go
@@ -41,12 +41,16 @@ func TestExtractAppNameFromResourceTrackerName(t *testing.T) {
 
 	for _, tc := range testcases {
 		gotRTName := ConstructResourceTrackerName(tc.appRevName, tc.ns)
-		gotAppName := extractAppNameFromResourceTrackerName(gotRTName, tc.ns)
+		gotAppName := ExtractAppName(gotRTName, tc.ns)
+		gotAppRevName := ExtractAppRevisionName(gotRTName, tc.ns)
 		if gotRTName != tc.wantRTName {
 			t.Fatalf("expect resource tracker name %q but got %q", tc.wantRTName, gotRTName)
 		}
 		if gotAppName != tc.wantAppName {
 			t.Fatalf("expect app name %q but got %q", tc.wantAppName, gotAppName)
+		}
+		if gotAppRevName != tc.appRevName {
+			t.Fatalf("expect app revision name %q but got %q", tc.appRevName, gotAppRevName)
 		}
 	}
 }

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -33,6 +33,8 @@ const (
 	LabelOAMResourceType = "app.oam.dev/resourceType"
 	// LabelAppRevisionHash records the Hash value of the application revision
 	LabelAppRevisionHash = "app.oam.dev/app-revision-hash"
+	// LabelAppNamespace records the namespace of Application
+	LabelAppNamespace = "app.oam.dev/namesapce"
 
 	// WorkloadTypeLabel indicates the type of the workloadDefinition
 	WorkloadTypeLabel = "workload.oam.dev/type"


### PR DESCRIPTION
separated from #1763 

### major changes:
assemble pkg:
- make sure the order of resources in the assembled result is same as defined in application
- fix helmDiscovery workload option bug (assembled workload only need a name but not all spec of helm-created workload)

dispatch pkg:
- add labels(appName + namespace) to resource tracker in order to list resource trackers of a specific app
- make dispatch/applyAndRecord to incrementally record applied resources
  - scenario:  an app revision outcome 1 workload + 2 traits,  caller can dispatch the workload without traits first, until a specific condition is reached, caller then call dispatch again to dispatch traits. The resource tracker should track workload and traits.
- add exported functions about naming resource tracker in dispatch pkg
- refine and add more logs

Signed-off-by: roy wang <seiwy2010@gmail.com>