### PR TITLE
definitions support specify the revision name

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller.go
@@ -62,8 +62,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	ctx, cancel := common2.NewReconcileContext(ctx)
 	defer cancel()
 
-	componentDefinition := new(v1beta1.ComponentDefinition)
-	if err := r.Get(ctx, req.NamespacedName, componentDefinition); err != nil {
+	var componentDefinition v1beta1.ComponentDefinition
+	if err := r.Get(ctx, req.NamespacedName, &componentDefinition); err != nil {
 		if apierrors.IsNotFound(err) {
 			err = nil
 		}
@@ -77,29 +77,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// refresh package discover when componentDefinition is registered
 	if componentDefinition.Spec.Workload.Type != types.AutoDetectWorkloadDefinition {
-		err := utils.RefreshPackageDiscover(ctx, r.Client, r.dm, r.pd, componentDefinition)
+		err := utils.RefreshPackageDiscover(ctx, r.Client, r.dm, r.pd, &componentDefinition)
 		if err != nil {
 			klog.InfoS("Could not discover the open api of the CRD", "err", err)
-			r.record.Event(componentDefinition, event.Warning("Could not discover the open api of the CRD", err))
-			return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, componentDefinition,
+			r.record.Event(&componentDefinition, event.Warning("Could not discover the open api of the CRD", err))
+			return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &componentDefinition,
 				condition.ReconcileError(fmt.Errorf(util.ErrRefreshPackageDiscover, err)))
 		}
 	}
 
 	// generate DefinitionRevision from componentDefinition
-	defRev, isNewRevision, err := coredef.GenerateDefinitionRevision(ctx, r.Client, componentDefinition)
+	defRev, isNewRevision, err := coredef.GenerateDefinitionRevision(ctx, r.Client, &componentDefinition)
 	if err != nil {
-		klog.InfoS("Could not generate DefinitionRevision", "componentDefinition", klog.KObj(componentDefinition), "err", err)
-		r.record.Event(componentDefinition, event.Warning("Could not generate DefinitionRevision", err))
-		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, componentDefinition,
+		klog.InfoS("Could not generate DefinitionRevision", "componentDefinition", klog.KObj(&componentDefinition), "err", err)
+		r.record.Event(&componentDefinition, event.Warning("Could not generate DefinitionRevision", err))
+		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &componentDefinition,
 			condition.ReconcileError(fmt.Errorf(util.ErrGenerateDefinitionRevision, componentDefinition.Name, err)))
 	}
 
 	if isNewRevision {
-		if err := r.createComponentDefRevision(ctx, componentDefinition, defRev.DeepCopy()); err != nil {
+		if err := r.createComponentDefRevision(ctx, &componentDefinition, defRev.DeepCopy()); err != nil {
 			klog.InfoS("Could not create DefinitionRevision", "err", err)
-			r.record.Event(componentDefinition, event.Warning("cannot create DefinitionRevision", err))
-			return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, componentDefinition,
+			r.record.Event(&componentDefinition, event.Warning("cannot create DefinitionRevision", err))
+			return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &componentDefinition,
 				condition.ReconcileError(fmt.Errorf(util.ErrCreateDefinitionRevision, defRev.Name, err)))
 		}
 		klog.InfoS("Successfully create definitionRevision", "definitionRevision", klog.KObj(defRev))
@@ -111,37 +111,33 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		RevisionHash: defRev.Spec.RevisionHash,
 	}
 
-	if err := r.UpdateStatus(ctx, componentDefinition); err != nil {
+	if err := r.UpdateStatus(ctx, &componentDefinition); err != nil {
 		klog.InfoS("Could not update componentDefinition Status", "err", err)
-		r.record.Event(componentDefinition, event.Warning("cannot update ComponentDefinition Status", err))
-		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, componentDefinition,
+		r.record.Event(&componentDefinition, event.Warning("cannot update ComponentDefinition Status", err))
+		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &componentDefinition,
 			condition.ReconcileError(fmt.Errorf(util.ErrUpdateComponentDefinition, componentDefinition.Name, err)))
 	}
 
