### PR TITLE
fix app finalizer bug

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_finalizer_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_finalizer_test.go
@@ -50,6 +50,9 @@ var _ = Describe("Test application controller finalizer logic", func() {
 	ncd := &v1beta1.ComponentDefinition{}
 	ncdDefJson, _ := yaml.YAMLToJSON([]byte(normalCompDefYaml))
 
+	badCD := &v1beta1.ComponentDefinition{}
+	badCDJson, _ := yaml.YAMLToJSON([]byte(badCompDefYaml))
+
 	td := &v1beta1.TraitDefinition{}
 	tdDefJson, _ := yaml.YAMLToJSON([]byte(crossNsTdYaml))
 
@@ -69,6 +72,9 @@ var _ = Describe("Test application controller finalizer logic", func() {
 
 		Expect(json.Unmarshal(ncdDefJson, ncd)).Should(BeNil())
 		Expect(k8sClient.Create(ctx, ncd.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+		Expect(json.Unmarshal(badCDJson, badCD)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, badCD.DeepCopy())).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
 	})
 
 	AfterEach(func() {
@@ -127,6 +133,35 @@ var _ = Describe("Test application controller finalizer logic", func() {
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(k8sClient.Get(ctx, getTrackerKey(checkApp.Namespace, checkApp.Name, "v1"), rt)).Should(Succeed())
 		Expect(checkApp.Status.ResourceTracker).Should(BeNil())
+	})
+
+	It("Test error occurs in the middle of dispatching", func() {
+		appName := "bad-app"
+		appKey := types.NamespacedName{Namespace: namespace, Name: appName}
+		app := getApp(appName, namespace, "bad-worker")
+		Expect(k8sClient.Create(ctx, app)).Should(BeNil())
+
+		By("Create a bad workload app")
+		checkApp := &v1beta1.Application{}
+		reconcileOnceAfterFinalizer(reconciler, ctrl.Request{NamespacedName: appKey})
+		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
+
+		// because error occurs in the middle of dispatching
+		// resource tracker for v1 is created but v1 is not recorded in app status
+		By("Verify latest app revision is not recorded in status")
+		Expect(checkApp.Status.LatestRevision).Should(BeNil())
+
+		By("Verify ResourceTracker is created")
+		rt := &v1beta1.ResourceTracker{}
+		Expect(k8sClient.Get(ctx, getTrackerKey(checkApp.Namespace, checkApp.Name, "v1"), rt)).Should(Succeed())
+
+		By("Delete Application")
+		Expect(k8sClient.Delete(ctx, checkApp)).Should(BeNil())
+		reconcileOnceAfterFinalizer(reconciler, ctrl.Request{NamespacedName: appKey})
+
+		By("Verify ResourceTracker is deleted")
+		rt = &v1beta1.ResourceTracker{}
+		Expect(k8sClient.Get(ctx, getTrackerKey(checkApp.Namespace, checkApp.Name, "v1"), rt)).Should(util.NotFoundMatcher{})
 	})
 
 	It("Test cross namespace workload, then delete the app", func() {
@@ -386,6 +421,40 @@ spec:
                   }
               }
 
+              selector:
+                  matchLabels:
+                      "app.oam.dev/component": context.name
+          }
+      }
+
+      parameter: {
+          // +usage=Which image would you like to use for your service
+          // +short=i
+          image: string
+
+          cmd?: [...string]
+      }
+`
+	badCompDefYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: bad-worker
+  namespace: vela-system
+  annotations:
+    definition.oam.dev/description: "It will make dispatching failed"
+spec:
+  workload:
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+  extension:
+    template: |
+      output: {
+          apiVersion: "apps/v1"
+          kind:       "Deployment"
+          spec: {
+              replicas: 0
               selector:
                   matchLabels:
                       "app.oam.dev/component": context.name


### PR DESCRIPTION
Signed-off-by: roy wang <seiwy2010@gmail.com>

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**Prblem**:

App controller uses finalizer to garbage collect resource tracker according to its status latest revision.
If an error occurs in the middle of dispatching(applying) resources, even resource tracker is created but app status cannot record its revision as the latest revision. Thus, if we delete the application now, app controller cannot GC this resource tracker.

**Solution**:
During GC, list all resource trackers related to this application and delete them.


