### PR TITLE
add application  controller to caps which can be disabled and remove appdeployment

### DIFF
--- a/pkg/controller/common/types.go
+++ b/pkg/controller/common/types.go
@@ -1,29 +1,13 @@
 package common
 
-import (
-	"reflect"
-
-	v1 "k8s.io/api/core/v1"
-)
-
 const (
-	// AutoscaleControllerName is the controller name of Trait autoscale
-	AutoscaleControllerName = "autoscale"
-	// MetricsControllerName is the controller name of Trait metrics
-	MetricsControllerName = "metrics"
 	// PodspecWorkloadControllerName is the controller name of Workload podsepcworkload
 	PodspecWorkloadControllerName = "podspecworkload"
-	// RouteControllerName is the controller name of Trait route
-	RouteControllerName = "route"
+	// ApplicationControllerName is the Application controller
+	ApplicationControllerName = "application"
 
 	// DisableAllCaps disable all capabilities
 	DisableAllCaps = "all"
 	// DisableNoneCaps disable none of capabilities
 	DisableNoneCaps = ""
 )
-
-// ServiceKind is string "Service"
-var ServiceKind = reflect.TypeOf(v1.Service{}).Name()
-
-// ServiceAPIVersion is string "v1"
-var ServiceAPIVersion = v1.SchemeGroupVersion.String()

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,7 +33,6 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
 	"github.com/oam-dev/kubevela/pkg/appfile"
-	core "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
 	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
@@ -178,7 +176,7 @@ func (r *Reconciler) UpdateStatus(ctx context.Context, app *v1alpha2.Application
 }
 
 // Setup adds a controller that reconciles ApplicationDeployment.
-func Setup(mgr ctrl.Manager, _ core.Args, _ logging.Logger) error {
+func Setup(mgr ctrl.Manager) error {
 	dm, err := discoverymapper.New(mgr.GetConfig())
 	if err != nil {
 		return fmt.Errorf("create discovery dm fail %w", err)

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationdeployment/applicationdeployment_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationdeployment/applicationdeployment_controller.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -18,7 +17,6 @@ import (
 
 	corev1alpha2 "github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
 	"github.com/oam-dev/kubevela/pkg/controller/common/rollout"
-	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/application"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
@@ -160,7 +158,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // Setup adds a controller that reconciles ApplicationDeployment.
-func Setup(mgr ctrl.Manager, _ controller.Args, _ logging.Logger) error {
+func Setup(mgr ctrl.Manager) error {
 	dm, err := discoverymapper.New(mgr.GetConfig())
 	if err != nil {
 		return fmt.Errorf("create discovery dm fail %w", err)

--- a/pkg/controller/core.oam.dev/v1alpha2/setup.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/setup.go
@@ -19,13 +19,10 @@ package v1alpha2
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/application"
-
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
 	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/applicationconfiguration"
-	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/applicationdeployment"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/core/scopes/healthscope"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/core/traits/manualscalertrait"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/core/workloads/containerizedworkload"
@@ -36,7 +33,6 @@ func Setup(mgr ctrl.Manager, args controller.Args, l logging.Logger) error {
 	for _, setup := range []func(ctrl.Manager, controller.Args, logging.Logger) error{
 		applicationconfiguration.Setup,
 		containerizedworkload.Setup, manualscalertrait.Setup, healthscope.Setup,
-		application.Setup, applicationdeployment.Setup,
 	} {
 		if err := setup(mgr, args, l); err != nil {
 			return err

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -20,6 +20,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/oam-dev/kubevela/pkg/controller/common"
+	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/application"
+	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/applicationdeployment"
 	"github.com/oam-dev/kubevela/pkg/controller/standard.oam.dev/v1alpha1/podspecworkload"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
 )
@@ -31,12 +33,17 @@ func Setup(mgr ctrl.Manager, disableCaps string) error {
 	case common.DisableNoneCaps:
 		functions = []func(ctrl.Manager) error{
 			podspecworkload.Setup,
+			application.Setup,
+			applicationdeployment.Setup,
 		}
 	case common.DisableAllCaps:
 	default:
 		disableCapsSet := utils.StoreInSet(disableCaps)
 		if !disableCapsSet.Contains(common.PodspecWorkloadControllerName) {
 			functions = append(functions, podspecworkload.Setup)
+		}
+		if !disableCapsSet.Contains(common.ApplicationControllerName) {
+			functions = append(functions, application.Setup)
 		}
 	}
 

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -22,8 +22,7 @@ const LabelPodSpecable = "workload.oam.dev/podspecable"
 
 // allBuiltinCapabilities includes all builtin controllers
 // TODO(zzxwill) needs to automatically discovery all controllers
-var allBuiltinCapabilities = mapset.NewSet(common.MetricsControllerName, common.PodspecWorkloadControllerName,
-	common.RouteControllerName, common.AutoscaleControllerName)
+var allBuiltinCapabilities = mapset.NewSet(common.PodspecWorkloadControllerName, common.ApplicationControllerName)
 
 // GetPodSpecPath get podSpec field and label
 func GetPodSpecPath(workloadDef *v1alpha2.WorkloadDefinition) (string, bool) {

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -18,7 +18,7 @@ var _ = Describe("utils", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("disable some capabilities", func() {
-			disableCaps := "autoscale,route"
+			disableCaps := "application"
 			err := CheckDisabledCapabilities(disableCaps)
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR let application controller can be disabled by `--disable-caps=all`, so 0.3.x can be exist only for AppConfig and Component case.

And it remove the applicationdeployment controller.



