### PR TITLE
override initial replicas of workload in first scale operation

### DIFF
--- a/docs/examples/cloneset-rollout/appRollout-scale.yaml
+++ b/docs/examples/cloneset-rollout/appRollout-scale.yaml
@@ -11,4 +11,4 @@ spec:
     targetSize: 5
     rolloutBatches:
       - replicas: 1
-      - replicas: 3
+      - replicas: 4

--- a/docs/examples/deployment-rollout/app-rollout-scale.yaml
+++ b/docs/examples/deployment-rollout/app-rollout-scale.yaml
@@ -10,5 +10,5 @@ spec:
   rolloutPlan:
     rolloutStrategy: "IncreaseFirst"
     rolloutBatches:
-      - replicas: 4
+      - replicas: 5
     targetSize: 5

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -25,9 +25,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -41,6 +39,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	core "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/application/dispatch"
+	"github.com/oam-dev/kubevela/pkg/controller/utils"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
@@ -117,15 +116,15 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if err != nil {
 		klog.ErrorS(err, "Failed to parse application", "application", klog.KObj(app))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedParse, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("Parsed", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Parsed", err))
 	}
-	app.Status.SetConditions(readyCondition("Parsed"))
+	app.Status.SetConditions(utils.ReadyCondition("Parsed"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonParsed, velatypes.MessageParsed))
 
 	if err := handler.prepareCurrentAppRevision(ctx, appFile); err != nil {
 		klog.ErrorS(err, "Failed to prepare app revision", "application", klog.KObj(app))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRevision, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("Revision", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Revision", err))
 	}
 	klog.Info("Successfully prepare current app revision", "revisionName", handler.currentAppRev.Name,
 		"revisionHash", handler.currentRevHash, "isNewRevision", handler.isNewRevision)
@@ -135,20 +134,20 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if err != nil {
 		klog.ErrorS(err, "Failed to render components", "application", klog.KObj(app))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRender, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("Render", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Render", err))
 	}
 	if err := handler.handleComponentsRevision(ctx, comps); err != nil {
 		klog.ErrorS(err, "Failed to handle compoents revision", "application", klog.KObj(app))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRevision, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("Render", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Render", err))
 	}
 
 	if err := handler.finalizeAndApplyAppRevision(ctx, comps); err != nil {
 		klog.ErrorS(err, "Failed to apply app revision", "application", klog.KObj(app))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRevision, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("Revision", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Revision", err))
 	}
-	app.Status.SetConditions(readyCondition("Revision"))
+	app.Status.SetConditions(utils.ReadyCondition("Revision"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonRevisoned, velatypes.MessageRevisioned))
 	klog.Info("Successfully apply application revision", "application", klog.KObj(app))
 
@@ -156,9 +155,9 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if err != nil {
 		klog.Error(err, "[Handle GenerateWorkflowAndPolicy]")
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRender, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("Render", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Render", err))
 	}
-	app.Status.SetConditions(readyCondition("Render"))
+	app.Status.SetConditions(utils.ReadyCondition("Render"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonRendered, velatypes.MessageRendered))
 	klog.Info("Successfully render application resources", "application", klog.KObj(app))
 
@@ -166,13 +165,13 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		klog.ErrorS(err, "Failed to apply application manifests",
 			"application", klog.KObj(app))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedApply, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("Applied", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Applied", err))
 	}
 	if err := handler.updateAppLatestRevisionStatus(ctx); err != nil {
 		klog.ErrorS(err, "Failed to update application status", "application", klog.KObj(app))
 		return r.endWithNegativeCondition(ctx, app, v1alpha1.ReconcileError(err))
 	}
-	app.Status.SetConditions(readyCondition("Applied"))
+	app.Status.SetConditions(utils.ReadyCondition("Applied"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonApplied, velatypes.MessageApplied))
 	klog.Info("Successfully apply application manifests", "application", klog.KObj(app))
 
@@ -180,7 +179,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if err != nil {
 		klog.Error(err, "[handle workflow]")
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedWorkflow, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("Workflow", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Workflow", err))
 	}
 	if !done {
 		return reconcile.Result{RequeueAfter: WorkflowReconcileWaitTime}, r.patchStatus(ctx, app)
@@ -192,7 +191,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		if err != nil {
 			klog.ErrorS(err, "Failed to handle rollout", "application", klog.KObj(app))
 			r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedRollout, err))
-			return r.endWithNegativeCondition(ctx, app, errorCondition("Rollout", err))
+			return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("Rollout", err))
 		}
 		// skip health check and garbage collection if rollout have not finished
 		// start next reconcile immediately
@@ -206,7 +205,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 		// there is no need reconcile immediately, that means the rollout operation have finished
 		r.Recorder.Event(app, event.Normal(velatypes.ReasonRollout, velatypes.MessageRollout))
-		app.Status.SetConditions(readyCondition("Rollout"))
+		app.Status.SetConditions(utils.ReadyCondition("Rollout"))
 		klog.Info("Finished rollout ")
 	}
 
@@ -217,16 +216,16 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if err != nil {
 		klog.ErrorS(err, "Failed to aggregate status", "application", klog.KObj(app))
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedHealthCheck, err))
-		return r.endWithNegativeCondition(ctx, app, errorCondition("HealthCheck", err))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("HealthCheck", err))
 	}
 	app.Status.Services = appCompStatus
 	if !healthy {
 		if err := r.patchStatus(ctx, app); err != nil {
 			return r.endWithNegativeCondition(ctx, app, v1alpha1.ReconcileError(err))
 		}
-		return r.endWithNegativeCondition(ctx, app, errorCondition("HealthCheck", errors.New("not healthy")))
+		return r.endWithNegativeCondition(ctx, app, utils.ErrorCondition("HealthCheck", errors.New("not healthy")))
 	}
-	app.Status.SetConditions(readyCondition("HealthCheck"))
+	app.Status.SetConditions(utils.ReadyCondition("HealthCheck"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonHealthCheck, velatypes.MessageHealthCheck))
 	app.Status.Phase = common.ApplicationRunning
 
@@ -328,25 +327,6 @@ func (r *Reconciler) patchStatus(ctx context.Context, app *v1beta1.Application) 
 // resources into the cluster. Rollout controller will do real release works.
 func appWillRollout(app *v1beta1.Application) bool {
 	return len(app.GetAnnotations()[oam.AnnotationAppRollout]) != 0 || app.Spec.RolloutPlan != nil
-}
-
-func errorCondition(tpy string, err error) v1alpha1.Condition {
-	return v1alpha1.Condition{
-		Type:               v1alpha1.ConditionType(tpy),
-		Status:             corev1.ConditionFalse,
-		LastTransitionTime: metav1.NewTime(time.Now()),
-		Reason:             v1alpha1.ReasonReconcileError,
-		Message:            err.Error(),
-	}
-}
-
-func readyCondition(tpy string) v1alpha1.Condition {
-	return v1alpha1.Condition{
-		Type:               v1alpha1.ConditionType(tpy),
-		Status:             corev1.ConditionTrue,
-		Reason:             v1alpha1.ReasonAvailable,
-		LastTransitionTime: metav1.NewTime(time.Now()),
-	}
 }
 
 // SetupWithManager install to manager

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/helper_suit_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationrollout/helper_suit_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationrollout
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/oam-dev/kubevela/pkg/oam"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("TestHandleReplicasFunc", func() {
+	ctx := context.Background()
+
+	It("Test exsit workload", func() {
+		ns := v1.Namespace{}
+		ns.SetName("test-namespace")
+		Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+		workloadName := "test-workload"
+		workload := new(appsv1.Deployment)
+		workload.SetName(workloadName)
+		workload.SetNamespace("test-namespace")
+		workload.SetLabels(map[string]string{
+			oam.LabelAppComponent: workloadName,
+		})
+		workload.Spec = appsv1.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(5),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"test": "test",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"test": "test",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "test",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, workload)).Should(BeNil())
+		checkworkload := unstructured.Unstructured{}
+		checkworkload.SetAPIVersion("apps/v1")
+		checkworkload.SetKind("Deployment")
+		checkworkload.SetNamespace("test-namespace")
+		checkworkload.SetName(workloadName)
+		checkworkload.SetLabels(map[string]string{
+			oam.LabelAppComponent: workloadName,
+		})
+		Eventually(func() error {
+			handleFunc := handleReplicas(ctx, workloadName, k8sClient)
+			if err := handleFunc.ApplyToWorkload(&checkworkload, nil, nil); err != nil {
+				return err
+			}
+			replicasFieldPath := "spec.replicas"
+			wlpv := fieldpath.Pave(checkworkload.UnstructuredContent())
+			replicas, err := wlpv.GetInteger(replicasFieldPath)
+			if err != nil {
+				return err
+			}
+			if replicas != 5 {
+				return fmt.Errorf("replicas number not 5")
+			}
+			return nil
+		}, 10*time.Second, 500*time.Millisecond).Should(BeNil())
+	})
+
+	It("Test not exist workload", func() {
+		workloadName := "not-exist-workload"
+		checkworkload := unstructured.Unstructured{}
+		checkworkload.SetAPIVersion("apps/v1")
+		checkworkload.SetKind("Deployment")
+		checkworkload.SetNamespace("test-namespace")
+		checkworkload.SetName(workloadName)
+		checkworkload.SetLabels(map[string]string{
+			oam.LabelAppComponent: workloadName,
+		})
+		Eventually(func() error {
+			handleFunc := handleReplicas(ctx, workloadName, k8sClient)
+			if err := handleFunc.ApplyToWorkload(&checkworkload, nil, nil); err != nil {
+				return err
+			}
+			replicasFieldPath := "spec.replicas"
+			wlpv := fieldpath.Pave(checkworkload.UnstructuredContent())
+			replicas, err := wlpv.GetInteger(replicasFieldPath)
+			if err != nil {
+				return err
+			}
+			if replicas != 0 {
+				return fmt.Errorf("replicas number not 0")
+			}
+			return nil
+		}, 10*time.Second, 500*time.Millisecond).Should(BeNil())
+	})
+})

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -384,3 +384,24 @@ func GetUnstructuredObjectStatusCondition(obj *unstructured.Unstructured, condTy
 
 	return nil, false, nil
 }
