### PR TITLE
Fix Initializer bugs & Enhance addon command 

### DIFF
--- a/charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/vela-core/templates/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -213,6 +213,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+          - DELETE
         resources:
           - initializers
 {{- end -}}

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -159,7 +159,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	app.Status.SetConditions(utils.ReadyCondition("Render"))
 	r.Recorder.Event(app, event.Normal(velatypes.ReasonRendered, velatypes.MessageRendered))
-	klog.Info("Successfully render application resources", "application", klog.KObj(app))
+	klog.InfoS("Successfully render application resources", "application", klog.KObj(app))
 
 	if err := handler.ApplyAppManifests(ctx, comps, policies); err != nil {
 		klog.ErrorS(err, "Failed to apply application manifests",

--- a/pkg/controller/core.oam.dev/v1alpha2/applicationcontext/applicationcontext_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/applicationcontext/applicationcontext_controller.go
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// always update ac status and set the error
 	// this should be the only place for status of AppContext to update, so we can patch to avoid update conflicts caused by `resourceVersion` changed by spec.
 	err = errors.Wrap(r.client.Status().Patch(ctx, appContext, appContextPatch), errUpdateAppContextStatus)
-	// use the controller build-in backoff mechanism if an error occurs
+	// use the controller built-in backoff mechanism if an error occurs
 	if err != nil {
 		reconResult.RequeueAfter = 0
 	} else if appContext.Status.RollingStatus == types.RollingTemplated {

--- a/pkg/controller/core.oam.dev/v1alpha2/initializer/initializer_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/initializer/initializer_controller.go
@@ -104,16 +104,16 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-// checkOrInstallDependsOn check the status of dependOn Initializer or help install the build-in Initializer.
+// checkOrInstallDependsOn check the status of dependOn Initializer or help install the built-in Initializer.
 // If the dependOn Initializer is not found and the namespace is default or vela-system, we will try to find
-// and install the build-in Initializer from ConfigMap.
+// and install the built-in Initializer from ConfigMap.
 // If all dependency are found(ready or not), err will be nil.
 func (r *Reconciler) checkOrInstallDependsOn(ctx context.Context, depends []v1beta1.DependsOn) (bool, error) {
 	for _, depend := range depends {
 		dependInit, err := utils.GetInitializer(ctx, r.Client, depend.Ref.Namespace, depend.Ref.Name)
 		if err != nil {
 			// if Initializer is not found and the namespace is default or vela-system,
-			// try to install build-in initializer from ConfigMap. Otherwise, err will be return
+			// try to install built-in initializer from ConfigMap. Otherwise, err will be return
 			if apierrors.IsNotFound(err) && (depend.Ref.Namespace == "" || depend.Ref.Namespace == velatypes.DefaultKubeVelaNS) {
 				init, err := utils.GetBuildInInitializer(ctx, r.Client, depend.Ref.Name)
 				if err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/initializer/initializer_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/initializer/initializer_controller.go
@@ -74,13 +74,13 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	init.Status.Phase = v1beta1.InitializerCheckingDependsOn
 	dependsOnInitReady, err := r.checkOrInstallDependsOn(ctx, init.Spec.DependsOn)
 	if err != nil {
-		klog.ErrorS(err, "Initializers which you depend on are not ready")
-		r.record.Event(init, event.Warning("Initializers which you depend on are not ready", err))
+		klog.ErrorS(err, "Check initializer dependsOn error")
+		r.record.Event(init, event.Warning("Checking Initializer dependsOn error", err))
 		return r.endWithNegativeCondition(ctx, init, cpv1alpha1.ReconcileError(err))
 	}
 	if !dependsOnInitReady {
 		klog.Info("Wait for dependent Initializer to be ready")
-		return reconcile.Result{RequeueAfter: InitializerReconcileWaitTime}, nil
+		return r.endWithTryLater(ctx, init)
 	}
 
 	init.Status.Phase = v1beta1.InitializerInitializing
@@ -92,7 +92,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	if !appReady {
 		klog.Info("Wait for the Application created by Initializer to be ready")
-		return reconcile.Result{RequeueAfter: InitializerReconcileWaitTime}, nil
+		return r.endWithTryLater(ctx, init)
 	}
 
 	init.Status.Phase = v1beta1.InitializerSuccess
@@ -107,20 +107,25 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 // checkOrInstallDependsOn check the status of dependOn Initializer or help install the build-in Initializer.
 // If the dependOn Initializer is not found and the namespace is default or vela-system, we will try to find
 // and install the build-in Initializer from ConfigMap.
+// If all dependency are found(ready or not), err will be nil.
 func (r *Reconciler) checkOrInstallDependsOn(ctx context.Context, depends []v1beta1.DependsOn) (bool, error) {
 	for _, depend := range depends {
 		dependInit, err := utils.GetInitializer(ctx, r.Client, depend.Ref.Namespace, depend.Ref.Name)
 		if err != nil {
 			// if Initializer is not found and the namespace is default or vela-system,
-			// try to install build-in initializer from ConfigMap
+			// try to install build-in initializer from ConfigMap. Otherwise, err will be return
 			if apierrors.IsNotFound(err) && (depend.Ref.Namespace == "" || depend.Ref.Namespace == velatypes.DefaultKubeVelaNS) {
 				init, err := utils.GetBuildInInitializer(ctx, r.Client, depend.Ref.Name)
 				if err != nil {
 					return false, err
 				}
-				return false, r.Client.Create(ctx, init)
+				err = r.Client.Create(ctx, init)
+				if err != nil {
+					return false, err
+				}
+			} else {
+				return false, errors.Errorf("Initializer dependency %s is not found", depend.Ref.Name)
 			}
-			return false, err
 		}
 
 		if dependInit.Status.Phase != v1beta1.InitializerSuccess {
@@ -137,7 +142,25 @@ func (r *Reconciler) endWithNegativeCondition(ctx context.Context, init *v1beta1
 	if err := r.patchStatus(ctx, init); err != nil {
 		return ctrl.Result{}, errors.WithMessage(err, "cannot update initializer status")
 	}
+	// if any condition is changed, patching status can trigger requeue the resource and we should return nil to
+	// avoid requeue it again
+	if oamutil.IsConditionChanged([]cpv1alpha1.Condition{condition}, init) {
+		return ctrl.Result{}, nil
+	}
+	// if no condition is changed, patching status can not trigger requeue, so we must return an error to
+	// requeue the resource
 	return ctrl.Result{}, errors.Errorf("object level reconcile error, type: %q, msg: %q", string(condition.Type), condition.Message)
+}
+
+// endWithTryLater means reconcile successfully but have to wait until initializer phase is success. initializer may be
+// 1. waiting dependent initializer to be ready
+// 2. initializing
+func (r *Reconciler) endWithTryLater(ctx context.Context, init *v1beta1.Initializer) (ctrl.Result, error) {
+	init.SetConditions(cpv1alpha1.ReconcileSuccess())
+	if err := r.patchStatus(ctx, init); err != nil {
+		return ctrl.Result{}, errors.WithMessage(err, "cannot update initializer status")
+	}
+	return reconcile.Result{RequeueAfter: InitializerReconcileWaitTime}, nil
 }
 
 func (r *Reconciler) patchStatus(ctx context.Context, init *v1beta1.Initializer) error {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -401,7 +401,7 @@ func GetInitializer(ctx context.Context, cli client.Client, namespace, name stri
 	return init, err
 }
 
-// GetBuildInInitializer get build-in initializer from configMap in vela-system namespace
+// GetBuildInInitializer get built-in initializer from configMap in vela-system namespace
 func GetBuildInInitializer(ctx context.Context, cli client.Client, name string) (*v1beta1.Initializer, error) {
 	listOpts := []client.ListOption{
 		client.InNamespace(velatypes.DefaultKubeVelaNS),
@@ -415,14 +415,14 @@ func GetBuildInInitializer(ctx context.Context, cli client.Client, name string) 
 		return nil, err
 	}
 	if len(configMapList.Items) != 1 {
-		return nil, errors.Errorf("fail to get build-in initializer %s, there are %d matched initializers", name, len(configMapList.Items))
+		return nil, errors.Errorf("fail to get built-in initializer %s, there are %d matched initializers", name, len(configMapList.Items))
 	}
 
 	init := new(v1beta1.Initializer)
 	initYaml := configMapList.Items[0].Data["initializer"]
 	err = yaml.Unmarshal([]byte(initYaml), init)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "fail to unmarshal build-in initializer %s from configmap", name)
+		return nil, errors.WithMessagef(err, "fail to unmarshal built-in initializer %s from configmap", name)
 	}
 
 	return init, nil

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -473,6 +473,7 @@ func EndReconcileWithNegativeCondition(ctx context.Context, r client.StatusClien
 	return errors.Errorf(ErrReconcileErrInCondition, condition[0].Type, condition[0].Message)
 }
 
+// IsConditionChanged will check if conditions in workload is changed compare to newCondition
 func IsConditionChanged(newCondition []cpv1alpha1.Condition, workload ConditionedObject) bool {
 	var conditionIsChanged bool
 	for _, newCond := range newCondition {

--- a/pkg/webhook/core.oam.dev/v1alpha2/initializer/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/initializer/validating_handler.go
@@ -35,8 +35,6 @@ import (
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
 )
 
-var initializerGVR = v1beta1.SchemeGroupVersion.WithResource("initializers")
-
 // ValidatingHandler handles validation of initializer
 type ValidatingHandler struct {
 	Client client.Client

--- a/pkg/webhook/core.oam.dev/v1alpha2/initializer/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/initializer/validating_handler.go
@@ -73,28 +73,64 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("expect resource to be %s", initializerGVR))
 	}
 
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
 	if req.Operation == admissionv1beta1.Create || req.Operation == admissionv1beta1.Update {
-		err := h.Decoder.Decode(req, obj)
-		if err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
-		}
-
 		for _, depend := range obj.Spec.DependsOn {
 			_, err = utils.GetInitializer(ctx, h.Client, depend.Ref.Namespace, depend.Ref.Name)
 			if err != nil {
 				if apierrors.IsNotFound(err) && (depend.Ref.Namespace == "" || depend.Ref.Namespace == velatypes.DefaultKubeVelaNS) {
 					_, err = utils.GetBuildInInitializer(ctx, h.Client, depend.Ref.Name)
 					if err != nil {
-						return admission.Denied(fmt.Sprintf("fail to get dependOn Initializer %s from err: %s", depend.Ref.Name, err.Error()))
+						return admission.Denied(fmt.Sprintf("fail to get built-in dependOn Initializer %s from err: %s", depend.Ref.Name, err.Error()))
 					}
 					continue
 				}
-				return admission.Denied(fmt.Sprintf("fail to get dependOn Initializer %s err: %s", depend.Ref.Name, err.Error()))
+				return admission.Denied(fmt.Sprintf("DependOn Initializer %s not Found, err: %s", depend.Ref.Name, err.Error()))
 			}
 		}
+	}
 
+	if req.Operation == admissionv1beta1.Delete {
+		// check if there are other initializers depends on this
+		isDepended, dependingInitName, err := h.CheckInitDependedOn(ctx, obj)
+		if err != nil {
+			return admission.Errored(500, err)
+		}
+		if isDepended {
+			return admission.Denied(fmt.Sprintf("initializer %s still depends on this initializer", dependingInitName))
+		}
 	}
 	return admission.ValidationResponse(true, "")
+}
+
+// CheckInitDependedOn check if there are other initializers depending on this init
+func (h *ValidatingHandler) CheckInitDependedOn(ctx context.Context, obj *v1beta1.Initializer) (bool, string, error) {
+	var (
+		inits          v1beta1.InitializerList
+		isDepended     bool
+		dependInitName string
+	)
+	err := h.Client.List(ctx, &inits)
+	if err != nil {
+		return false, "", err
+	}
+	for _, i := range inits.Items {
+		depends := i.Spec.DependsOn
+		for _, d := range depends {
+			if d.Ref.Name == obj.Name {
+				dependInitName = i.Name
+				isDepended = true
+				break
+			}
+		}
+		if isDepended {
+			break
+		}
+	}
+	return isDepended, dependInitName, nil
 }
 
 // RegisterValidatingHandler will register initializer validation to webhook

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -329,7 +329,7 @@ func waitForInitializerSuccess(obj *unstructured.Unstructured) error {
 	return wait.PollImmediateInfinite(period, func() (done bool, err error) {
 		err = clt.Get(ctx, types2.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, &init)
 		if err != nil {
-			return false, nil
+			return false, client.IgnoreNotFound(err)
 		}
 		phase := init.Status.Phase
 		if phase == v1beta1.InitializerSuccess {

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -19,7 +19,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"time"
 
 	"github.com/gosuri/uitable"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	types2 "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -335,7 +335,6 @@ func waitForInitializerSuccess(obj *unstructured.Unstructured) {
 		}
 		fmt.Printf("Initializer %s is in phase:%s...\n", obj.GetName(), phase)
 	}, period, stopCh)
-	return
 }
 func (a *Addon) disable() error {
 	dynamicClient, err := dynamic.NewForConfig(clientArgs.Config)

--- a/test/e2e-test/initializer_test.go
+++ b/test/e2e-test/initializer_test.go
@@ -292,15 +292,14 @@ var _ = Describe("Initializer Normal tests", func() {
 				Spec: v1beta1.InitializerSpec{
 					AppTemplate: v1beta1.Application{
 						Spec: v1beta1.ApplicationSpec{
-							Components: []v1beta1.ApplicationComponent{
-								{
-									Name: "comp1",
-									Type: "worker",
-									Properties: util.Object2RawExtension(map[string]interface{}{
-										"image": "busybox",
-										"cmd":   []string{"sleep", "10000"},
-									}),
-								},
+							Components: []v1beta1.ApplicationComponent{{
+								Name: "comp1",
+								Type: "worker",
+								Properties: util.Object2RawExtension(map[string]interface{}{
+									"image": "busybox",
+									"cmd":   []string{"sleep", "10000"},
+								}),
+							},
 							},
 						},
 					},

--- a/test/e2e-test/initializer_test.go
+++ b/test/e2e-test/initializer_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Initializer Normal tests", func() {
 			}, 30*time.Second, 5*time.Second).Should(Succeed())
 		})
 
-		It("initializer depends on not non-build-in initializer not found, should be rejected by webhook", func() {
+		It("initializer depends on not non-built-in initializer not found, should be rejected by webhook", func() {
 			init := &v1beta1.Initializer{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Initializer",
@@ -309,7 +309,7 @@ var _ = Describe("Initializer Normal tests", func() {
 							Ref: corev1.ObjectReference{
 								APIVersion: "core.oam.dev/v1beta1",
 								Kind:       "Initializer",
-								Name:       "non-build-in",
+								Name:       "non-built-in",
 							},
 						},
 					},
@@ -320,17 +320,17 @@ var _ = Describe("Initializer Normal tests", func() {
 			Expect(k8sClient.Create(ctx, init)).Should(HaveOccurred())
 		})
 
-		It("initializer depends on build-in initializer", func() {
+		FIt("initializer depends on built-in initializer", func() {
 			initCm := &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ConfigMap",
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "build-in",
+					Name:      "built-in",
 					Namespace: velatypes.DefaultKubeVelaNS,
 					Labels: map[string]string{
-						"addons.oam.dev/type": "build-in",
+						"addons.oam.dev/type": "built-in",
 					},
 				},
 				Data: map[string]string{
@@ -338,7 +338,7 @@ var _ = Describe("Initializer Normal tests", func() {
 				},
 			}
 
-			By("create build-in addon")
+			By("create built-in addon")
 			Expect(k8sClient.Create(ctx, initCm)).Should(Succeed())
 
 			init := &v1beta1.Initializer{
@@ -347,7 +347,7 @@ var _ = Describe("Initializer Normal tests", func() {
 					APIVersion: "core.oam.dev/v1beta1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "env-depends-buildin",
+					Name:      "env-depends-builtin",
 					Namespace: namespace,
 				},
 				Spec: v1beta1.InitializerSpec{
@@ -355,7 +355,7 @@ var _ = Describe("Initializer Normal tests", func() {
 						Spec: v1beta1.ApplicationSpec{
 							Components: []v1beta1.ApplicationComponent{
 								{
-									Name: "",
+									Name: "comp1",
 									Type: "worker",
 									Properties: util.Object2RawExtension(map[string]interface{}{
 										"image": "busybox",
@@ -370,7 +370,7 @@ var _ = Describe("Initializer Normal tests", func() {
 							Ref: corev1.ObjectReference{
 								APIVersion: "core.oam.dev/v1beta1",
 								Kind:       "Initializer",
-								Name:       "build-in",
+								Name:       "built-in",
 								Namespace:  velatypes.DefaultKubeVelaNS,
 							},
 						},
@@ -381,10 +381,10 @@ var _ = Describe("Initializer Normal tests", func() {
 			By("Create Initializer env-depends")
 			Expect(k8sClient.Create(ctx, init)).Should(Succeed())
 
-			By("Check build-in Initializer is ready")
+			By("Check built-in Initializer is ready")
 			buildInInit := new(v1beta1.Initializer)
 			Eventually(func() error {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: "build-in", Namespace: "vela-system"}, buildInInit)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: "built-in", Namespace: "vela-system"}, buildInInit)
 				if err != nil {
 					return err
 				}
@@ -394,17 +394,17 @@ var _ = Describe("Initializer Normal tests", func() {
 				return fmt.Errorf("initializer %s is not ready", buildInInit.Name)
 			}, 30*time.Second, 500*time.Millisecond).Should(Succeed())
 
-			By("Check Initializer env-depends-buildin is ready")
+			By("Check Initializer env-depends-builtin is ready")
 			Eventually(func() error {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: "env-depends-buildin", Namespace: namespace}, buildInInit)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: "env-depends-builtin", Namespace: namespace}, buildInInit)
 				if err != nil {
 					return err
 				}
 				if buildInInit.Status.Phase == v1beta1.InitializerSuccess {
 					return nil
 				}
-				return errors.New("initializer env-depends-buildin is not ready")
-			}, 30*time.Second, 500*time.Millisecond).Should(Succeed())
+				return errors.New("initializer env-depends-builtin is not ready")
+			}, 120*time.Second, 500*time.Millisecond).Should(Succeed())
 		})
 
 		It("Deleting initializer depended by other initializer should be rejected by webhook", func() {
@@ -422,7 +422,7 @@ var _ = Describe("Initializer Normal tests", func() {
 						Spec: v1beta1.ApplicationSpec{
 							Components: []v1beta1.ApplicationComponent{
 								{
-									Name: "",
+									Name: "comp1",
 									Type: "worker",
 									Properties: util.Object2RawExtension(map[string]interface{}{
 										"image": "busybox",
@@ -488,7 +488,7 @@ kind: Initializer
 metadata:
   annotations:
     addons.oam.dev/description: Kruise is a Kubernetes extended suite for application automations
-  name: build-in
+  name: built-in
   namespace: vela-system
 spec:
   appTemplate:
@@ -497,6 +497,6 @@ spec:
       - name: kruise-repo
         type: worker
         properties:
-          image: busybox,
+          image: busybox
           cmd:   ["sleep", "10000"]
 `

--- a/test/e2e-test/initializer_test.go
+++ b/test/e2e-test/initializer_test.go
@@ -464,6 +464,7 @@ var _ = Describe("Initializer Normal tests", func() {
 								APIVersion: "core.oam.dev/v1beta1",
 								Kind:       "Initializer",
 								Name:       "init-depended",
+								Namespace:  namespace,
 							},
 						},
 					},

--- a/test/e2e-test/initializer_test.go
+++ b/test/e2e-test/initializer_test.go
@@ -294,7 +294,7 @@ var _ = Describe("Initializer Normal tests", func() {
 						Spec: v1beta1.ApplicationSpec{
 							Components: []v1beta1.ApplicationComponent{
 								{
-								Name: "",
+									Name: "comp1",
 									Type: "worker",
 									Properties: util.Object2RawExtension(map[string]interface{}{
 										"image": "busybox",

--- a/test/e2e-test/initializer_test.go
+++ b/test/e2e-test/initializer_test.go
@@ -294,7 +294,7 @@ var _ = Describe("Initializer Normal tests", func() {
 						Spec: v1beta1.ApplicationSpec{
 							Components: []v1beta1.ApplicationComponent{
 								{
-									Name: "",
+								Name: "",
 									Type: "worker",
 									Properties: util.Object2RawExtension(map[string]interface{}{
 										"image": "busybox",


### PR DESCRIPTION
**What this PR does / why we need it**:

Initializer:
1. When installing dependent initializer ,controller won't update status as `CheckingDepends` ,fix that
![image](https://user-images.githubusercontent.com/47812250/126603138-94633c16-2b6e-44dc-a1f5-02739f963f00.png)
![image](https://user-images.githubusercontent.com/47812250/126603404-5b3c8859-c811-4221-9804-d6a70d47e8bd.png)
2. After initializer patch status, reconcile return an error, that will requeue the request twice, fix that.
3. Add delete webhook, forbid deletion of initializer that are depended by other initializer. Add test for that.

vela CLI:
1. enable: continually show initializer status
![image](https://user-images.githubusercontent.com/47812250/126604933-3c11596d-3723-45c3-8bca-06bbb6a2af83.png)
2. disable: remove deleting ns logic(all init are now in vela-system namespace)