### PR TITLE
Add deploymentController struct

### DIFF
--- a/pkg/controller/common/rollout/workloads/delopyment_controller.go
+++ b/pkg/controller/common/rollout/workloads/delopyment_controller.go
@@ -75,6 +75,7 @@ func (c *deploymentController) scaleDeployment(ctx context.Context, deploy *apps
 	if err := c.client.Patch(ctx, deploy, deployPatch, client.FieldOwner(c.parentController.GetUID())); err != nil {
 		c.recorder.Event(c.parentController, event.Warning(event.Reason(fmt.Sprintf(
 			"Failed to update the deployment %s to the correct target %d", deploy.GetName(), size)), err))
+		c.rolloutStatus.RolloutRetry(err.Error())
 		return err
 	}
 

--- a/pkg/controller/common/rollout/workloads/delopyment_controller.go
+++ b/pkg/controller/common/rollout/workloads/delopyment_controller.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloads
+
+import "k8s.io/apimachinery/pkg/types"
+
+// deploymentController is the place to hold fields needed for handle Deployment type of workloads
+type deploymentController struct {
+	workloadController
+	targetNamespacedName types.NamespacedName
+}

--- a/pkg/controller/common/rollout/workloads/deployment_rollout_controller.go
+++ b/pkg/controller/common/rollout/workloads/deployment_rollout_controller.go
@@ -39,8 +39,7 @@ import (
 
 // DeploymentRolloutController is responsible for handling rollout deployment type of workloads
 type DeploymentRolloutController struct {
-	workloadController
-	targetNamespacedName types.NamespacedName
+	deploymentController
 	sourceNamespacedName types.NamespacedName
 	sourceDeploy         apps.Deployment
 	targetDeploy         apps.Deployment
@@ -51,14 +50,16 @@ func NewDeploymentRolloutController(client client.Client, recorder event.Recorde
 	rolloutSpec *v1alpha1.RolloutPlan, rolloutStatus *v1alpha1.RolloutStatus, sourceNamespacedName,
 	targetNamespacedName types.NamespacedName) *DeploymentRolloutController {
 	return &DeploymentRolloutController{
-		workloadController: workloadController{
-			client:           client,
-			recorder:         recorder,
-			parentController: parentController,
-			rolloutSpec:      rolloutSpec,
-			rolloutStatus:    rolloutStatus,
+		deploymentController: deploymentController{
+			workloadController: workloadController{
+				client:           client,
+				recorder:         recorder,
+				parentController: parentController,
+				rolloutSpec:      rolloutSpec,
+				rolloutStatus:    rolloutStatus,
+			},
+			targetNamespacedName: targetNamespacedName,
 		},
-		targetNamespacedName: targetNamespacedName,
 		sourceNamespacedName: sourceNamespacedName,
 	}
 }

--- a/pkg/controller/common/rollout/workloads/deployment_rollout_unit_test.go
+++ b/pkg/controller/common/rollout/workloads/deployment_rollout_unit_test.go
@@ -82,10 +82,12 @@ func TestCalculateCurrentSource(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			controller := DeploymentRolloutController{
-				workloadController: workloadController{
-					rolloutSpec: tc.rolloutSpec,
-					rolloutStatus: &v1alpha1.RolloutStatus{
-						CurrentBatch: tc.currentBatch,
+				deploymentController: deploymentController{
+					workloadController: workloadController{
+						rolloutSpec: tc.rolloutSpec,
+						rolloutStatus: &v1alpha1.RolloutStatus{
+							CurrentBatch: tc.currentBatch,
+						},
 					},
 				},
 			}

--- a/pkg/controller/common/rollout/workloads/deployment_scale_controller.go
+++ b/pkg/controller/common/rollout/workloads/deployment_scale_controller.go
@@ -154,7 +154,6 @@ func (s *DeploymentScaleController) RolloutOneBatchPods(ctx context.Context) (bo
 		int(s.rolloutStatus.RolloutTargetSize), int(s.rolloutStatus.CurrentBatch))
 
 	if err := s.scaleDeployment(ctx, s.deploy, int32(newPodTarget)); err != nil {
-		s.rolloutStatus.RolloutRetry(err.Error())
 		return false, nil
 	}
 


### PR DESCRIPTION
This PR adds `deploymentController` struct to share fields and methods between `DeploymentScaleController` and `DeploymentRolloutController`.