### PR TITLE
enable vela def to use import decl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ run: fmt vet
 fmt: goimports installcue
 	go fmt ./...
 	$(GOIMPORTS) -local github.com/oam-dev/kubevela -w $$(go list -f {{.Dir}} ./...)
-	$(CUE) fmt ./vela-templates/internal/cue/*
-	$(CUE) fmt ./vela-templates/registry/cue/*
+	$(CUE) fmt ./vela-templates/definitions/internal/
+	$(CUE) fmt ./vela-templates/definitions/registry/
 
 # Run go vet against code
 vet:

--- a/charts/vela-core/templates/defwithtemplate/ingress-1-20.yaml
+++ b/charts/vela-core/templates/defwithtemplate/ingress-1-20.yaml
@@ -29,7 +29,6 @@ spec:
         		]
         	}
         }
-
         outputs: ingress: {
         	apiVersion: "networking.k8s.io/v1"
         	kind:       "Ingress"
@@ -48,7 +47,6 @@ spec:
         		]
         	}]
         }
-
         parameter: {
         	// +usage=Specify the domain you want to expose
         	domain: string

--- a/charts/vela-core/templates/defwithtemplate/ingress.yaml
+++ b/charts/vela-core/templates/defwithtemplate/ingress.yaml
@@ -29,7 +29,6 @@ spec:
         		]
         	}
         }
-
         outputs: ingress: {
         	apiVersion: "networking.k8s.io/v1beta1"
         	kind:       "Ingress"
@@ -47,7 +46,6 @@ spec:
         		]
         	}]
         }
-
         parameter: {
         	// +usage=Specify the domain you want to expose
         	domain: string

--- a/charts/vela-core/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-core/templates/defwithtemplate/rollout.yaml
@@ -29,13 +29,11 @@ spec:
         		}
         	}
         }
-
         parameter: {
         	targetRevision: *context.revision | string
         	targetSize:     int
         	rolloutBatches: [...rolloutBatch]
         }
-
         rolloutBatch: replicas: int
   skipRevisionAffect: true
 

--- a/charts/vela-core/templates/defwithtemplate/service-binding.yaml
+++ b/charts/vela-core/templates/defwithtemplate/service-binding.yaml
@@ -35,7 +35,6 @@ spec:
         		]
         	}]
         }
-
         parameter: {
         	// +usage=The mapping of environment variables to secret
         	envMappings: [string]: [string]: string

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -88,7 +88,6 @@ spec:
         		}
         	}
         }
-
         parameter: {
         	// +usage=Specify number of tasks to run in parallel
         	// +short=c
@@ -166,7 +165,6 @@ spec:
         	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
         	readinessProbe?: #HealthProbe
         }
-
         #HealthProbe: {
 
         	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.

--- a/charts/vela-core/templates/defwithtemplate/volumes.yaml
+++ b/charts/vela-core/templates/defwithtemplate/volumes.yaml
@@ -45,7 +45,6 @@ spec:
         		}
         	},
         ]
-
         parameter: {
         	// +usage=Declare volumes and volumeMounts
         	volumes?: [...{

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -206,7 +206,6 @@ spec:
         	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
         	readinessProbe?: #HealthProbe
         }
-
         #HealthProbe: {
 
         	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -110,7 +110,6 @@ spec:
         		}
         	}
         }
-
         parameter: {
         	// +usage=Which image would you like to use for your service
         	// +short=i
@@ -187,7 +186,6 @@ spec:
         	// +usage=Instructions for assessing whether the container is in a suitable state to serve traffic.
         	readinessProbe?: #HealthProbe
         }
-
         #HealthProbe: {
 
         	// +usage=Instructions for assessing container health by executing a command. Either this attribute or the httpGet attribute or the tcpSocket attribute MUST be specified. This attribute is mutually exclusive with both the httpGet attribute and the tcpSocket attribute.

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -79,6 +79,7 @@ func DefinitionCommandGroup(c common.Args) *cobra.Command {
 			types.TagCommandType: types.TypeCap,
 		},
 	}
+	_ = c.SetConfig() // set config if possible
 	cmd.AddCommand(
 		NewDefinitionGetCommand(c),
 		NewDefinitionListCommand(c),
@@ -458,7 +459,7 @@ func NewDefinitionEditCommand(c common.Args) *cobra.Command {
 				cmd.Printf("definition unchanged\n")
 				return nil
 			}
-			if err := def.FromCUEString(string(newBuf)); err != nil {
+			if err := def.FromCUEString(string(newBuf), c.Config); err != nil {
 				return errors.Wrapf(err, "failed to load edited cue string")
 			}
 			if err := k8sClient.Update(context.Background(), def); err != nil {
@@ -512,7 +513,7 @@ func NewDefinitionRenderCommand(c common.Args) *cobra.Command {
 					return errors.Wrapf(err, "failed to get %s", args[0])
 				}
 				def := common2.Definition{Unstructured: unstructured.Unstructured{}}
-				if err := def.FromCUEString(string(cueBytes)); err != nil {
+				if err := def.FromCUEString(string(cueBytes), c.Config); err != nil {
 					return errors.Wrapf(err, "failed to parse CUE")
 				}
 
@@ -617,7 +618,7 @@ func NewDefinitionApplyCommand(c common.Args) *cobra.Command {
 				return errors.Wrapf(err, "failed to get %s", args[0])
 			}
 			def := common2.Definition{Unstructured: unstructured.Unstructured{}}
-			if err := def.FromCUEString(string(cueBytes)); err != nil {
+			if err := def.FromCUEString(string(cueBytes), c.Config); err != nil {
 				return errors.Wrapf(err, "failed to parse CUE")
 			}
 			def.SetNamespace(namespace)
@@ -648,7 +649,7 @@ func NewDefinitionApplyCommand(c common.Args) *cobra.Command {
 				}
 				return errors.Wrapf(err, "failed to check existence of target definition in kubernetes")
 			}
-			if err := oldDef.FromCUEString(string(cueBytes)); err != nil {
+			if err := oldDef.FromCUEString(string(cueBytes), c.Config); err != nil {
 				return errors.Wrapf(err, "failed to merge with existing definition")
 			}
 			if err = k8sClient.Update(ctx, &oldDef); err != nil {
@@ -744,7 +745,7 @@ func NewDefinitionValidateCommand(c common.Args) *cobra.Command {
 				return errors.Wrapf(err, "failed to read %s", args[0])
 			}
 			def := common2.Definition{Unstructured: unstructured.Unstructured{}}
-			if err := def.FromCUEString(string(cueBytes)); err != nil {
+			if err := def.FromCUEString(string(cueBytes), c.Config); err != nil {
 				return errors.Wrapf(err, "failed to parse CUE")
 			}
 			cmd.Println("Validation succeed.")

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -79,7 +79,7 @@ func DefinitionCommandGroup(c common.Args) *cobra.Command {
 			types.TagCommandType: types.TypeCap,
 		},
 	}
-	_ = c.SetConfig() // set config if possible
+	_ = c.SetConfig() // set kubeConfig if possible, otherwise ignore it
 	cmd.AddCommand(
 		NewDefinitionGetCommand(c),
 		NewDefinitionListCommand(c),

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -33,6 +33,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	common3 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	common2 "github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/references/common"
@@ -72,6 +73,9 @@ func createNamespacedTrait(c common2.Args, name string, ns string, t *testing.T)
 			Annotations: map[string]string{
 				common.DefinitionDescriptionKey: "My test-trait " + traitName,
 			},
+		},
+		Spec: v1beta1.TraitDefinitionSpec{
+			Schematic: &common3.Schematic{CUE: &common3.CUE{Template: "parameter: {}"}},
 		},
 	}); err != nil {
 		t.Fatalf("failed to create trait: %v", err)
@@ -364,7 +368,7 @@ func TestNewDefinitionVetCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read trait file %s: %v", traitFilename, err)
 	}
-	bs = []byte(string(bs) + "abc")
+	bs = []byte(string(bs) + "abc:{xa}")
 	if err = os.WriteFile(traitFilename, bs, 0600); err != nil {
 		t.Fatalf("failed to modify trait file %s: %v", traitFilename, err)
 	}

--- a/references/common/definition.go
+++ b/references/common/definition.go
@@ -334,6 +334,7 @@ func (def *Definition) FromCUEString(cueString string, config *rest.Config) erro
 	if metadataString, err = encodeDeclsToString(metadataDecls); err != nil {
 		return errors.Wrapf(err, "failed to encode metadata decls to string")
 	}
+	// notice that current template decls are concatenated without any blank lines which might be inconsistent with original cue file, but it would not affect the syntax
 	if templateString, err = encodeDeclsToString(templateDecls); err != nil {
 		return errors.Wrapf(err, "failed to encode template decls to string")
 	}

--- a/references/common/definition_test.go
+++ b/references/common/definition_test.go
@@ -49,6 +49,7 @@ func TestDefinitionBasicFunctions(t *testing.T) {
 		t.Fatalf("set type should failed due to invalid type, but got no error")
 	}
 	def.Object["spec"] = GetDefinitionDefaultSpec("TraitDefinition")
+	_ = unstructured.SetNestedField(def.Object, "patch: metadata: labels: \"KubeVela-test\": parameter.tag\nparameter: tag: string\n", "spec", "schematic", "cue", "template")
 	cueString, err := def.ToCUEString()
 	if err != nil {
 		t.Fatalf("unexpected error when getting to cue: %v", err)
@@ -83,6 +84,11 @@ func TestDefinitionBasicFunctions(t *testing.T) {
 	}
 	if err = def.FromCUEString(cueString, nil); err != nil {
 		t.Fatalf("unexpected error when setting from cue: %v", err)
+	}
+	if _cueString, err := def.ToCUEString(); err != nil {
+		t.Fatalf("failed to generate cue string: %v", err)
+	} else if _cueString != cueString {
+		t.Fatalf("the bidirectional conversion of cue string is not idempotent")
 	}
 	templateString, _, _ := unstructured.NestedString(def.Object, DefinitionTemplateKeys...)
 	_ = unstructured.SetNestedField(def.Object, "import \"strconv\"\n"+templateString, DefinitionTemplateKeys...)

--- a/references/common/definition_test.go
+++ b/references/common/definition_test.go
@@ -59,23 +59,29 @@ func TestDefinitionBasicFunctions(t *testing.T) {
 	if err = c.Create(context.Background(), trait); err != nil {
 		t.Fatalf("unexpected error when creating new definition with fake client: %v", err)
 	}
-	if err = def.FromCUEString(cueString + "abc"); err == nil {
+	if err = def.FromCUEString("abc:]{xa}", nil); err == nil {
+		t.Fatalf("should encounter invalid cue string but not found error")
+	}
+	if err = def.FromCUEString(cueString+"abc: {xa}", nil); err == nil {
 		t.Fatalf("should encounter invalid cue string but not found error")
 	}
 	parts := strings.Split(cueString, "template: ")
-	if err = def.FromCUEString(parts[0]); err == nil {
+	if err = def.FromCUEString(parts[0], nil); err == nil {
 		t.Fatalf("should encounter no template found error but not found error")
 	}
-	if err = def.FromCUEString("import \"strconv\"\n" + cueString); err == nil {
+	if err = def.FromCUEString("template:"+parts[1], nil); err == nil {
+		t.Fatalf("should encounter no metadata found error but not found error")
+	}
+	if err = def.FromCUEString("import \"strconv\"\n"+cueString, nil); err == nil {
 		t.Fatalf("should encounter cue compile error due to useless import but not found error")
 	}
-	if err = def.FromCUEString("abc: {}\n" + cueString); err == nil {
+	if err = def.FromCUEString("abc: {}\n"+cueString, nil); err == nil {
 		t.Fatalf("should encounter duplicated object name error but not found error")
 	}
-	if err = def.FromCUEString(strings.Replace(cueString, "\"trait\"", "\"tr\"", 1)); err == nil {
+	if err = def.FromCUEString(strings.Replace(cueString, "\"trait\"", "\"tr\"", 1), nil); err == nil {
 		t.Fatalf("should encounter invalid type error but not found error")
 	}
-	if err = def.FromCUEString(cueString); err != nil {
+	if err = def.FromCUEString(cueString, nil); err != nil {
 		t.Fatalf("unexpected error when setting from cue: %v", err)
 	}
 	templateString, _, _ := unstructured.NestedString(def.Object, DefinitionTemplateKeys...)
@@ -86,7 +92,7 @@ func TestDefinitionBasicFunctions(t *testing.T) {
 		t.Fatalf("definition ToCUEString missed import, val: %v", s)
 	}
 	def = &Definition{}
-	if err = def.FromCUEString(cueString); err != nil {
+	if err = def.FromCUEString(cueString, nil); err != nil {
 		t.Fatalf("unexpected error when setting from cue for empty def: %v", err)
 	}
 

--- a/vela-templates/registry/auto-gen/kustomize.yaml
+++ b/vela-templates/registry/auto-gen/kustomize.yaml
@@ -36,7 +36,6 @@ spec:
         		validation: "client"
         	}
         }
-
         parameter: {
         	//+usage=The repository URL, can be a HTTP/S or SSH address.
         	repoUrl: string


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Previous `vela def` do not support internal package import such as `vela/op` or `kube/v1`. This PR enables it.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #2068

**Special notes for your reviewer**:

Notice that to support internal package use, users need to have connections with Kubernetes api-server, as the OpenAPI Schema is required. While no Kubernetes cluster is connected, the vela def will not support using internal package.

