### PR TITLE
fix definition controller log error cause by openapi schema generation error

### DIFF
--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -152,7 +152,7 @@ func GenOpenAPI(inst *cue.Instance) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-// extractParameterDefinitionNodeFromInstance extracts the `#parameter` ast.Node from root instance, if failed fall back to `parameter`
+// extractParameterDefinitionNodeFromInstance extracts the `#parameter` ast.Node from root instance, if failed fall back to `parameter` by LookUpDef
 func extractParameterDefinitionNodeFromInstance(inst *cue.Instance) ast.Node {
 	opts := []cue.Option{cue.All(), cue.DisallowCycles(true), cue.ResolveReferences(true), cue.Docs(true)}
 	node := inst.Value().Syntax(opts...)

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -152,6 +152,7 @@ func GenOpenAPI(inst *cue.Instance) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
+// extractParameterDefinitionNodeFromInstance extracts the `#parameter` ast.Node from root instance, if failed fall back to `parameter`
 func extractParameterDefinitionNodeFromInstance(inst *cue.Instance) ast.Node {
 	opts := []cue.Option{cue.All(), cue.DisallowCycles(true), cue.ResolveReferences(true), cue.Docs(true)}
 	node := inst.Value().Syntax(opts...)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

As discussed in #1939, the reason for the error reported in TraitController and ComponentController is due to a failure encountered while generating OpenAPI v3 schema. The real reason behind it is because we want only `parameter` field in template to generate schema, as mentioned in [#1773](https://github.com/oam-dev/kubevela/issues/1773) and fixed by [#1970](https://github.com/oam-dev/kubevela/pull/1790). 

To realize that, #1790 uses `inst.LookupDef` to extract `cue.Value` of field `parameter`, converting it into cue string, and then transforming it back to `cue.Instance`, which is needed for generating OpenAPI schema. Due to the improper implementation in cue v0.2.2 which we use, when getting `ast.Node` from `cue.Instance`, the IfClause and some other syntax are transformed with a wrap of the `close()` function for definitions, which leads to invalid cue string generated. Therefore, the back transformation fails and lead to the error we encountered in the log.

The solution here is mainly implemented by two workarounds.
1. Instead of using the `parameter` field which is paraphrased by `parameter: #parameter\n#parameter: ...`, here we directly use `#parameter` field in avoid of explicit *definitionize*.
2. The extraction of `#parameter` field into `ast.Node` is done by directly retrieving `ast.File` and following codes.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [#1939](https://github.com/oam-dev/kubevela/issues/1939) (deplicated with issue [#2062](https://github.com/oam-dev/kubevela/issues/1959))

**Special notes for your reviewer**:

Several scenarios are manually-tested and controller work correctly, including:
1. Single parameter field with IfClause
```cue
parameter: {
  x?: string
  if x != _|_ {
    y: string
  }
}
```
2. Multiple parameter field as struct
```cue
parameter: {
  x?: string
}
parameter: y: [...string]
patch: { ... }
parameter: {
  z: int
}
```
3. Multiple parameter field as list
```cue
parameter: [...string]
patch: {...}
parameter: ["a", "b", ...string]
```
The first two cases work well but for the third case or other cases when `parameter` is a list, the OpenAPI schema will encounter unmarshal failure, which is caused by other problems. It is not determined whether the third case should be addressed but for now, our official definitions do not use `parameter` as list so it would not be triggered if users uses the official definitions.