-	if err := coredef.CleanUpDefinitionRevision(ctx, r.Client, componentDefinition, r.defRevLimit); err != nil {
+	if err := coredef.CleanUpDefinitionRevision(ctx, r.Client, &componentDefinition, r.defRevLimit); err != nil {
 		klog.InfoS("Failed to collect garbage", "err", err)
-		r.record.Event(componentDefinition, event.Warning("failed to garbage collect DefinitionRevision of type ComponentDefinition", err))
+		r.record.Event(&componentDefinition, event.Warning("failed to garbage collect DefinitionRevision of type ComponentDefinition", err))
 	}
 
-	if !isNewRevision && componentDefinition.Status.ConfigMapRef == defRev.Name {
-		return ctrl.Result{}, nil
-	}
-
-	def := utils.NewCapabilityComponentDef(componentDefinition)
+	def := utils.NewCapabilityComponentDef(&componentDefinition)
 	// Store the parameter of componentDefinition to configMap
 	cmName, err := def.StoreOpenAPISchema(ctx, r.Client, r.pd, req.Namespace, req.Name, defRev.Name)
 	if err != nil {
 		klog.InfoS("Could not capability in ConfigMap", "err", err)
-		r.record.Event(componentDefinition, event.Warning("Could not store capability in ConfigMap", err))
-		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, componentDefinition,
+		r.record.Event(&(componentDefinition), event.Warning("Could not store capability in ConfigMap", err))
+		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &(componentDefinition),
 			condition.ReconcileError(fmt.Errorf(util.ErrStoreCapabilityInConfigMap, def.Name, err)))
 	}
 
 	componentDefinition.Status.ConfigMapRef = cmName
-	if err := r.UpdateStatus(ctx, componentDefinition); err != nil {
+	if err := r.UpdateStatus(ctx, &componentDefinition); err != nil {
 		klog.InfoS("Could not update componentDefinition Status", "err", err)
-		r.record.Event(componentDefinition, event.Warning("cannot update ComponentDefinition Status", err))
-		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, componentDefinition,
+		r.record.Event(&componentDefinition, event.Warning("cannot update ComponentDefinition Status", err))
+		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &componentDefinition,
 			condition.ReconcileError(fmt.Errorf(util.ErrUpdateComponentDefinition, componentDefinition.Name, err)))
 	}
 	klog.Info("Successfully stored Capability Schema in ConfigMap", "configMap", klog.KRef(componentDefinition.Namespace, cmName))

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componetrevision_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componetrevision_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/oam-dev/kubevela/pkg/oam/testutil"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +34,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	coredef "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/core"
 	"github.com/oam-dev/kubevela/pkg/oam"
+	"github.com/oam-dev/kubevela/pkg/oam/testutil"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
@@ -289,6 +289,178 @@ var _ = Describe("Test DefinitionRevision created by ComponentDefinition", func(
 			}, 10*time.Second, time.Second).Should(BeNil())
 
 			deleteRevKey = types.NamespacedName{Namespace: namespace, Name: cdName + "-v2"}
