### PR TITLE
fix(CI): use buildkit as docker build engine to avoid 401 unauthorized

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -46,6 +46,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: image=moby/buildkit:master
       - uses: docker/build-push-action@v2
         name: Build & Pushing
         with:


### PR DESCRIPTION
ref to https://github.com/docker/buildx/issues/327


same case: https://github.com/jetstack/jetstack-secure/pull/227