### PR TITLE
Refine the latest chart name build on master branch

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -115,15 +115,11 @@ jobs:
         run:  |
           latest_repo_tag=${{ steps.latest_tag.outputs.tag }}
           sub="."
-          major="$(cut -d"$sub" -f1 <<<"$latest_repo_tag")"
-          minor="$(cut -d"$sub" -f2 <<<"$latest_repo_tag")"
-          patch="0"
-          next_repo_tag="$major.$(($minor + 1)).$patch"
           image_tag=${GITHUB_REF#refs/tags/}
           chart_version=$latest_repo_tag
           if [[ ${GITHUB_REF} == "refs/heads/master" ]]; then
             image_tag=latest
-            chart_version=${next_repo_tag}-rc-master
+            chart_version=${$latest_repo_tag}-nightly-build
           fi
           sed -i "s/latest/${image_tag}/g" $HELM_CHART/values.yaml
           sed -i "s/latest/${image_tag}/g" $LEGACY_HELM_CHART/values.yaml


### PR DESCRIPTION
Rename the latest master chart name to x.y.z-nighty-build

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently, the latest chart name is like `x.y.z-rc-master` conflicts with our release-candidate chart name. So we rename the chart.
![image](https://user-images.githubusercontent.com/2805315/129658158-fbda0882-c600-4f2d-9dcd-cd41d57cda5c.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