+			Eventually(func() error {
+				err := k8sClient.List(ctx, defRevList, listOpts...)
+				if err != nil {
+					return err
+				}
+				if len(defRevList.Items) != defRevisionLimit+1 {
+					return fmt.Errorf("error defRevison number wants %d, actually %d", defRevisionLimit+1, len(defRevList.Items))
+				}
+				err = k8sClient.Get(ctx, deleteRevKey, deletedRevision)
+				if err == nil || !apierrors.IsNotFound(err) {
+					return fmt.Errorf("haven't clean up the oldest revision")
+				}
+				return nil
+			}, time.Second*30, time.Microsecond*300).Should(BeNil())
+		})
+
+		It("Test clean up definitionRevision contains definitionRevision with custom name", func() {
+			var revKey client.ObjectKey
+			var defRev v1beta1.DefinitionRevision
+			revisionNames := []string{"1.3.1", "", "1.3.3", "", "prod"}
+			cdName := "test-cd-with-specify-revision"
+			revisionNum := 1
+			defKey := client.ObjectKey{Namespace: namespace, Name: cdName}
+			req := reconcile.Request{NamespacedName: defKey}
+
+			By("create a new componentDefinition")
+			cd := cdWithNoTemplate.DeepCopy()
+			cd.Name = cdName
+			cd.Spec.Schematic.CUE.Template = fmt.Sprintf(cdTemplate, fmt.Sprintf("test-v%d", revisionNum))
+			Expect(k8sClient.Create(ctx, cd)).Should(BeNil())
+			testutil.ReconcileRetry(&r, req)
+			revKey = client.ObjectKey{Namespace: namespace, Name: fmt.Sprintf("%s-v%d", cdName, revisionNum)}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, revKey, &defRev)
+			}, 10*time.Second, time.Second).Should(BeNil())
+			Expect(defRev.Spec.Revision).Should(Equal(int64(revisionNum)))
+
+			By("update componentDefinition")
+			for _, revisionName := range revisionNames {
+				revisionNum++
+				Eventually(func() error {
+					oldComp := cd.DeepCopy()
+					err := k8sClient.Get(ctx, defKey, oldComp)
+					if err != nil {
+						return err
+					}
+					oldComp.SetAnnotations(map[string]string{
+						oam.AnnotationDefinitionRevisionName: revisionName,
+					})
+					oldComp.Spec.Schematic.CUE.Template = fmt.Sprintf(cdTemplate, fmt.Sprintf("test-v%d", revisionNum))
+					return k8sClient.Update(ctx, oldComp)
+				}, 10*time.Second, time.Second).Should(BeNil())
+
+				Eventually(func() error {
+					testutil.ReconcileOnce(&r, req)
+					newCd := new(v1beta1.ComponentDefinition)
+					err := k8sClient.Get(ctx, req.NamespacedName, newCd)
+					if err != nil {
+						return err
+					}
+					if newCd.Status.LatestRevision.Revision != int64(revisionNum) {
+						return fmt.Errorf("fail to update status")
+					}
+					return nil
+				}, 15*time.Second, time.Second)
+
+				if len(revisionName) == 0 {
+					revKey = client.ObjectKey{Namespace: namespace, Name: fmt.Sprintf("%s-v%d", cdName, revisionNum)}
+				} else {
+					revKey = client.ObjectKey{Namespace: namespace, Name: fmt.Sprintf("%s-v%s", cdName, revisionName)}
+				}
+
+				By("check the definitionRevision is created by controller")
+				var defRev v1beta1.DefinitionRevision
+				Eventually(func() error {
+					return k8sClient.Get(ctx, revKey, &defRev)
+				}, 10*time.Second, time.Second).Should(BeNil())
+
+				Expect(defRev.Spec.Revision).Should(Equal(int64(revisionNum)))
+			}
+
+			By("create new componentDefinition will remove oldest definitionRevision")
+			revisionNum++
+			Eventually(func() error {
+				oldComp := cd.DeepCopy()
+				err := k8sClient.Get(ctx, defKey, oldComp)
+				if err != nil {
+					return err
+				}
+				oldComp.SetAnnotations(map[string]string{
+					oam.AnnotationDefinitionRevisionName: "test",
+				})
+				oldComp.Spec.Schematic.CUE.Template = fmt.Sprintf(cdTemplate, "test-vtest")
+				return k8sClient.Update(ctx, oldComp)
+			}, 10*time.Second, time.Second).Should(BeNil())
+
+			Eventually(func() error {
+				testutil.ReconcileOnce(&r, req)
+				newCd := new(v1beta1.ComponentDefinition)
+				err := k8sClient.Get(ctx, req.NamespacedName, newCd)
+				if err != nil {
+					return err
+				}
+				if newCd.Status.LatestRevision.Revision != int64(revisionNum) {
+					return fmt.Errorf("fail to update status")
+				}
+				return nil
+			}, 15*time.Second, time.Second)
+
+			revKey = client.ObjectKey{Namespace: namespace, Name: fmt.Sprintf("%s-v%s", cdName, "test")}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, revKey, &defRev)
+			}, 10*time.Second, time.Second).Should(BeNil())
+
+			deletedRevision := new(v1beta1.DefinitionRevision)
+			deleteRevKey := types.NamespacedName{Namespace: namespace, Name: cdName + "-v1"}
+			listOpts := []client.ListOption{
+				client.InNamespace(namespace),
+				client.MatchingLabels{
+					oam.LabelComponentDefinitionName: cdName,
+				},
+			}
+			defRevList := new(v1beta1.DefinitionRevisionList)
+			Eventually(func() error {
+				err := k8sClient.List(ctx, defRevList, listOpts...)
+				if err != nil {
+					return err
+				}
+				if len(defRevList.Items) != defRevisionLimit+1 {
+					return fmt.Errorf("error defRevison number wants %d, actually %d", defRevisionLimit+1, len(defRevList.Items))
+				}
+				err = k8sClient.Get(ctx, deleteRevKey, deletedRevision)
+				if err == nil || !apierrors.IsNotFound(err) {
+					return fmt.Errorf("haven't clean up the oldest revision")
+				}
+				return nil
+			}, time.Second*30, time.Microsecond*300).Should(BeNil())
+
+			By("update app again will continue to delete the oldest revision")
+			revisionNum++
+			Eventually(func() error {
+				oldComp := cd.DeepCopy()
+				err := k8sClient.Get(ctx, defKey, oldComp)
+				if err != nil {
+					return err
+				}
+				oldComp.SetAnnotations(map[string]string{
+					oam.AnnotationDefinitionRevisionName: "",
+				})
+				oldComp.Spec.Schematic.CUE.Template = fmt.Sprintf(cdTemplate, fmt.Sprintf("test-v%d", revisionNum))
+				return k8sClient.Update(ctx, oldComp)
+			}, 10*time.Second, time.Second).Should(BeNil())
+
+			Eventually(func() error {
+				testutil.ReconcileOnce(&r, req)
+				newCd := new(v1beta1.ComponentDefinition)
+				err := k8sClient.Get(ctx, req.NamespacedName, newCd)
+				if err != nil {
+					return err
+				}
+				if newCd.Status.LatestRevision.Revision != int64(revisionNum) {
+					return fmt.Errorf("fail to update status")
+				}
+				return nil
+			}, 15*time.Second, time.Second)
+
+			revKey = client.ObjectKey{Namespace: namespace, Name: fmt.Sprintf("%s-v%d", cdName, revisionNum)}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, revKey, &defRev)
+			}, 10*time.Second, time.Second).Should(BeNil())
+
+			deleteRevKey = types.NamespacedName{Namespace: namespace, Name: cdName + "-v1.3.1"}
 			Eventually(func() error {
 				err := k8sClient.List(ctx, defRevList, listOpts...)
 				if err != nil {

--- a/pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition/policydefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition/policydefinition_controller.go
@@ -133,12 +133,14 @@ func (r *Reconciler) createPolicyDefRevision(ctx context.Context, def *v1beta1.P
 	defRev.SetLabels(util.MergeMapOverrideWithDst(defRev.Labels,
 		map[string]string{oam.LabelPolicyDefinitionName: def.Name}))
 	defRev.SetNamespace(namespace)
-	defRev.SetAnnotations(def.GetAnnotations())
 
 	rev := &v1beta1.DefinitionRevision{}
 	err := r.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: defRev.Name}, rev)
 	if apierrors.IsNotFound(err) {
-		return r.Create(ctx, defRev)
+		err = r.Create(ctx, defRev)
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
 	}
 	return err
 }

--- a/pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition/policydefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition/policydefinition_controller.go
@@ -24,11 +24,9 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -97,29 +95,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &policydefinition,
 			condition.ReconcileError(fmt.Errorf(util.ErrGenerateDefinitionRevision, policydefinition.Name, err)))
 	}
