### PR TITLE
Fix the way to ignore errors for rm command

### DIFF
--- a/vela-templates/gen_definitions.sh
+++ b/vela-templates/gen_definitions.sh
@@ -8,8 +8,8 @@ pushd $SCRIPT_DIR
 INTERNAL_TEMPLATE_DIR="../charts/vela-core/templates/defwithtemplate"
 REGISTRY_TEMPLATE_DIR="registry/auto-gen"
 
-rm ${INTERNAL_TEMPLATE_DIR}/* 2>/dev/null | true
-rm ${REGISTRY_TEMPLATE_DIR}/* 2>/dev/null | true
+rm ${INTERNAL_TEMPLATE_DIR}/* 2>/dev/null || true
+rm ${REGISTRY_TEMPLATE_DIR}/* 2>/dev/null || true
 
 
 for filename in internal/cue/*; do


### PR DESCRIPTION
This script is piping to `rm`, a command that doesn't read from stdin.