### PR TITLE
Optimize Workflow

### DIFF
--- a/docs/examples/workflow/app.yaml
+++ b/docs/examples/workflow/app.yaml
@@ -18,7 +18,7 @@ spec:
           name: "firstApp"
         outputs:
           - name: server1Ip
-            exportKey: "myIp"
+            exportKey: "myIP"
       - name: deploy-server2
         type: apply
         inputs:

--- a/docs/examples/workflow/definition.yaml
+++ b/docs/examples/workflow/definition.yaml
@@ -11,7 +11,6 @@ spec:
            component: string
            name: string
            prefixIP?: string
-           myIp?: string
         }
 
         // load component from application
@@ -34,7 +33,7 @@ spec:
         }
 
         // export podIP
-        myIp: apply.status.podIP
+        myIP: apply.status.podIP
 ---
 apiVersion: core.oam.dev/v1beta1
 kind: ComponentDefinition

--- a/docs/examples/workflow/definition.yaml
+++ b/docs/examples/workflow/definition.yaml
@@ -34,13 +34,7 @@ spec:
         }
 
         // export podIP
-        if parameter.myIp!=_|_{
-            export: op.#Export & {
-                type: "var"
-                path: parameter.myIp
-                value: apply.status.podIP
-            }
-        }
+        myIp: apply.status.podIP
 ---
 apiVersion: core.oam.dev/v1beta1
 kind: ComponentDefinition

--- a/pkg/stdlib/op.go
+++ b/pkg/stdlib/op.go
@@ -54,6 +54,7 @@ var opFile = file{
 #Apply: {
   #do: "apply"
   #provider: "kube"
+  patch: _
   ...
 }
 

--- a/pkg/stdlib/op.go
+++ b/pkg/stdlib/op.go
@@ -54,14 +54,14 @@ var opFile = file{
 #Apply: {
   #do: "apply"
   #provider: "kube"
-  patch: _
+  patch?: _
   ...
 }
 
 #Read: {
   #do: "read"
   #provider: "kube"
-  result: {...}
+  result?: {...}
   ...
 }
 

--- a/pkg/stdlib/op.go
+++ b/pkg/stdlib/op.go
@@ -66,6 +66,7 @@ var opFile = file{
 
 #Steps: {
   #do: "steps"
+  ...
 }
 
 NoExist: _|_

--- a/pkg/workflow/context/context.go
+++ b/pkg/workflow/context/context.go
@@ -79,7 +79,10 @@ func (wf *WorkflowContext) SetVar(v *value.Value, paths ...string) error {
 	if err != nil {
 		return errors.WithMessage(err, "compile var")
 	}
-	return wf.vars.FillRaw(str, paths...)
+	if err := wf.vars.FillRaw(str, paths...); err != nil {
+		return err
+	}
+	return wf.vars.Error()
 }
 
 // MakeParameter make 'value' with map[string]interface{}

--- a/pkg/workflow/context/context_test.go
+++ b/pkg/workflow/context/context_test.go
@@ -193,6 +193,10 @@ result: 101
 score:  100
 result: 101
 `)
+
+	conflictV, _ := value.NewValue(`score: 101`, nil)
+	err = wfCtx.SetVar(conflictV, "football")
+	assert.Equal(t, err != nil, true)
 }
 
 func TestRefObj(t *testing.T) {

--- a/pkg/workflow/providers/kube/handle.go
+++ b/pkg/workflow/providers/kube/handle.go
@@ -45,8 +45,8 @@ type provider struct {
 // Apply create or update CR in cluster.
 func (h *provider) Apply(ctx wfContext.Context, v *value.Value, act types.Action) error {
 	var workload = new(unstructured.Unstructured)
-	pv, _ := v.Field("patch")
-	if pv.Exists() {
+	pv, err := v.Field("patch")
+	if pv.Exists() && err == nil {
 		base, err := model.NewBase(v.CueValue())
 		if err != nil {
 			return err

--- a/pkg/workflow/providers/kube/handle.go
+++ b/pkg/workflow/providers/kube/handle.go
@@ -18,11 +18,11 @@ package kube
 
 import (
 	"context"
-	"github.com/oam-dev/kubevela/pkg/cue/model"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/oam-dev/kubevela/pkg/cue/model"
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers"
@@ -71,7 +71,7 @@ func (h *provider) Apply(ctx wfContext.Context, v *value.Value, act types.Action
 	if workload.GetNamespace() == "" {
 		workload.SetNamespace("default")
 	}
-	delete(workload.Object,"patch")
+	delete(workload.Object, "patch")
 	if err := h.apply(deployCtx, workload); err != nil {
 		return err
 	}

--- a/pkg/workflow/providers/kube/handle.go
+++ b/pkg/workflow/providers/kube/handle.go
@@ -96,7 +96,7 @@ func (h *provider) Read(ctx wfContext.Context, v *value.Value, act types.Action)
 	retObj.SetKind(obj.GetKind())
 	retObj.SetAPIVersion(obj.GetAPIVersion())
 	if err := h.cli.Get(context.Background(), key, retObj); err != nil {
-		return v.FillRaw(err.Error(), "err")
+		return v.FillObject(err.Error(), "err")
 	}
 	return v.FillObject(retObj.Object, "result")
 }

--- a/pkg/workflow/providers/kube/handle_test.go
+++ b/pkg/workflow/providers/kube/handle_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Test Workflow Provider Kube", func() {
 		v, err := value.NewValue(fmt.Sprintf(`
 %s
 metadata: name: "app"
-`,component.Workload.String()), nil)
+`, component.Workload.String()), nil)
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Apply(ctx, v, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -97,7 +97,7 @@ metadata: name: "app"
 		v, err = value.NewValue(fmt.Sprintf(`
 %s
 metadata: name: "app"
-`,component.Workload.String()), nil)
+`, component.Workload.String()), nil)
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Read(ctx, v, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -139,7 +139,7 @@ metadata: name: "app"
 		Expect(err).ToNot(HaveOccurred())
 		v, err := value.NewValue(fmt.Sprintf(`
 %s
-patch: metadata: name: "test-app-1"`,component.Workload.String()), nil)
+patch: metadata: name: "test-app-1"`, component.Workload.String()), nil)
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Apply(ctx, v, nil)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/workflow/providers/kube/handle_test.go
+++ b/pkg/workflow/providers/kube/handle_test.go
@@ -153,6 +153,25 @@ patch: metadata: name: "test-app-1"`, component.Workload.String()), nil)
 			}, workload)
 		}, time.Second*2, time.Millisecond*300).Should(BeNil())
 	})
+	It("test patch error", func() {
+		p := &provider{}
+		ctx, err := newWorkflowContextForTest()
+		Expect(err).ToNot(HaveOccurred())
+
+		v, _ := value.NewValue(`
+kind: "Pod"
+apiVersion: "v1"
+patch: close({kind: 12})`, nil)
+		err = p.Apply(ctx, v, nil)
+		Expect(err).To(HaveOccurred())
+
+		v, _ = value.NewValue(`
+kind: "Pod"
+apiVersion: "v1"
+patch: _|_`, nil)
+		err = p.Apply(ctx, v, nil)
+		Expect(err).To(HaveOccurred())
+	})
 
 })
 

--- a/pkg/workflow/providers/kube/handle_test.go
+++ b/pkg/workflow/providers/kube/handle_test.go
@@ -19,6 +19,7 @@ package kube
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -77,7 +78,10 @@ var _ = Describe("Test Workflow Provider Kube", func() {
 		component, err := ctx.GetComponent("server")
 		Expect(err).ToNot(HaveOccurred())
 
-		v, err := value.NewValue(component.Workload.String()+"\nmetadata: name: \"app\"", nil)
+		v, err := value.NewValue(fmt.Sprintf(`
+%s
+metadata: name: "app"
+`,component.Workload.String()), nil)
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Apply(ctx, v, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -90,7 +94,10 @@ var _ = Describe("Test Workflow Provider Kube", func() {
 			}, workload)
 		}, time.Second*2, time.Millisecond*300).Should(BeNil())
 
-		v, err = value.NewValue(component.Workload.String()+"\nmetadata: name: \"app\"", nil)
+		v, err = value.NewValue(fmt.Sprintf(`
+%s
+metadata: name: "app"
+`,component.Workload.String()), nil)
 		Expect(err).ToNot(HaveOccurred())
 		err = p.Read(ctx, v, nil)
 		Expect(err).ToNot(HaveOccurred())
@@ -109,6 +116,42 @@ var _ = Describe("Test Workflow Provider Kube", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cmp.Diff(rv, expected)).Should(BeEquivalentTo(""))
+	})
+	It("patch & apply", func() {
+		p := &provider{
+			apply: func(ctx context.Context, manifests ...*unstructured.Unstructured) error {
+				for _, obj := range manifests {
+					if err := k8sClient.Create(ctx, obj); err != nil {
+						if errors.IsAlreadyExists(err) {
+							return k8sClient.Update(ctx, obj)
+						}
+						return err
+					}
+				}
+				return nil
+			},
+			cli: k8sClient,
+		}
+		ctx, err := newWorkflowContextForTest()
+		Expect(err).ToNot(HaveOccurred())
+
+		component, err := ctx.GetComponent("server")
+		Expect(err).ToNot(HaveOccurred())
+		v, err := value.NewValue(fmt.Sprintf(`
+%s
+patch: metadata: name: "test-app-1"`,component.Workload.String()), nil)
+		Expect(err).ToNot(HaveOccurred())
+		err = p.Apply(ctx, v, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		workload, err := component.Workload.Unstructured()
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      "test-app-1",
+			}, workload)
+		}, time.Second*2, time.Millisecond*300).Should(BeNil())
 	})
 
 })
@@ -191,7 +234,7 @@ spec: {
 }`
 )
 
-func TestDefinition(t *testing.T) {
+func TestProvider(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -196,6 +196,14 @@ close({
 			}},
 		},
 		{
+			Name: "output",
+			Type: "ok",
+			Outputs: v1beta1.StepOutputs{{
+				Name:      "podIP",
+				ExportKey: "myIP",
+			}},
+		},
+		{
 			Name: "wait",
 			Type: "wait",
 		},
@@ -213,6 +221,9 @@ close({
 		switch step.Name {
 		case "input":
 			assert.Equal(t, err != nil, true)
+		case "ouput":
+			assert.Equal(t, status.Reason, StatusReasonOutput)
+			assert.Equal(t, status.Phase, common.WorkflowStepPhaseFailed)
 		default:
 			assert.Equal(t, status.Phase, common.WorkflowStepPhaseFailed)
 		}

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -204,6 +204,14 @@ close({
 			}},
 		},
 		{
+			Name: "output-var-conflict",
+			Type: "ok",
+			Outputs: v1beta1.StepOutputs{{
+				Name:      "score",
+				ExportKey: "name",
+			}},
+		},
+		{
 			Name: "wait",
 			Type: "wait",
 		},
@@ -221,7 +229,7 @@ close({
 		switch step.Name {
 		case "input":
 			assert.Equal(t, err != nil, true)
-		case "ouput":
+		case "ouput", "output-var-conflict":
 			assert.Equal(t, status.Reason, StatusReasonOutput)
 			assert.Equal(t, status.Phase, common.WorkflowStepPhaseFailed)
 		default:
@@ -250,10 +258,10 @@ parameter: {}
 process: {
 	#provider: "test"
 	#do: "%s"
-    // check injected context.
-    name: context.name
 	parameter
 }
+// check injected context.
+name: context.name
 `
 	switch name {
 	case "output":

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -229,6 +229,8 @@ func newWorkflowContextForTest(t *testing.T) wfContext.Context {
 	wfCtx := new(wfContext.WorkflowContext)
 	err = wfCtx.LoadFromConfigMap(cm)
 	assert.NilError(t, err)
+	v, _ := value.NewValue(`name: "app"`, nil)
+	assert.NilError(t, wfCtx.SetVar(v, types.ContextKeyMetadata))
 	return wfCtx
 }
 func mockLoadTemplate(_ context.Context, name string) (string, error) {
@@ -237,6 +239,8 @@ parameter: {}
 process: {
 	#provider: "test"
 	#do: "%s"
+    // check injected context.
+    name: context.name
 	parameter
 }
 `

--- a/pkg/workflow/types/types.go
+++ b/pkg/workflow/types/types.go
@@ -47,3 +47,8 @@ type Action interface {
 	Terminate(message string)
 	Wait(message string)
 }
+
+const (
+	// ContextKeyMetadata is key that refer to application metadata.
+	ContextKeyMetadata = "metadata__"
+)

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -18,13 +18,14 @@ package workflow
 
 import (
 	"context"
-	"github.com/oam-dev/kubevela/pkg/oam/util"
+
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	oamcore "github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
 	wfTypes "github.com/oam-dev/kubevela/pkg/workflow/types"
 )

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -18,12 +18,13 @@ package workflow
 
 import (
 	"context"
-
+	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	oamcore "github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
 	wfTypes "github.com/oam-dev/kubevela/pkg/workflow/types"
 )
@@ -82,21 +83,47 @@ func (w *workflow) ExecuteSteps(ctx context.Context, rev string, taskRunners []w
 		wfCtx wfContext.Context
 	)
 
-	if wfStatus.ContextBackend != nil {
-		wfCtx, gerr = wfContext.LoadContext(w.cli, w.app.Namespace, rev)
-		if gerr != nil {
-			gerr = errors.WithMessage(gerr, "load context")
-			return
-		}
-	} else {
-		wfCtx, gerr = wfContext.NewContext(w.cli, w.app.Namespace, rev)
-		if gerr != nil {
-			gerr = errors.WithMessage(gerr, "new context")
-			return
-		}
-		wfStatus.ContextBackend = wfCtx.StoreRef()
+	wfCtx, gerr = w.makeContext(rev)
+	if gerr != nil {
+		return
 	}
 
+	gerr = w.setMetadataToContext(wfCtx)
+	if gerr != nil {
+		return
+	}
+
+	return w.run(wfCtx, taskRunners)
+}
+
+func (w *workflow) makeContext(rev string) (wfCtx wfContext.Context, err error) {
+	wfStatus := w.app.Status.Workflow
+	if wfStatus.ContextBackend != nil {
+		wfCtx, err = wfContext.LoadContext(w.cli, w.app.Namespace, rev)
+		if err != nil {
+			err = errors.WithMessage(err, "load context")
+		}
+		return
+	}
+	wfCtx, err = wfContext.NewContext(w.cli, w.app.Namespace, rev)
+	if err != nil {
+		err = errors.WithMessage(err, "new context")
+		return
+	}
+	wfStatus.ContextBackend = wfCtx.StoreRef()
+	return
+}
+
+func (w *workflow) setMetadataToContext(wfCtx wfContext.Context) error {
+	metadata, err := value.NewValue(string(util.MustJSONMarshal(w.app.ObjectMeta)), nil)
+	if err != nil {
+		return err
+	}
+	return wfCtx.SetVar(metadata, wfTypes.ContextKeyMetadata)
+}
+
+func (w *workflow) run(wfCtx wfContext.Context, taskRunners []wfTypes.TaskRunner) (done bool, pause bool, gerr error) {
+	wfStatus := w.app.Status.Workflow
 	for _, run := range taskRunners[wfStatus.StepIndex:] {
 		status, operation, err := run(wfCtx)
 		if err != nil {

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -148,8 +148,9 @@ var _ = Describe("Test Workflow", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(done).Should(BeFalse())
 		Expect(pause).Should(BeTrue())
-		app.Status.Workflow.ContextBackend = nil
-		Expect(cmp.Diff(*app.Status.Workflow, common.WorkflowStatus{
+		wfStatus := *app.Status.Workflow
+		wfStatus.ContextBackend = nil
+		Expect(cmp.Diff(wfStatus, common.WorkflowStatus{
 			AppRevision: revision,
 			StepIndex:   2,
 			Suspend:     true,


### PR DESCRIPTION
1. Optimize output mechanism
The content in the WorkflowStep can be output flexibly through the task step name
```
// workflowStep
...
myIP:  apply.status.podIP

---
// application.yaml
properties:
...
outputs: 
- name: serverIP
  exportKey: myIp
```
2. Inject app's metadata for StepDefinition

You can use `context` to reference application metadata, as below
```
apply: op.#Apply & {
    ...
    metadata: namespace: context.namespace
}
```