### PR TITLE
add the option to choose whether to automatically generated workloaddef which componentdef refers to

### DIFF
--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -118,6 +118,7 @@ spec:
             - "--use-webhook=true"
             - "--webhook-port={{ .Values.webhookService.port }}"
             - "--webhook-cert-dir={{ .Values.admissionWebhooks.certificate.mountPath }}"
+            - "--autogen-workload-definition={{ .Values.admissionWebhooks.autoGenWorkloadDefinition }}"
             {{ end }}
             {{ if not .Values.useAppConfig }}
             - "--app-config-installed=false"

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -77,6 +77,8 @@ admissionWebhooks:
     tolerations: []
   certManager:
     enabled: false
+  # If autoGenWorkloadDefinition is true, webhook will auto generated workloadDefinition which componentDefinition refers to
+  autoGenWorkloadDefinition: true
 
 #Enable debug logs for development purpose
 logDebug: false

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -91,6 +91,7 @@ func main() {
 		"custom-revision-hook-url is a webhook url which will let KubeVela core to call with applicationConfiguration and component info and return a customized component revision")
 	flag.BoolVar(&controllerArgs.ApplicationConfigurationInstalled, "app-config-installed", true,
 		"app-config-installed indicates if applicationConfiguration CRD is installed")
+	flag.BoolVar(&controllerArgs.AutoGenWorkloadDefinition, "autogen-workload-definition", true, "Automatic generated workloadDefinition which componentDefinition refers to.")
 	flag.StringVar(&healthAddr, "health-addr", ":9440", "The address the health endpoint binds to.")
 	flag.StringVar(&applyOnceOnly, "apply-once-only", "false",
 		"For the purpose of some production environment that workload or trait should not be affected if no spec change, available options: on, off, force.")

--- a/design/api/vela-controller-params-reference.md
+++ b/design/api/vela-controller-params-reference.md
@@ -1,0 +1,27 @@
+# KubeVela Controller Parameters Reference
+
+|          parameter          |  type  |              default              |                           describe                           |
+| :-------------------------: | :----: | :-------------------------------: | :----------------------------------------------------------: |
+|         use-webhook         |  bool  |               false               |                   Enable Admission Webhook                   |
+|      webhook-cert-dir       | string | /k8s-webhook-server/serving-certs |               Admission webhook cert/key dir.                |
+|        webhook-port         |  int   |               9443                |               Admission webhook listen address               |
+|        metrics-addr         | string |               :8080               |          The address the metric endpoint binds to.           |
+|   enable-leader-election    |  bool  |               false               | Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager. |
+|  leader-election-namespace  | string |                ""                 | Determines the namespace in which the leader election configmap will be created. |
+|        log-file-path        | string |                ""                 |                  The file to write logs to.                  |
+|      log-file-max-size      |  int   |               1024                | Defines the maximum size a log file can grow to, Unit is megabytes. |
+|          log-debug          |  bool  |               false               |          Enable debug logs for development purpose           |
+|       revision-limit        |  int   |                50                 | revision-limit is the maximum number of revisions that will be maintained. The default value is 50. |
+| application-revision-limit  |  int   |                10                 | application-revision-limit is the maximum number of application useless revisions that will be maintained, if the useless revisions exceed this number, older ones will be GCed first.The default value is 10. |
+|  definition-revision-limit  |  int   |                20                 | definition-revision-limit is the maximum number of component/trait definition useless revisions that will be maintained, if the useless revisions exceed this number, older ones will be GCed first.The default value is 20. |
+|  custom-revision-hook-url   | string |                ""                 | custom-revision-hook-url is a webhook url which will let KubeVela core to call with applicationConfiguration and component info and return a customized component revision |
+|    app-config-installed     |  bool  |               true                | app-config-installed indicates if applicationConfiguration CRD is installed |
+| autogen-workload-definition |  bool  |               true                | Automatic generated workloadDefinition which componentDefinition refers to |
+|         health-addr         | string |               :9440               |          The address the health endpoint binds to.           |
+|       apply-once-only       | string |               false               | For the purpose of some production environment that workload or trait should not be affected if no spec change, available options: on, off, force. |
+|        disable-caps         | string |                ""                 |           To be disabled builtin capability list.            |
+|       storage-driver        | string |               Local               |         Application file save to the storage driver          |
+|  informer-re-sync-interval  |  time  |                2h                 |    controller shared informer lister full re-sync period     |
+| system-definition-namespace | string |            vela-system            |     define the namespace of the system-level definition      |
+|    concurrent-reconciles    |  int   |                 4                 | concurrent-reconciles is the concurrent reconcile number of the controller. |
+|      depend-check-wait      |  time  |                30s                | depend-check-wait is the time to wait for ApplicationConfiguration's dependent-resource ready. |

--- a/pkg/controller/core.oam.dev/oamruntime_controller.go
+++ b/pkg/controller/core.oam.dev/oamruntime_controller.go
@@ -76,4 +76,7 @@ type Args struct {
 
 	// DependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready
 	DependCheckWait time.Duration
+
+	// AutoGenWorkloadDefinition indicates whether automatic generated workloadDefinition which componentDefinition refers to
+	AutoGenWorkloadDefinition bool
 }


### PR DESCRIPTION
You can use the option `autoGenWorkloadDefinition` to choose whether to automatically create `WorkloadDefinition` which `ComponentDefinition` refers to. 

The default value of `autoGenWorkloadDefinition` is `true`, which means the webhook will automatically create `WorkloadDefinition`  which `ComponentDefinition` refers to , if the `WorkloadDefinition` doesn't exist.

You can set the `autoGenWorkloadDefinition` to `false` to disable this feature.