-	if !isNewRevision {
-		if err = r.createOrUpdatePolicyDefRevision(ctx, req.Namespace, &policydefinition, defRev); err != nil {
-			klog.ErrorS(err, "cannot update DefinitionRevision")
-			r.record.Event(&(policydefinition), event.Warning("cannot update DefinitionRevision", err))
+
+	if isNewRevision {
+		if err = r.createPolicyDefRevision(ctx, &policydefinition, defRev); err != nil {
+			klog.ErrorS(err, "cannot create DefinitionRevision")
+			r.record.Event(&(policydefinition), event.Warning("cannot create DefinitionRevision", err))
 			return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &(policydefinition),
-				condition.ReconcileError(fmt.Errorf(util.ErrCreateOrUpdateDefinitionRevision, defRev.Name, err)))
+				condition.ReconcileError(fmt.Errorf(util.ErrCreateDefinitionRevision, defRev.Name, err)))
 		}
-		klog.InfoS("Successfully update DefinitionRevision", "name", defRev.Name)
-
-		if err := coredef.CleanUpDefinitionRevision(ctx, r.Client, &policydefinition, r.defRevLimit); err != nil {
-			klog.Error("[Garbage collection]")
-			r.record.Event(&policydefinition, event.Warning("failed to garbage collect DefinitionRevision of type PolicyDefinition", err))
-		}
-		return ctrl.Result{}, nil
+		klog.InfoS("Successfully create PolicyDefRevision", "name", defRev.Name)
 	}
