### PR TITLE
Add open-kruise as addon

### DIFF
--- a/charts/vela-core/templates/addons/kruise.yaml
+++ b/charts/vela-core/templates/addons/kruise.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+data:
+  initializer: |
+    apiVersion: core.oam.dev/v1beta1
+    kind: Initializer
+    metadata:
+      annotations:
+        addons.oam.dev/description: Kruise is a Kubernetes extended suite for application automations
+      name: kruise
+      namespace: kruise-system
+    spec:
+      appTemplate:
+        spec:
+          components:
+          - name: kruise-release
+            properties:
+              apiVersion: helm.toolkit.fluxcd.io/v2beta1
+              kind: HelmRelease
+              metadata:
+                annotations:
+                  meta.helm.sh/release-name: kruise-release
+                  meta.helm.sh/release-namespace: kruise-system
+                labels:
+                  app.kubernetes.io/managed-by: Helm
+                name: kruise-release
+                namespace: flux-system
+              spec:
+                chart:
+                  spec:
+                    chart: ./charts/kruise/v0.9.0
+                    interval: 1m
+                    sourceRef:
+                      kind: GitRepository
+                      name: kruise-repo
+                      namespace: flux-system
+                interval: 5m
+                values:
+                  replicaCount: 1
+            type: raw
+          - name: kruise-repo
+            properties:
+              apiVersion: source.toolkit.fluxcd.io/v1beta1
+              kind: GitRepository
+              metadata:
+                name: kruise-repo
+                namespace: flux-system
+              spec:
+                interval: 5m
+                ref:
+                  branch: master
+                url: https://github.com/openkruise/kruise
+            type: raw
+        status:
+          rollout:
+            batchRollingState: ""
+            currentBatch: 0
+            lastTargetAppRevision: ""
+            rollingState: ""
+            upgradedReadyReplicas: 0
+            upgradedReplicas: 0
+    status:
+      observedGeneration: 0
+kind: ConfigMap
+metadata:
+  annotations:
+    addons.oam.dev/description: Kruise is a Kubernetes extended suite for application automations
+  labels:
+    addons.oam.dev/type: kruise
+  name: kruise

--- a/vela-templates/addons/auto-gen/kruise.yaml
+++ b/vela-templates/addons/auto-gen/kruise.yaml
@@ -1,0 +1,59 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Initializer
+metadata:
+  annotations:
+    addons.oam.dev/description: Kruise is a Kubernetes extended suite for application automations
+  name: kruise
+  namespace: kruise-system
+spec:
+  appTemplate:
+    spec:
+      components:
+      - name: kruise-release
+        properties:
+          apiVersion: helm.toolkit.fluxcd.io/v2beta1
+          kind: HelmRelease
+          metadata:
+            annotations:
+              meta.helm.sh/release-name: kruise-release
+              meta.helm.sh/release-namespace: kruise-system
+            labels:
+              app.kubernetes.io/managed-by: Helm
+            name: kruise-release
+            namespace: flux-system
+          spec:
+            chart:
+              spec:
+                chart: ./charts/kruise/v0.9.0
+                interval: 1m
+                sourceRef:
+                  kind: GitRepository
+                  name: kruise-repo
+                  namespace: flux-system
+            interval: 5m
+            values:
+              replicaCount: 1
+        type: raw
+      - name: kruise-repo
+        properties:
+          apiVersion: source.toolkit.fluxcd.io/v1beta1
+          kind: GitRepository
+          metadata:
+            name: kruise-repo
+            namespace: flux-system
+          spec:
+            interval: 5m
+            ref:
+              branch: master
+            url: https://github.com/openkruise/kruise
+        type: raw
+    status:
+      rollout:
+        batchRollingState: ""
+        currentBatch: 0
+        lastTargetAppRevision: ""
+        rollingState: ""
+        upgradedReadyReplicas: 0
+        upgradedReplicas: 0
+status:
+  observedGeneration: 0

--- a/vela-templates/addons/kruise/resource/kruise-rel.yaml
+++ b/vela-templates/addons/kruise/resource/kruise-rel.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kruise-release
+  namespace: flux-system
+  annotations:
+    meta.helm.sh/release-name: kruise-release
+    meta.helm.sh/release-namespace: kruise-system
+  labels:
+    app.kubernetes.io/managed-by: Helm
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: ./charts/kruise/v0.9.0
+      sourceRef:
+        kind: GitRepository
+        name: kruise-repo
+        namespace: flux-system
+      interval: 1m
+  values:
+    replicaCount: 1

--- a/vela-templates/addons/kruise/resource/kruise-repo.yaml
+++ b/vela-templates/addons/kruise/resource/kruise-repo.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: kruise-repo
+  namespace: flux-system
+spec:
+  url: https://github.com/openkruise/kruise
+  ref:
+    branch: master
+  interval: 5m

--- a/vela-templates/addons/kruise/template.yaml
+++ b/vela-templates/addons/kruise/template.yaml
@@ -12,4 +12,4 @@ spec:
         - name: {{ .Name }}
           type: raw
           properties:
-{{ .Content }} {{ end }}
+{{ .Content | indent 12 }} {{ end }}

--- a/vela-templates/addons/kruise/template.yaml
+++ b/vela-templates/addons/kruise/template.yaml
@@ -1,0 +1,15 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Initializer
+metadata:
+  annotations:
+    addons.oam.dev/description: "Kruise is a Kubernetes extended suite for application automations"
+  name: kruise
+  namespace: kruise-system
+spec:
+  appTemplate:
+    spec:
+      components: {{  range .ResourceFiles  }}
+        - name: {{ .Name }}
+          type: raw
+          properties:
+{{ .Content }} {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add open-kruise as addon
run addon list after chart deployed:

```shell
$ bin/vela addon list            
NAME                    DESCRIPTION                                                                     STATUS     
fluxcd                  Flux is a set of continuous and progressive delivery solutions for Kubernetes   uninstalled  
kruise                  Kruise is a Kubernetes extended suite for application automations               uninstalled
ocm-cluster-manager     ocm-cluster-manager can deploy an OCM hub cluster environment.                  uninstalled
```

**Which issue(s) this PR fixes**:

part-fix https://github.com/oam-dev/kubevela/issues/1760

**Special notes for your reviewer**:

