### PR TITLE
suppress dirty logs during import libraries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/briandowns/spinner v1.11.1
+	github.com/containerd/containerd v1.3.2
 	github.com/coreos/prometheus-operator v0.41.1
 	github.com/crossplane/crossplane-runtime v0.10.0
 	github.com/davecgh/go-spew v1.1.1

--- a/references/a/preimport/preimport.go
+++ b/references/a/preimport/preimport.go
@@ -1,0 +1,42 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package preimport
+
+import (
+	"flag"
+
+	"github.com/containerd/containerd/log"
+	"k8s.io/klog"
+)
+
+var _flagSet *flag.FlagSet
+
+// disable logging during import
+func init() {
+	lvl, _ := log.ParseLevel("panic")
+	log.L.Logger.SetLevel(lvl)
+	_flagSet = flag.CommandLine
+	klog.InitFlags(_flagSet)
+	_ = _flagSet.Set("v", "-1")
+}
+
+// Start recover logging
+func Start() {
+	lvl, _ := log.ParseLevel("info")
+	log.L.Logger.SetLevel(lvl)
+	_ = _flagSet.Set("v", "0")
+}

--- a/references/cmd/cli/main.go
+++ b/references/cmd/cli/main.go
@@ -21,10 +21,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/oam-dev/kubevela/references/a/preimport"
 	"github.com/oam-dev/kubevela/references/cli"
 )
 
 func main() {
+	preimport.Start()
 	rand.Seed(time.Now().UnixNano())
 
 	command := cli.NewCommand()


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The vela CLI tools prints "getCPUInfo" error for `darwin/arm64` architecture which confuses Mac M1 users. Besides, the "throttling request" message logged during the import process is not necessary for the CLI tool. This PR suppress these two loggings during the init stage. The logging is recovered when the import process is over and the CLI starts to execute. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [#1924](https://github.com/oam-dev/kubevela/issues/1924)

**Special notes for your reviewer**:

The solution is to suppress loggings from `containerd` lib for "getCPUInfo" log and `klog` for "throttling request" in client-go. The `klog` logging is brought back when the CLI command starts execution.