+
+// ReadyCondition generate ready condition for conditionType
+func ReadyCondition(tpy string) runtimev1alpha1.Condition {
+	return runtimev1alpha1.Condition{
+		Type:               runtimev1alpha1.ConditionType(tpy),
+		Status:             corev1.ConditionTrue,
+		Reason:             runtimev1alpha1.ReasonAvailable,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	}
+}
+
+// ErrorCondition generate error condition for conditionType and error
+func ErrorCondition(tpy string, err error) runtimev1alpha1.Condition {
+	return runtimev1alpha1.Condition{
+		Type:               runtimev1alpha1.ConditionType(tpy),
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		Reason:             runtimev1alpha1.ReasonReconcileError,
+		Message:            err.Error(),
+	}
+}

--- a/test/e2e-test/rollout_plan_test.go
+++ b/test/e2e-test/rollout_plan_test.go
@@ -723,18 +723,18 @@ var _ = Describe("Cloneset based rollout tests", func() {
 		appRollout.Namespace = namespaceName
 		appRollout.Spec.SourceAppRevisionName = ""
 		appRollout.Spec.TargetAppRevisionName = utils.ConstructRevisionName(app.GetName(), 1)
-		appRollout.Spec.RolloutPlan.TargetSize = pointer.Int32Ptr(3)
+		appRollout.Spec.RolloutPlan.TargetSize = pointer.Int32Ptr(2)
 		appRollout.Spec.RolloutPlan.BatchPartition = nil
 		By("create appRollout initial targetSize is 3")
 		createAppRolling(&appRollout)
 		appRolloutName = appRollout.Name
 		verifyRolloutSucceeded(appRollout.Spec.TargetAppRevisionName)
-		By("modify appRollout targetSize to 5")
+		By("modify appRollout targetSize to 4")
 		Eventually(func() error {
 			if err = k8sClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: appRolloutName}, &appRollout); err != nil {
 				return err
 			}
-			appRollout.Spec.RolloutPlan.TargetSize = pointer.Int32Ptr(5)
+			appRollout.Spec.RolloutPlan.TargetSize = pointer.Int32Ptr(4)
 			if err = k8sClient.Update(ctx, &appRollout); err != nil {
 				return err
 			}
@@ -748,18 +748,18 @@ var _ = Describe("Cloneset based rollout tests", func() {
 			if err != nil {
 				return err
 			}
-			if *kc.Spec.Replicas != 5 {
+			if *kc.Spec.Replicas != 4 {
 				return fmt.Errorf("pod replicas mismatch")
 			}
 			return nil
 		}, 30*time.Second, 300*time.Microsecond).Should(BeNil())
 		verifyRolloutSucceeded(appRollout.Spec.TargetAppRevisionName)
-		By("modify appRollout targetSize to 7")
+		By("modify appRollout targetSize to 6")
 		Eventually(func() error {
 			if err = k8sClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: appRolloutName}, &appRollout); err != nil {
 				return err
 			}
-			appRollout.Spec.RolloutPlan.TargetSize = pointer.Int32Ptr(7)
+			appRollout.Spec.RolloutPlan.TargetSize = pointer.Int32Ptr(6)
 			if err = k8sClient.Update(ctx, &appRollout); err != nil {
 				return err
 			}
@@ -773,7 +773,7 @@ var _ = Describe("Cloneset based rollout tests", func() {
 			if err != nil {
 				return err
 			}
-			if *kc.Spec.Replicas != 7 {
+			if *kc.Spec.Replicas != 6 {
 				return fmt.Errorf("pod replicas mismatch")
 			}
 			return nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Before, we don't override initial `replicas`  of workload. So when first scale, user must be aware of total `rolloutBatches+1=targetSize`.
This pr will override initial replicas of workload.So in first scale operation total `rolloutBatches=targetSize` is fine.
eg.
```yaml
apiVersion: core.oam.dev/v1beta1
kind: AppRollout
metadata:
  name: rollout
spec:
  targetAppRevisionName: rollout-v1
  componentList:
    - metrics-provider
  rolloutPlan:
    rolloutStrategy: "IncreaseFirst"
    rolloutBatches:
      - replicas: 2
    targetSize: 2
```

1. override initial replicas of wokrload
2. reorder rollout phase  `prepare workload`->`determineCommonComponent`->`generate assemble manifest`
  `generate assemble manifest` phase must know which is the common component between source and target appRev
   `determineCommonComponent` must know source and target workloads list.
3. after #1888 merged we don't template source manifest, so clean up related logic
4. change relate e2e-test.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #1629 

**Special notes for your reviewer**:

