### PR TITLE
Replace gcr.io image in chart kube-metrics-server

### DIFF
--- a/charts/vela-core/templates/addons/observability.yaml
+++ b/charts/vela-core/templates/addons/observability.yaml
@@ -106,6 +106,10 @@ data:
               repoType: helm
               repoUrl: https://prometheus-community.github.io/helm-charts
               targetNamespace: observability
+              values:
+                image:
+                  repository: oamdev/kube-state-metrics
+                  tag: v2.1.0
               version: 3.4.1
             type: helm
         status:

--- a/vela-templates/addons/auto-gen/observability.yaml
+++ b/vela-templates/addons/auto-gen/observability.yaml
@@ -103,6 +103,10 @@ spec:
           repoType: helm
           repoUrl: https://prometheus-community.github.io/helm-charts
           targetNamespace: observability
+          values:
+            image:
+              repository: oamdev/kube-state-metrics
+              tag: v2.1.0
           version: 3.4.1
         type: helm
     status:

--- a/vela-templates/addons/observability/template.yaml
+++ b/vela-templates/addons/observability/template.yaml
@@ -115,6 +115,10 @@ spec:
             repoType: helm
             repoUrl: https://prometheus-community.github.io/helm-charts
             targetNamespace: observability
+            values:
+              image:
+                repository: oamdev/kube-state-metrics
+                tag: v2.1.0
 
 {{ range .ResourceFiles }}
         - name: {{ .Name }}


### PR DESCRIPTION
As it's difficult to pull gcr.io iamge, so replace the image
k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0 to the one
hosted in dockerhub.io

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

