### PR TITLE
Order Steps by Field Tag

### DIFF
--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -81,7 +81,7 @@ func NewValue(s string, pd *packages.PackageDiscover, opts ...func(ast.Node)) (*
 	for _, opt := range opts {
 		opt(file)
 	}
-	if err := builder.AddFile("-", s); err != nil {
+	if err := builder.AddSyntax(file); err != nil {
 		return nil, err
 	}
 
@@ -109,6 +109,7 @@ func TagFieldOrder(root ast.Node) {
 	ast.Walk(root, func(node ast.Node) bool {
 		field, ok := node.(*ast.Field)
 		if ok && field.Attrs == nil {
+			i++
 			field.Attrs = []*ast.Attribute{
 				{Text: fmt.Sprintf("@step(%d)", i)},
 			}

--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -74,7 +74,7 @@ func (val *Value) UnmarshalTo(x interface{}) error {
 func NewValue(s string, pd *packages.PackageDiscover, opts ...func(ast.Node)) (*Value, error) {
 	builder := &build.Instance{}
 
-	file, err := parser.ParseFile("-", s)
+	file, err := parser.ParseFile("-", s, parser.ParseComments)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -85,7 +85,7 @@ step2: {prefix: step1.value}
 step3: {prefix: step2.value}
 step4: {prefix: step3.value}
 if step4.value > 100 {
-        step5: "end"
+        step5: {prefix: step4.value}
 } 
 `,
 			expected: `step1: {
@@ -103,7 +103,10 @@ step4: {
 	prefix: 102
 	value:  103
 }
-step5: "end"
+step5: {
+	prefix: 103
+	value:  104
+}
 `},
 
 		{base: `
@@ -209,8 +212,11 @@ step2: {prefix: step1.value}
 step3: {prefix: step2.value}
 step4: {prefix: step3.value}
 if step4.value > 100 {
-        step5: "end"
-} 
+        step5: {}
+}
+step5: {
+	value:  *100|int
+}
 `,
 			expected: `step1: {
 	value: 100
@@ -227,7 +233,9 @@ step4: {
 	prefix: 102
 	value:  103
 } @step(4)
-step5: "end" @step(5)
+step5: {
+	value: 104
+} @step(5)
 `}, {base: `
 step1: {}
 step2: {prefix: step1.value}
@@ -236,9 +244,6 @@ if step2.value > 100 {
 }
 step3: {prefix: step2.value}
 step4: {prefix: step3.value}
-if step4.value > 100 {
-        step5: "end"
-} 
 `,
 			expected: `step1: {
 	value: 100
@@ -259,7 +264,6 @@ step4: {
 	prefix: 103
 	value:  104
 } @step(5)
-step5: "end" @step(6)
 `}, {base: `
 step2: {prefix: step1.value} @step(2)
 step1: {} @step(1)
@@ -303,18 +307,18 @@ step1: {
 step2_3: {
 	prefix: 101
 	value:  102
-} @step(3)
+} @step(2)
 step3: {
 	prefix: 101
 	value:  103
-} @step(4)
+} @step(3)
 `}}
 
 	for _, tCase := range testCases {
 		val, err := NewValue(tCase.base, nil, TagFieldOrder)
 		assert.NilError(t, err)
 		number := 99
-		err = val.StepByFields(func(_ string, in *Value) (bool, error) {
+		err = val.StepByFields(func(name string, in *Value) (bool, error) {
 			number++
 			return false, in.FillObject(map[string]interface{}{
 				"value": number,

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -216,18 +216,18 @@ if step4.value > 100 {
 	value: 100
 } @step(1)
 step2: {
-	prefix: 100 @step(3)
+	prefix: 100
 	value:  101
 } @step(2)
 step3: {
-	prefix: 101 @step(5)
+	prefix: 101
 	value:  102
-} @step(4)
+} @step(3)
 step4: {
-	prefix: 102 @step(7)
+	prefix: 102
 	value:  103
-} @step(6)
-step5: "end" @step(8)
+} @step(4)
+step5: "end" @step(5)
 `}, {base: `
 step1: {}
 step2: {prefix: step1.value}
@@ -244,22 +244,22 @@ if step4.value > 100 {
 	value: 100
 } @step(1)
 step2: {
-	prefix: 100 @step(3)
+	prefix: 100
 	value:  101
 } @step(2)
 step2_3: {
-	prefix: 101 @step(5)
+	prefix: 101
 	value:  102
-} @step(4)
+} @step(3)
 step3: {
-	prefix: 101 @step(7)
+	prefix: 101
 	value:  103
-} @step(6)
+} @step(4)
 step4: {
-	prefix: 103 @step(9)
+	prefix: 103
 	value:  104
-} @step(8)
-step5: "end" @step(10)
+} @step(5)
+step5: "end" @step(6)
 `}, {base: `
 step2: {prefix: step1.value} @step(2)
 step1: {} @step(1)
@@ -269,18 +269,18 @@ if step2.value > 100 {
 }
 `,
 			expected: `step2: {
-	prefix: 100 @step(1)
+	prefix: 100
 	value:  101
 } @step(2)
 step1: {
 	value: 100
 } @step(1)
 step3: {
-	prefix: 101 @step(2)
+	prefix: 101
 	value:  103
 } @step(4)
 step2_3: {
-	prefix: 101 @step(3)
+	prefix: 101
 	value:  102
 } @step(3)
 `},
@@ -294,20 +294,20 @@ if step2.value > 100 {
 step3: {prefix: step2.value}
 `,
 			expected: `step2: {
-	prefix: 100 @step(2)
+	prefix: 100
 	value:  101
 } @step(1)
 step1: {
 	value: 100
 } @step(-1)
 step2_3: {
-	prefix: 101 @step(4)
+	prefix: 101
 	value:  102
 } @step(3)
 step3: {
-	prefix: 101 @step(6)
+	prefix: 101
 	value:  103
-} @step(5)
+} @step(4)
 `}}
 
 	for _, tCase := range testCases {

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -130,60 +130,10 @@ step3: {
 	value:  103
 }
 `},
-
-		{base: `
-step2: {prefix: step1.value} @step(2)
-step1: {} @step(1)
-step3: {prefix: step2.value} @step(4)
-if step2.value > 100 {
-        step2_3: {prefix: step2.value} @step(3)
-}
-`,
-			expected: `step2: {
-	prefix: 100
-	value:  101
-} @step(2)
-step1: {
-	value: 100
-} @step(1)
-step3: {
-	prefix: 101
-	value:  103
-} @step(4)
-step2_3: {
-	prefix: 101
-	value:  102
-} @step(3)
-`},
-
-		{base: `
-step2: {prefix: step1.value} 
-step1: {} @step(1)
-if step2.value > 100 {
-        step2_3: {prefix: step2.value}
-}
-step3: {prefix: step2.value}
-`,
-			expected: `step2: {
-	prefix: 100
-	value:  101
-}
-step1: {
-	value: 100
-} @step(1)
-step2_3: {
-	prefix: 101
-	value:  102
-}
-step3: {
-	prefix: 101
-	value:  103
-}
-`},
 	}
 
 	for _, tCase := range testCases {
-		val, err := NewValue(tCase.base, nil, TagFieldOrder)
+		val, err := NewValue(tCase.base, nil)
 		assert.NilError(t, err)
 		number := 99
 		err = val.StepByFields(func(_ string, in *Value) (bool, error) {
@@ -246,6 +196,135 @@ step3: "3"
 	assert.Equal(t, err != nil, true)
 	assert.Equal(t, inc, 2)
 
+}
+
+func TestStepWithTag(t *testing.T) {
+	testCases := []struct {
+		base     string
+		expected string
+	}{
+		{base: `
+step1: {}
+step2: {prefix: step1.value}
+step3: {prefix: step2.value}
+step4: {prefix: step3.value}
+if step4.value > 100 {
+        step5: "end"
+} 
+`,
+			expected: `step1: {
+	value: 100
+} @step(1)
+step2: {
+	prefix: 100 @step(3)
+	value:  101
+} @step(2)
+step3: {
+	prefix: 101 @step(5)
+	value:  102
+} @step(4)
+step4: {
+	prefix: 102 @step(7)
+	value:  103
+} @step(6)
+step5: "end" @step(8)
+`}, {base: `
+step1: {}
+step2: {prefix: step1.value}
+if step2.value > 100 {
+        step2_3: {prefix: step2.value}
+}
+step3: {prefix: step2.value}
+step4: {prefix: step3.value}
+if step4.value > 100 {
+        step5: "end"
+} 
+`,
+			expected: `step1: {
+	value: 100
+} @step(1)
+step2: {
+	prefix: 100 @step(3)
+	value:  101
+} @step(2)
+step2_3: {
+	prefix: 101 @step(5)
+	value:  102
+} @step(4)
+step3: {
+	prefix: 101 @step(7)
+	value:  103
+} @step(6)
+step4: {
+	prefix: 103 @step(9)
+	value:  104
+} @step(8)
+step5: "end" @step(10)
+`}, {base: `
+step2: {prefix: step1.value} @step(2)
+step1: {} @step(1)
+step3: {prefix: step2.value} @step(4)
+if step2.value > 100 {
+        step2_3: {prefix: step2.value} @step(3)
+}
+`,
+			expected: `step2: {
+	prefix: 100 @step(1)
+	value:  101
+} @step(2)
+step1: {
+	value: 100
+} @step(1)
+step3: {
+	prefix: 101 @step(2)
+	value:  103
+} @step(4)
+step2_3: {
+	prefix: 101 @step(3)
+	value:  102
+} @step(3)
+`},
+
+		{base: `
+step2: {prefix: step1.value} 
+step1: {} @step(-1)
+if step2.value > 100 {
+        step2_3: {prefix: step2.value}
+}
+step3: {prefix: step2.value}
+`,
+			expected: `step2: {
+	prefix: 100 @step(2)
+	value:  101
+} @step(1)
+step1: {
+	value: 100
+} @step(-1)
+step2_3: {
+	prefix: 101 @step(4)
+	value:  102
+} @step(3)
+step3: {
+	prefix: 101 @step(6)
+	value:  103
+} @step(5)
+`}}
+
+	for _, tCase := range testCases {
+		val, err := NewValue(tCase.base, nil, TagFieldOrder)
+		assert.NilError(t, err)
+		number := 99
+		err = val.StepByFields(func(_ string, in *Value) (bool, error) {
+			number++
+			return false, in.FillObject(map[string]interface{}{
+				"value": number,
+			})
+		})
+		assert.NilError(t, err)
+		str, err := val.String()
+		assert.NilError(t, err)
+		assert.Equal(t, str, tCase.expected)
+	}
 }
 
 func TestUnmarshal(t *testing.T) {

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -130,10 +130,60 @@ step3: {
 	value:  103
 }
 `},
+
+		{base: `
+step2: {prefix: step1.value} @step(2)
+step1: {} @step(1)
+step3: {prefix: step2.value} @step(4)
+if step2.value > 100 {
+        step2_3: {prefix: step2.value} @step(3)
+}
+`,
+			expected: `step2: {
+	prefix: 100
+	value:  101
+} @step(2)
+step1: {
+	value: 100
+} @step(1)
+step3: {
+	prefix: 101
+	value:  103
+} @step(4)
+step2_3: {
+	prefix: 101
+	value:  102
+} @step(3)
+`},
+
+		{base: `
+step2: {prefix: step1.value} 
+step1: {} @step(1)
+if step2.value > 100 {
+        step2_3: {prefix: step2.value}
+}
+step3: {prefix: step2.value}
+`,
+			expected: `step2: {
+	prefix: 100
+	value:  101
+}
+step1: {
+	value: 100
+} @step(1)
+step2_3: {
+	prefix: 101
+	value:  102
+}
+step3: {
+	prefix: 101
+	value:  103
+}
+`},
 	}
 
 	for _, tCase := range testCases {
-		val, err := NewValue(tCase.base, nil)
+		val, err := NewValue(tCase.base, nil, TagFieldOrder)
 		assert.NilError(t, err)
 		number := 99
 		err = val.StepByFields(func(_ string, in *Value) (bool, error) {

--- a/pkg/stdlib/op.go
+++ b/pkg/stdlib/op.go
@@ -44,13 +44,13 @@ var (
    _componentName: component
    load: ws.#Load & {
       component: _componentName
-   }
+   } @step(1)
    
    workload: workload__.value
    workload__: kube.#Apply & {
       value: load.value.workload
       ...
-   }
+   } @step(2)
     
    applyTraits__: #Steps & {
       for index,o in load.value.auxiliaries {
@@ -58,7 +58,7 @@ var (
                value: o
           }
       }
-   }
+   } @step(3)
 }
 
 #ApplyRemaining: #Steps & {
@@ -77,7 +77,7 @@ var (
       skipApplyTraits: [...string]
   }
 
-  components: ws.#Load
+  components: ws.#Load @step(1)
   #up__: [for name,c in components.value {
         #Steps 
         if exceptions[name] != _|_ {
@@ -102,7 +102,7 @@ var (
 				
         }
      }
-  ]
+  ] @step(2)
 }
 
 #Load: ws.#Load

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -168,7 +168,7 @@ func (t *TaskLoader) makeValue(ctx wfContext.Context, templ string) (*value.Valu
 		}
 		templ += fmt.Sprintf("\ncontext: {%s}", ms)
 	}
-	return value.NewValue(templ, t.pd)
+	return value.NewValue(templ, t.pd, value.TagFieldOrder)
 }
 
 type executor struct {

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -317,8 +317,8 @@ process: {
   err: {
     #provider: "test"
 	#do: "error"
-  }
-  #up: [{},process]
+  } @step(1)
+  #up: [{},process] @step(2)
 }]
 `,
 			expected: "okok",


### PR DESCRIPTION
1. Set the taskStep execution order by tag.
2. Automatically generate order tags for workflowStep definition 
```
#ApplyComponent: #Steps & {
   component: string
   _componentName: component
   load: ws.#Load & {
      component: _componentName
   } @step(1)
   
   workload: workload__.value
   workload__: kube.#Apply & {
      value: load.value.workload
      ...
   } @step(2)
}
```