### PR TITLE
bugfix: workload namespace is empty while sync appdeployment

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/appdeployment/appdeployment_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/appdeployment/appdeployment_controller.go
@@ -317,6 +317,7 @@ func (r *Reconciler) getWorkloadsFromRevision(ctx context.Context, revName, ns s
 			return nil, err
 		}
 		comp.Name = makeRevisionName(comp.Name, revName)
+		comp.Namespace = appRev.Namespace
 		comps = append(comps, comp)
 	}
 


### PR DESCRIPTION
Signed-off-by: shaowenchen mail@chenshaowen.com

What this PR does / why we need it:

It raises an error Failed to reconcile appDeployment default/cross-cluster-app: cannot get object: an empty namespace may not be set when a resource name is provided when I test case refers to https://kubevela.io/docs/v1.1/end-user/scopes/appdeploy/#appdeployment
