### PR TITLE
TraitDefinition support use insertSecretTo in template to consumer cloud resource

### DIFF
--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -276,9 +276,9 @@ func GetOutputSecretNames(workloads *Workload) (string, error) {
 	return fmt.Sprint(secretName), nil
 }
 
-func parseWorkloadInsertSecretTo(ctx context.Context, c client.Client, namespace string, wl *Workload) ([]process.RequiredSecrets, error) {
+func parseInsertSecretTo(ctx context.Context, c client.Client, namespace string, templateStr string, props map[string]interface{}) ([]process.RequiredSecrets, error) {
 	var requiredSecret []process.RequiredSecrets
-	cueStr := velacue.BaseTemplate + wl.FullTemplate.TemplateStr
+	cueStr := velacue.BaseTemplate + templateStr
 	r := cue.Runtime{}
 	ins, err := r.Compile("-", cueStr)
 	if err != nil {
@@ -304,7 +304,7 @@ func parseWorkloadInsertSecretTo(ctx context.Context, c client.Client, namespace
 				if strings.Contains(comment.Text, InsertSecretToTag) {
 					contextName := strings.Split(comment.Text, InsertSecretToTag)[1]
 					contextName = strings.TrimSpace(contextName)
-					secretNameInterface, err := getComponentSetting(fName, wl.Params)
+					secretNameInterface, err := getComponentSetting(fName, props)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/appfile/parser_test.go
+++ b/pkg/appfile/parser_test.go
@@ -546,7 +546,7 @@ settings: {
 				FullTemplate: &Template{TemplateStr: template},
 			}
 			By("call target function")
-			secrets, err := parseWorkloadInsertSecretTo(ctx, k8sClient, ns, wl)
+			secrets, err := parseInsertSecretTo(ctx, k8sClient, ns, wl.FullTemplate.TemplateStr, wl.Params)
 			Expect(err).Should(BeNil())
 			Expect(secrets).Should(BeNil())
 		})
@@ -609,7 +609,7 @@ parameter: {
 			err := k8sClient.Create(ctx, s)
 			Expect(err).Should(BeNil())
 			By("call target function")
-			secrets, err := parseWorkloadInsertSecretTo(ctx, k8sClient, ns, wl)
+			secrets, err := parseInsertSecretTo(ctx, k8sClient, ns, wl.FullTemplate.TemplateStr, wl.Params)
 			Expect(err).Should(BeNil())
 			Expect(secrets).Should(Equal(targetRequiredSecret))
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

add `insertSecretTo` feature in TraitDefinition Template, so that application can consumer cloud resource in `trait`.


