### PR TITLE
dont't template source in rollout and rollout first component

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -242,6 +242,8 @@ func (h *appHandler) handleRollout(ctx context.Context) (reconcile.Result, error
 	var comps []string
 	for _, component := range h.app.Spec.Components {
 		comps = append(comps, component.Name)
+		// TODO rollout only support one component now, and we only rollout the first component in Application
+		break
 	}
 
 	// targetRevision should always points to LatestRevison

--- a/pkg/controller/core.oam.dev/v1alpha2/application/assemble/options_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/assemble/options_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Test WorkloadOption", func() {
 				StandardWorkload: cs,
 			}
 			By("Add PrepareWorkloadForRollout WorkloadOption")
-			ao := NewAppManifests(appRev).WithWorkloadOption(PrepareWorkloadForRollout())
+			ao := NewAppManifests(appRev).WithWorkloadOption(PrepareWorkloadForRollout(compName))
 			ao.componentManifests = []*types.ComponentManifest{&comp}
 			workloads, _, _, err := ao.GroupAssembledManifests()
 			Expect(err).Should(BeNil())
@@ -89,7 +89,7 @@ var _ = Describe("Test WorkloadOption", func() {
 				StandardWorkload: sts,
 			}
 			By("Add PrepareWorkloadForRollout WorkloadOption")
-			ao := NewAppManifests(appRev).WithWorkloadOption(PrepareWorkloadForRollout())
+			ao := NewAppManifests(appRev).WithWorkloadOption(PrepareWorkloadForRollout(compName))
 			ao.componentManifests = []*types.ComponentManifest{&comp}
 			workloads, _, _, err := ao.GroupAssembledManifests()
 			Expect(err).Should(BeNil())
@@ -106,7 +106,7 @@ var _ = Describe("Test WorkloadOption", func() {
 
 		It("test rollout Deployment", func() {
 			By("Add PrepareWorkloadForRollout WorkloadOption")
-			ao := NewAppManifests(appRev).WithWorkloadOption(PrepareWorkloadForRollout())
+			ao := NewAppManifests(appRev).WithWorkloadOption(PrepareWorkloadForRollout(compName))
 			workloads, _, _, err := ao.GroupAssembledManifests()
 			Expect(err).Should(BeNil())
 			Expect(len(workloads)).Should(Equal(1))

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/dispatch.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/dispatch.go
@@ -288,6 +288,7 @@ func (a *AppManifestsDispatcher) updateResourceTrackerStatus(ctx context.Context
 	return nil
 }
 
+// ObjectOwner is a interface for get and set ownerReference
 type ObjectOwner interface {
 	GetOwnerReferences() []metav1.OwnerReference
 	SetOwnerReferences([]metav1.OwnerReference)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/dispatch.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/dispatch.go
@@ -239,6 +239,7 @@ func (a *AppManifestsDispatcher) ImmutableResourcesUpdate(ctx context.Context, r
 			return true, err
 		}
 		setOrOverrideControllerOwner(pv, ownerRef)
+		pv.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind(reflect.TypeOf(v1.PersistentVolume{}).Name()))
 		return true, a.applicator.Apply(ctx, pv, applyOpts...)
 	default:
 	}

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/applicationrollout_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/applicationrollout_controller.go
@@ -165,11 +165,6 @@ func (r *Reconciler) DoReconcile(ctx context.Context, appRollout *v1beta1.AppRol
 			return ctrl.Result{}, nil
 		}
 	case v1alpha1.LocatingTargetAppState:
-		// dispatch sourceWorkload
-		err = h.templateSourceManifest(ctx)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 		// target manifest haven't template yet, call dispatch template target manifest firstly
 		err = h.templateTargetManifest(ctx)
 		if err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/applicationrollout_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/applicationrollout_controller.go
@@ -165,6 +165,12 @@ func (r *Reconciler) DoReconcile(ctx context.Context, appRollout *v1beta1.AppRol
 			return ctrl.Result{}, nil
 		}
 	case v1alpha1.LocatingTargetAppState:
+		if h.sourceAppRevision != nil {
+			err = h.handleSourceWorkload(ctx)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
 		// target manifest haven't template yet, call dispatch template target manifest firstly
 		err = h.templateTargetManifest(ctx)
 		if err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/applicationrollout_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/applicationrollout_controller.go
@@ -136,6 +136,11 @@ func (r *Reconciler) DoReconcile(ctx context.Context, appRollout *v1beta1.AppRol
 		h.targetRevName = appRollout.Spec.TargetAppRevisionName
 	}
 
+	// 	TODO we only support rollout for one component and it should be specified in componentList
+	if len(appRollout.Spec.ComponentList) == 1 {
+		h.needRollComponent = appRollout.Spec.ComponentList[0]
+	}
+
 	// call assemble func generate source and target manifest
 	if err = h.prepareRollout(ctx); err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/helper.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/helper.go
@@ -19,11 +19,10 @@ package applicationrollout
 import (
 	"reflect"
 
-	"k8s.io/utils/pointer"
-
 	"github.com/openkruise/kruise-api/apps/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	oamstd "github.com/oam-dev/kubevela/apis/standard.oam.dev/v1alpha1"
@@ -31,8 +30,14 @@ import (
 	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
-func rolloutWorkloadName() assemble.WorkloadOption {
+func rolloutWorkloadName(rolloutComp string) assemble.WorkloadOption {
 	return assemble.WorkloadOptionFn(func(w *unstructured.Unstructured, _ *v1beta1.ComponentDefinition, _ []*unstructured.Unstructured) error {
+
+		compName := w.GetLabels()[oam.LabelAppComponent]
+		if compName != rolloutComp {
+			return nil
+		}
+
 		// we hard code the behavior depends on the workload group/kind for now. The only in-place upgradable resources
 		// we support is cloneset/statefulset for now. We can easily add more later.
 		if w.GroupVersionKind().Group == v1alpha1.GroupVersion.Group {

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/rollout_handler.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/rollout_handler.go
@@ -76,8 +76,8 @@ func (h *rolloutHandler) prepareRollout(ctx context.Context) error {
 
 	// construct a assemble manifest for targetAppRevision
 	targetAssemble := assemble.NewAppManifests(h.targetAppRevision).
-		WithWorkloadOption(rolloutWorkloadName()).
-		WithWorkloadOption(assemble.PrepareWorkloadForRollout())
+		WithWorkloadOption(rolloutWorkloadName(h.needRollComponent)).
+		WithWorkloadOption(assemble.PrepareWorkloadForRollout(h.needRollComponent))
 
 	// in template phase, we should use targetManifests including target workloads/traits to
 	h.targetManifests, err = targetAssemble.AssembledManifests()
@@ -100,8 +100,8 @@ func (h *rolloutHandler) prepareRollout(ctx context.Context) error {
 		}
 		// construct a assemble manifest for sourceAppRevision
 		sourceAssemble := assemble.NewAppManifests(h.sourceAppRevision).
-			WithWorkloadOption(assemble.PrepareWorkloadForRollout()).
-			WithWorkloadOption(rolloutWorkloadName())
+			WithWorkloadOption(assemble.PrepareWorkloadForRollout(h.needRollComponent)).
+			WithWorkloadOption(rolloutWorkloadName(h.needRollComponent))
 		h.sourceWorkloads, _, _, err = sourceAssemble.GroupAssembledManifests()
 		if err != nil {
 			klog.Error("appRollout sourceAppRevision failed to assemble workloads", "appRollout", klog.KRef(h.appRollout.Namespace, h.appRollout.Name))

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/rollout_handler.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/rollout_handler.go
@@ -118,6 +118,10 @@ func (h *rolloutHandler) prepareRollout(ctx context.Context) error {
 
 // we only support one workload now, so this func is to determine witch component is need to rollout
 func (h *rolloutHandler) determineRolloutComponent() error {
+	if h.needRollComponent != "" {
+		return nil
+	}
+
 	componentList := h.appRollout.Spec.ComponentList
 	// if user not set ComponentList in AppRollout we also find a common component between source and target
 	if len(componentList) == 0 {


### PR DESCRIPTION
1.fix rolloutplan that do not limit only one component but the rollout only support one component. Make apply workload option works only for the target component
2.do not block other component to render if they're not rollout target
3.remove redundant step templateSourceManifest, it want's to apply the new resource with older ownerID and fails the update.