### PR TITLE
[FIX]incorrect pod-disruptive defalut configuration in label of traits

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/labels.yaml
+++ b/charts/vela-core/templates/defwithtemplate/labels.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   appliesToWorkloads:
     - deployments.apps
+  podDisruptive: true
   schematic:
     cue:
       template: |-

--- a/vela-templates/internal/definitions/labels.yaml
+++ b/vela-templates/internal/definitions/labels.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   appliesToWorkloads:
     - deployments.apps
+  podDisruptive: true
   schematic:
     cue:
       template: |-


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The label of traits will update `spec.template.metadata.labels`, which will trigger pod rebuild. But in the default template, podDisruptive=true is not declared, which will cause misunderstandings by users.
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