-
-	if err = r.createOrUpdatePolicyDefRevision(ctx, req.Namespace, &policydefinition, defRev); err != nil {
-		klog.ErrorS(err, "cannot create DefinitionRevision")
-		r.record.Event(&(policydefinition), event.Warning("cannot create DefinitionRevision", err))
-		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &(policydefinition),
-			condition.ReconcileError(fmt.Errorf(util.ErrCreateOrUpdateDefinitionRevision, defRev.Name, err)))
-	}
-	klog.InfoS("Successfully createOrUpdatePolicyDefRevision", "name", defRev.Name)
 
 	policydefinition.Status.LatestRevision = &common.Revision{
 		Name:         defRev.Name,
@@ -142,37 +127,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) createOrUpdatePolicyDefRevision(ctx context.Context, ns string,
-	def *v1beta1.PolicyDefinition, defRev *v1beta1.DefinitionRevision) error {
-
-	ownerReference := []metav1.OwnerReference{{
-		APIVersion:         def.APIVersion,
-		Kind:               def.Kind,
-		Name:               def.Name,
-		UID:                def.GetUID(),
-		Controller:         pointer.BoolPtr(true),
-		BlockOwnerDeletion: pointer.BoolPtr(true),
-	}}
-
+func (r *Reconciler) createPolicyDefRevision(ctx context.Context, def *v1beta1.PolicyDefinition, defRev *v1beta1.DefinitionRevision) error {
+	namespace := def.GetNamespace()
 	defRev.SetLabels(def.GetLabels())
 	defRev.SetLabels(util.MergeMapOverrideWithDst(defRev.Labels,
 		map[string]string{oam.LabelPolicyDefinitionName: def.Name}))
-	defRev.SetNamespace(ns)
+	defRev.SetNamespace(namespace)
 	defRev.SetAnnotations(def.GetAnnotations())
-	defRev.SetOwnerReferences(ownerReference)
 
 	rev := &v1beta1.DefinitionRevision{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: ns, Name: defRev.Name}, rev); err != nil {
-		if apierrors.IsNotFound(err) {
-			return r.Create(ctx, defRev)
-		}
-		return err
+	err := r.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: defRev.Name}, rev)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, defRev)
 	}
-
-	rev.SetAnnotations(defRev.GetAnnotations())
-	rev.SetLabels(defRev.GetLabels())
-	rev.SetOwnerReferences(ownerReference)
-	return r.Update(ctx, rev)
+	return err
 }
 
 // UpdateStatus updates v1beta1.PolicyDefinition's Status with retry.RetryOnConflict

--- a/pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition/workflowstepdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition/workflowstepdefinition_controller.go
@@ -136,7 +136,10 @@ func (r *Reconciler) createWFStepDefRevision(ctx context.Context, def *v1beta1.W
 	rev := &v1beta1.DefinitionRevision{}
 	err := r.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: defRev.Name}, rev)
 	if apierrors.IsNotFound(err) {
-		return r.Create(ctx, defRev)
+		err = r.Create(ctx, defRev)
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
 	}
 	return err
 }

--- a/pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition/workflowstepdefinition_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition/workflowstepdefinition_controller.go
@@ -24,11 +24,9 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -97,29 +95,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			condition.ReconcileError(fmt.Errorf(util.ErrGenerateDefinitionRevision, wfstepdefinition.Name, err)))
 	}
 
-	if !isNewRevision {
-		if err = r.createOrUpdateWFStepDefRevision(ctx, req.Namespace, &wfstepdefinition, defRev); err != nil {
-			klog.ErrorS(err, "cannot update DefinitionRevision")
-			r.record.Event(&(wfstepdefinition), event.Warning("cannot update DefinitionRevision", err))
+	if isNewRevision {
+		if err = r.createWFStepDefRevision(ctx, &wfstepdefinition, defRev); err != nil {
+			klog.ErrorS(err, "cannot create DefinitionRevision")
+			r.record.Event(&(wfstepdefinition), event.Warning("cannot create DefinitionRevision", err))
 			return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &(wfstepdefinition),
-				condition.ReconcileError(fmt.Errorf(util.ErrCreateOrUpdateDefinitionRevision, defRev.Name, err)))
+				condition.ReconcileError(fmt.Errorf(util.ErrCreateDefinitionRevision, defRev.Name, err)))
 		}
-		klog.InfoS("Successfully update DefinitionRevision", "name", defRev.Name)
-
-		if err := coredef.CleanUpDefinitionRevision(ctx, r.Client, &wfstepdefinition, r.defRevLimit); err != nil {
-			klog.Error("[Garbage collection]")
-			r.record.Event(&wfstepdefinition, event.Warning("failed to garbage collect DefinitionRevision of type WorkflowStepDefinition", err))
-		}
-		return ctrl.Result{}, nil
+		klog.InfoS("Successfully create WFStepDefRevision", "name", defRev.Name)
 	}
-
-	if err = r.createOrUpdateWFStepDefRevision(ctx, req.Namespace, &wfstepdefinition, defRev); err != nil {
-		klog.ErrorS(err, "cannot create DefinitionRevision")
-		r.record.Event(&(wfstepdefinition), event.Warning("cannot create DefinitionRevision", err))
-		return ctrl.Result{}, util.EndReconcileWithNegativeCondition(ctx, r, &(wfstepdefinition),
-			condition.ReconcileError(fmt.Errorf(util.ErrCreateOrUpdateDefinitionRevision, defRev.Name, err)))
-	}
-	klog.InfoS("Successfully createOrUpdateWFStepDefRevision", "name", defRev.Name)
 
 	wfstepdefinition.Status.LatestRevision = &common.Revision{
 		Name:         defRev.Name,
@@ -142,37 +126,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) createOrUpdateWFStepDefRevision(ctx context.Context, ns string,
-	def *v1beta1.WorkflowStepDefinition, defRev *v1beta1.DefinitionRevision) error {
-
-	ownerReference := []metav1.OwnerReference{{
-		APIVersion:         def.APIVersion,
-		Kind:               def.Kind,
-		Name:               def.Name,
-		UID:                def.GetUID(),
-		Controller:         pointer.BoolPtr(true),
-		BlockOwnerDeletion: pointer.BoolPtr(true),
-	}}
-
+func (r *Reconciler) createWFStepDefRevision(ctx context.Context, def *v1beta1.WorkflowStepDefinition, defRev *v1beta1.DefinitionRevision) error {
+	namespace := def.GetNamespace()
 	defRev.SetLabels(def.GetLabels())
 	defRev.SetLabels(util.MergeMapOverrideWithDst(defRev.Labels,
 		map[string]string{oam.LabelWorkflowStepDefinitionName: def.Name}))
-	defRev.SetNamespace(ns)
-	defRev.SetAnnotations(def.GetAnnotations())
-	defRev.SetOwnerReferences(ownerReference)
+	defRev.SetNamespace(namespace)
 
 	rev := &v1beta1.DefinitionRevision{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: ns, Name: defRev.Name}, rev); err != nil {
-		if apierrors.IsNotFound(err) {
-			return r.Create(ctx, defRev)
-		}
-		return err
+	err := r.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: defRev.Name}, rev)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, defRev)
 	}
