### PR TITLE
Rename deployment-rollout-controller constructor

### DIFF
--- a/pkg/controller/common/rollout/rollout_plan_controller.go
+++ b/pkg/controller/common/rollout/rollout_plan_controller.go
@@ -351,7 +351,7 @@ func (r *Controller) GetWorkloadController() (workloads.WorkloadController, erro
 		if r.targetWorkload.GetKind() == reflect.TypeOf(apps.Deployment{}).Name() {
 			// check whether current rollout plan is for workload rolling or scaling
 			if r.sourceWorkload != nil {
-				return workloads.NewDeploymentController(r.client, r.recorder, r.parentController,
+				return workloads.NewDeploymentRolloutController(r.client, r.recorder, r.parentController,
 					r.rolloutSpec, r.rolloutStatus, source, target), nil
 			}
 			return workloads.NewDeploymentScaleController(r.client, r.recorder, r.parentController,

--- a/pkg/controller/common/rollout/workloads/cloneset_rollout_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/cloneset_rollout_integration_test.go
@@ -100,8 +100,8 @@ var _ = Describe("cloneset controller", func() {
 		k8sClient.Delete(ctx, &cloneSet)
 	})
 
-	Context("TestNewCloneSetController", func() {
-		It("init a CloneSet Controller", func() {
+	Context("TestNewCloneSetRolloutController", func() {
+		It("init a CloneSet Rollout Controller", func() {
 			recorder := event.NewAPIRecorder(mgr.GetEventRecorderFor("AppRollout")).
 				WithAnnotations("controller", "AppRollout")
 			parentController := &v1beta1.AppRollout{ObjectMeta: metav1.ObjectMeta{Name: name}}

--- a/pkg/controller/common/rollout/workloads/cloneset_scale_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/cloneset_scale_integration_test.go
@@ -105,8 +105,8 @@ var _ = Describe("cloneset controller", func() {
 		k8sClient.Delete(ctx, &cloneSet)
 	})
 
-	Context("TestNewCloneSetController", func() {
-		It("init a CloneSet Controller", func() {
+	Context("TestNewCloneSetScaleController", func() {
+		It("init a CloneSet Scale Controller", func() {
 			recorder := event.NewAPIRecorder(mgr.GetEventRecorderFor("AppRollout")).
 				WithAnnotations("controller", "AppRollout")
 			parentController := &v1beta1.AppRollout{ObjectMeta: metav1.ObjectMeta{Name: name}}

--- a/pkg/controller/common/rollout/workloads/deployment_rollout_controller.go
+++ b/pkg/controller/common/rollout/workloads/deployment_rollout_controller.go
@@ -46,8 +46,8 @@ type DeploymentRolloutController struct {
 	targetDeploy         apps.Deployment
 }
 
-// NewDeploymentController creates a new deployment rollout controller
-func NewDeploymentController(client client.Client, recorder event.Recorder, parentController oam.Object,
+// NewDeploymentRolloutController creates a new deployment rollout controller
+func NewDeploymentRolloutController(client client.Client, recorder event.Recorder, parentController oam.Object,
 	rolloutSpec *v1alpha1.RolloutPlan, rolloutStatus *v1alpha1.RolloutStatus, sourceNamespacedName,
 	targetNamespacedName types.NamespacedName) *DeploymentRolloutController {
 	return &DeploymentRolloutController{

--- a/pkg/controller/common/rollout/workloads/deployment_rollout_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/deployment_rollout_integration_test.go
@@ -129,7 +129,7 @@ var _ = Describe("deployment controller", func() {
 	})
 
 	Context("TestNewDeploymentRolloutController", func() {
-		It("init a Deployment Controller", func() {
+		It("init a Deployment Rollout Controller", func() {
 			recorder := event.NewAPIRecorder(mgr.GetEventRecorderFor("AppRollout")).
 				WithAnnotations("controller", "AppRollout")
 			parentController := &v1beta1.AppRollout{ObjectMeta: metav1.ObjectMeta{Name: sourceName}}

--- a/pkg/controller/common/rollout/workloads/deployment_rollout_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/deployment_rollout_integration_test.go
@@ -128,7 +128,7 @@ var _ = Describe("deployment controller", func() {
 		k8sClient.Delete(ctx, &targetDeploy)
 	})
 
-	Context("TestNewDeploymentController", func() {
+	Context("TestNewDeploymentRolloutController", func() {
 		It("init a Deployment Controller", func() {
 			recorder := event.NewAPIRecorder(mgr.GetEventRecorderFor("AppRollout")).
 				WithAnnotations("controller", "AppRollout")
@@ -141,7 +141,7 @@ var _ = Describe("deployment controller", func() {
 			}
 			rolloutStatus := &v1alpha1.RolloutStatus{RollingState: v1alpha1.RolloutSucceedState}
 			workloadNamespacedName := client.ObjectKey{Name: sourceName, Namespace: namespaceName}
-			got := NewDeploymentController(k8sClient, recorder, parentController, rolloutSpec, rolloutStatus,
+			got := NewDeploymentRolloutController(k8sClient, recorder, parentController, rolloutSpec, rolloutStatus,
 				workloadNamespacedName, workloadNamespacedName)
 			c := &DeploymentRolloutController{
 				workloadController: workloadController{

--- a/pkg/controller/common/rollout/workloads/deployment_scale_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/deployment_scale_integration_test.go
@@ -104,7 +104,7 @@ var _ = Describe("deployment controller", func() {
 		k8sClient.Delete(ctx, &deployment)
 	})
 
-	Context("TestNewDeploymentController", func() {
+	Context("TestNewDeploymentRolloutController", func() {
 		It("init a Deployment Controller", func() {
 			recorder := event.NewAPIRecorder(mgr.GetEventRecorderFor("AppRollout")).
 				WithAnnotations("controller", "AppRollout")

--- a/pkg/controller/common/rollout/workloads/deployment_scale_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/deployment_scale_integration_test.go
@@ -104,8 +104,8 @@ var _ = Describe("deployment controller", func() {
 		k8sClient.Delete(ctx, &deployment)
 	})
 
-	Context("TestNewDeploymentRolloutController", func() {
-		It("init a Deployment Controller", func() {
+	Context("TestNewDeploymentScaleController", func() {
+		It("init a Deployment Scale Controller", func() {
 			recorder := event.NewAPIRecorder(mgr.GetEventRecorderFor("AppRollout")).
 				WithAnnotations("controller", "AppRollout")
 			parentController := &v1beta1.AppRollout{ObjectMeta: metav1.ObjectMeta{Name: name}}


### PR DESCRIPTION
This PR renames `NewDeploymentController` to `NewDeploymentRolloutController`.