### PR TITLE
fix def init bug

### DIFF
--- a/design/vela-cli/def.md
+++ b/design/vela-cli/def.md
@@ -96,7 +96,10 @@ The first part `labels: {...}` expresses the basic information of the definition
         labels: {}
         type: "trait"
 }
-template: patch: {}
+template: {
+        patch: {}
+        parameter: {}
+}
 ```
 
 Or you can use `vela def init my-comp --interactive` to initiate definitions interactively.
@@ -203,7 +206,7 @@ template: {
                 apiVersion: "v1"
                 kind:       "Service"
         }
-        parameters: {}
+        parameter: {}
 
 }
 ```
@@ -272,7 +275,7 @@ spec:
                 apiVersion: "v1"
                 kind:       "Service"
         }
-        parameters: {}
+        parameter: {}
   workload:
     definition:
       apiVersion: apps/v1

--- a/design/vela-cli/def_zh.md
+++ b/design/vela-cli/def_zh.md
@@ -96,7 +96,10 @@ template: {
         labels: {}
         type: "trait"
 }
-template: patch: {}
+template: {
+        patch: {}
+        parameter: {}
+}
 ```
 
 或者是采用 `vela def init my-comp --interactive` 来交互式地创建新的 Definition 。
@@ -203,7 +206,7 @@ template: {
                 apiVersion: "v1"
                 kind:       "Service"
         }
-        parameters: {}
+        parameter: {}
 
 }
 ```
@@ -272,7 +275,7 @@ spec:
                 apiVersion: "v1"
                 kind:       "Service"
         }
-        parameters: {}
+        parameter: {}
   workload:
     definition:
       apiVersion: apps/v1

--- a/references/common/definition.go
+++ b/references/common/definition.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	velacue "github.com/oam-dev/kubevela/pkg/cue"
 	"github.com/oam-dev/kubevela/pkg/cue/model/sets"
 )
 
@@ -285,7 +286,7 @@ func (def *Definition) FromCUEString(cueString string) error {
 	if err != nil {
 		return err
 	}
-	if _, err = r.Compile("-", templateString+"\ncontext: [string]: string"); err != nil {
+	if _, err = r.Compile("-", templateString+"\n"+velacue.BaseTemplate); err != nil {
 		return err
 	}
 	val := inst.Value()
@@ -353,7 +354,7 @@ func GetDefinitionDefaultSpec(kind string) map[string]interface{} {
 			},
 			"schematic": map[string]interface{}{
 				"cue": map[string]interface{}{
-					"template": "output: {}\nparameters: {}\n",
+					"template": "output: {}\nparameter: {}\n",
 				},
 			},
 		}
@@ -366,7 +367,7 @@ func GetDefinitionDefaultSpec(kind string) map[string]interface{} {
 			"podDisruptive":      false,
 			"schematic": map[string]interface{}{
 				"cue": map[string]interface{}{
-					"template": "patch: {}\n",
+					"template": "patch: {}\nparameter: {}\n",
 				},
 			},
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Previous `vela def init` generate definition templates with wrong variable `parameters` instead of `parameter`. This PR fixes it.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