-
-	rev.SetAnnotations(defRev.GetAnnotations())
-	rev.SetLabels(defRev.GetLabels())
-	rev.SetOwnerReferences(ownerReference)
-	return r.Update(ctx, rev)
+	return err
 }
 
 // UpdateStatus updates v1beta1.WorkflowStepDefinition's Status with retry.RetryOnConflict

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -34,7 +34,7 @@ const (
 	// LabelAppRevisionHash records the Hash value of the application revision
 	LabelAppRevisionHash = "app.oam.dev/app-revision-hash"
 	// LabelAppNamespace records the namespace of Application
-	LabelAppNamespace = "app.oam.dev/namesapce"
+	LabelAppNamespace = "app.oam.dev/namespace"
 
 	// WorkloadTypeLabel indicates the type of the workloadDefinition
 	WorkloadTypeLabel = "workload.oam.dev/type"
@@ -111,4 +111,7 @@ const (
 
 	// AnnotationSkipGC is used to tell application to skip gc workload/trait
 	AnnotationSkipGC = "app.oam.dev/skipGC"
+
+	// AnnotationDefinitionRevisionName is used to specify the name of DefinitionRevision in component/trait definition
+	AnnotationDefinitionRevisionName = "definitionrevision.oam.dev/name"
 )

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -2227,38 +2227,29 @@ func TestExtractDefinitionRevName(t *testing.T) {
 	testcases := []struct {
 		defName     string
 		wantRevName string
-		hasError    bool
 	}{{
 		defName:     "worker@v2",
 		wantRevName: "worker-v2",
-		hasError:    false,
 	}, {
 		defName:     "worker@v10",
 		wantRevName: "worker-v10",
-		hasError:    false,
 	}, {
 		defName:     "worker",
 		wantRevName: "",
-		hasError:    true,
 	}, {
 		defName:     "webservice@@v2",
 		wantRevName: "webservice@-v2",
-		hasError:    false,
 	}, {
 		defName:     "webservice@v10@v3",
 		wantRevName: "webservice@v10-v3",
-		hasError:    false,
 	}, {
 		defName:     "@v10",
 		wantRevName: "",
-		hasError:    true,
 	}}
 
 	for _, tt := range testcases {
-		revName, err := util.ConvertDefinitionRevName(tt.defName)
-		hasError := err != nil
+		revName := util.ConvertDefinitionRevName(tt.defName)
 		assert.Equal(t, tt.wantRevName, revName)
-		assert.Equal(t, tt.hasError, hasError)
 	}
 }
 

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -2223,33 +2223,40 @@ func TestExtractRevisionNum(t *testing.T) {
 	}
 }
 
