### PR TITLE
Strategy Merge: `patchKey` can specify the field of the substructure of the array element

### DIFF
--- a/pkg/cue/model/sets/operation.go
+++ b/pkg/cue/model/sets/operation.go
@@ -49,7 +49,7 @@ func listMergeProcess(field *ast.Field, key string, baseList, patchList *ast.Lis
 		if _, ok := elt.(*ast.Ellipsis); ok {
 			continue
 		}
-		nodev, err := lookUp(elt, key)
+		nodev, err := lookUp(elt, strings.Split(key, ".")...)
 		if err != nil {
 			return
 		}
@@ -67,7 +67,7 @@ func listMergeProcess(field *ast.Field, key string, baseList, patchList *ast.Lis
 			continue
 		}
 
-		nodev, err := lookUp(elt, key)
+		nodev, err := lookUp(elt, strings.Split(key, ".")...)
 		if err != nil {
 			return
 		}

--- a/pkg/cue/model/sets/operation_test.go
+++ b/pkg/cue/model/sets/operation_test.go
@@ -181,6 +181,67 @@ containers: [{
 }, ...]
 `,
 		},
+		{
+			base: `envFrom: [{
+					secretRef: {
+						name:  "nginx-rds"
+					}},...]`,
+			patch: `
+// +patchKey=secretRef.name
+envFrom: [{
+					secretRef: {
+						name:  "nginx-redis"
+					}},...]
+`,
+			result: `// +patchKey=secretRef.name
+envFrom: [{
+	secretRef: {
+		name: "nginx-rds"
+	}
+}, {
+	secretRef: {
+		name: "nginx-redis"
+	}
+}, ...]
+`},
+		{
+			base: `
+             containers: [{
+                 name: "c1"
+             },{
+                 name: "c2"
+                 envFrom: [{
+					secretRef: {
+						name:  "nginx-rds"
+                 }},...]
+             },...]`,
+			patch: `
+             // +patchKey=name
+             containers: [{
+                 name: "c2"
+                 // +patchKey=secretRef.name
+                 envFrom: [{
+					secretRef: {
+						name:  "nginx-redis"
+                 }},...]
+             }]`,
+			result: `// +patchKey=name
+containers: [{
+	name: "c1"
+}, {
+	name: "c2"
+	// +patchKey=secretRef.name
+	envFrom: [{
+		secretRef: {
+			name: "nginx-rds"
+		}
+	}, {
+		secretRef: {
+			name: "nginx-redis"
+		}
+	}, ...]
+}, ...]
+`},
 	}
 
 	for i, tcase := range testCase {


### PR DESCRIPTION
Let `patchKey` can specify the field of the substructure of the array element, in a format such as `x.y`

for example, base object as follow:
```
envFrom: [{
     secretRef: {
	name:  "my-secret-1"
     }
}]
```

and, patcher is as follows:
```
// patchKey=secretRef.name
envFrom: [{
     secretRef: {
	name:  "my-secret-2"
     }
}]
```

then, the result will be as follow after strategy merge:
```
// +patchKey=secretRef.name
envFrom: [{
	secretRef: {
		name: "my-secret-1"
	}
}, {
	secretRef: {
		name: "my-secret-2"
	}
}, ...]
```

fixes #1913