### PR TITLE
fix rollout test

### DIFF
--- a/pkg/controller/common/rollout/workloads/deployment_rollout_controller.go
+++ b/pkg/controller/common/rollout/workloads/deployment_rollout_controller.go
@@ -302,7 +302,6 @@ func (c *DeploymentRolloutController) fetchDeployments(ctx context.Context) erro
 		}
 		return err
 	}
-
 	if err := c.client.Get(ctx, c.targetNamespacedName, &c.targetDeploy); err != nil {
 		if !apierrors.IsNotFound(err) {
 			c.recorder.Event(c.parentController, event.Warning("Failed to get the target Deployment", err))

--- a/pkg/controller/common/rollout/workloads/deployment_rollout_integration_test.go
+++ b/pkg/controller/common/rollout/workloads/deployment_rollout_integration_test.go
@@ -247,9 +247,11 @@ var _ = Describe("deployment controller", func() {
 			var sourceReplica int32 = 6
 			sourceDeploy.Spec.Replicas = &sourceReplica
 			Expect(k8sClient.Create(ctx, &sourceDeploy)).Should(SatisfyAny(Succeed(), &util.AlreadyExistMatcher{}))
+
 			// test environment doesn't have deployment controller, has to fake it
-			c.sourceDeploy.Status.Replicas = sourceReplica // this has to pass batch check
+			sourceDeploy.Status.Replicas = sourceReplica // this has to pass batch check
 			Expect(k8sClient.Status().Update(ctx, &sourceDeploy)).Should(Succeed())
+
 			targetDeploy.Spec.Replicas = pointer.Int32Ptr(0)
 			Expect(k8sClient.Create(ctx, &targetDeploy)).Should(SatisfyAny(Succeed(), &util.AlreadyExistMatcher{}))
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2173670/127646981-1947e01c-98a8-4c9b-a0dd-1c1e489c94b5.png)

This is a mis-match, and we don't find out it because the controller-runtime don't override data when the value is empty.