-func TestExtractDefinitionRevName(t *testing.T) {
+func TestConvertDefinitionRevName(t *testing.T) {
 	testcases := []struct {
 		defName     string
 		wantRevName string
+		hasError    bool
 	}{{
 		defName:     "worker@v2",
 		wantRevName: "worker-v2",
+		hasError:    false,
 	}, {
 		defName:     "worker@v10",
 		wantRevName: "worker-v10",
+		hasError:    false,
 	}, {
 		defName:     "worker",
-		wantRevName: "",
+		wantRevName: "worker",
+		hasError:    false,
 	}, {
-		defName:     "webservice@@v2",
-		wantRevName: "webservice@-v2",
+		defName:  "webservice@@v2",
+		hasError: true,
 	}, {
-		defName:     "webservice@v10@v3",
-		wantRevName: "webservice@v10-v3",
+		defName:  "webservice@v10@v3",
+		hasError: true,
 	}, {
-		defName:     "@v10",
-		wantRevName: "",
+		defName:  "@v10",
+		hasError: true,
 	}}
 
 	for _, tt := range testcases {
-		revName := util.ConvertDefinitionRevName(tt.defName)
-		assert.Equal(t, tt.wantRevName, revName)
+		revName, err := util.ConvertDefinitionRevName(tt.defName)
+		assert.Equal(t, tt.hasError, err != nil)
+		if !tt.hasError {
+			assert.Equal(t, tt.wantRevName, revName)
+		}
 	}
 }
 

--- a/pkg/webhook/core.oam.dev/v1alpha2/traitdefinition/validating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/traitdefinition/validating_handler.go
@@ -33,7 +33,9 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/appfile"
 	controller "github.com/oam-dev/kubevela/pkg/controller/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
+	webhookutils "github.com/oam-dev/kubevela/pkg/webhook/utils"
 )
 
 const (
@@ -86,6 +88,14 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 		for _, validator := range h.Validators {
 			if err := validator.Validate(ctx, *obj); err != nil {
 				klog.Info("validation failed ", " name: ", obj.Name, " errMsgi: ", err.Error())
+				return admission.Denied(err.Error())
+			}
+		}
+		revisionName := obj.GetAnnotations()[oam.AnnotationDefinitionRevisionName]
+		if len(revisionName) != 0 {
+			defRevName := fmt.Sprintf("%s-v%s", obj.Name, revisionName)
+			err = webhookutils.ValidateDefinitionRevision(ctx, h.Client, obj, client.ObjectKey{Namespace: obj.Namespace, Name: defRevName})
+			if err != nil {
 				return admission.Denied(err.Error())
 			}
 		}

--- a/pkg/webhook/utils/utils.go
+++ b/pkg/webhook/utils/utils.go
@@ -1,0 +1,55 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/core"
+)
+
+// ValidateDefinitionRevision validate whether definition will modify the immutable object definitionRevision
+func ValidateDefinitionRevision(ctx context.Context, cli client.Client, def runtime.Object, defRevNamespacedName types.NamespacedName) error {
+	if errs := validation.IsQualifiedName(defRevNamespacedName.Name); len(errs) != 0 {
+		return errors.Errorf("invalid definitionRevision name %s:%s", defRevNamespacedName.Name, strings.Join(errs, ","))
+	}
+
+	defRev := new(v1beta1.DefinitionRevision)
+	if err := cli.Get(ctx, defRevNamespacedName, defRev); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	newRev, _, err := core.GatherRevisionInfo(def)
+	if err != nil {
+		return err
+	}
+	if defRev.Spec.RevisionHash != newRev.Spec.RevisionHash {
+		return errors.New("the definition's spec is different with existing definitionRevision's spec")
+	}
+	if !core.DeepEqualDefRevision(defRev, newRev) {
+		return errors.New("the definition's spec is different with existing definitionRevision's spec")
+	}
+	return nil
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Everytime you update the spec of deifnitions, KubeVela will automatic generated definitionRevision with name in
in the format of `definitionName@revisionNum`.  

Now, this PR supports you specify the revision name in annotation `definitionrevision.oam.dev/name`

```yaml
#worker.yaml
apiVersion: core.oam.dev/v1beta1
kind: ComponentDefinition
metadata:
  name: worker
  namespace: vela-system
  annotations:
    definition.oam.dev/description: "Describes long-running, scalable, containerized services that running at backend. They do NOT have network endpoint to receive external network traffic."
    # you can specify the revision name in annotations
    definitionrevision.oam.dev/name: "1.1.3"
spec:
  workload:
    definition:
      apiVersion: apps/v1
      kind: Deployment
  schematic:
    cue:
      template: |
        output: {
        	apiVersion: "apps/v1"
        	kind:       "Deployment"
        	spec: {
        		selector: matchLabels: {
        			"app.oam.dev/component": context.name
        		}

        		template: {
        			metadata: labels: {
        				"app.oam.dev/component": context.name
        			}
         ..........
```

```shell
kubectl apply -f worker.yaml
```

after apply the `worker` definition, KubeVela will create a definitionRevision named `worker-v1.1.3`

```shell
$ kubectl get definitionrevisions.core.oam.dev -A
NAMESPACE            NAME                                 REVISION   HASH               TYPE
vela-system          worker-v1.1.3                        1          a6d925a57ba3c297   Component
```

then you can specify the target componentDeifnition in your application

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: first-vela-appvprod
  namespace: default
spec:
  components:
    - name: test
      properties:
        image: crccheck/hello-world
      type: worker@v1.1.3
```

- [x] support named defRev
- [x] add test
