### PR TITLE
Make the WorkflowStepDefinition to be Universal

### DIFF
--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -118,6 +118,7 @@ func TagFieldOrder(root *ast.File) error {
 	return nil
 }
 
+// ProcessScript preprocess the script builtin function.
 func ProcessScript(root *ast.File) error {
 	return sets.PreprocessBuiltinFunc(root, "script", func(values []ast.Node) (ast.Expr, error) {
 		for _, v := range values {

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -105,7 +105,7 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 			}
 
 			for _, input := range inputs {
-				inputValue, err := ctx.GetVar(input.From)
+				inputValue, err := ctx.GetVar(strings.Split(input.From, ".")...)
 				if err != nil {
 					return common.WorkflowStepStatus{}, nil, errors.WithMessagef(err, "get input from [%s]", input.From)
 				}
@@ -141,7 +141,7 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 
 			if exec.status().Phase == common.WorkflowStepPhaseSucceeded {
 				for _, output := range outputs {
-					v, err := taskv.LookupValue(output.ExportKey)
+					v, err := taskv.LookupValue(strings.Split(output.ExportKey, ".")...)
 					if err != nil {
 						exec.err(err, StatusReasonOutput)
 						return exec.status(), exec.operation(), nil
@@ -168,7 +168,7 @@ func (t *TaskLoader) makeValue(ctx wfContext.Context, templ string) (*value.Valu
 		}
 		templ += fmt.Sprintf("\ncontext: {%s}", ms)
 	}
-	return value.NewValue(templ, t.pd, value.TagFieldOrder)
+	return value.NewValue(templ, t.pd, value.ProcessScript, value.TagFieldOrder)
 }
 
 type executor struct {

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -43,7 +43,7 @@ func TestTaskLoader(t *testing.T) {
 	discover.Register("test", map[string]providers.Handler{
 		"output": func(ctx wfContext.Context, v *value.Value, act types.Action) error {
 			ip, _ := v.MakeValue(`
-myIP: "1.1.1.1"            
+myIP: value: "1.1.1.1"            
 `)
 			return v.FillObject(ip)
 		},
@@ -78,7 +78,7 @@ myIP: "1.1.1.1"
 			Name: "output",
 			Type: "output",
 			Outputs: v1beta1.StepOutputs{{
-				ExportKey: "myIP",
+				ExportKey: "myIP.value",
 				Name:      "podIP",
 			}},
 		},

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -26,6 +26,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers"
+	"github.com/oam-dev/kubevela/pkg/workflow/providers/http"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers/workspace"
 	"github.com/oam-dev/kubevela/pkg/workflow/tasks/custom"
 	"github.com/oam-dev/kubevela/pkg/workflow/types"
@@ -69,7 +70,7 @@ func suspend(step v1beta1.WorkflowStep) (types.TaskRunner, error) {
 func NewTaskDiscover(providerHandlers providers.Providers, pd *packages.PackageDiscover, loadTemplate custom.LoadTaskTemplate) types.TaskDiscover {
 	// install builtin provider
 	workspace.Install(providerHandlers)
-
+	http.Install(providerHandlers)
 	return &taskDiscover{
 		builtins: map[string]types.TaskGenerator{
 			"suspend": suspend,


### PR DESCRIPTION
- [x] workflowStepDefinition support `script`
- [x] add http provider
- [x] `outputs` exportKey support to refer to the field of the substructure of workflow step definition

1.  Use case of `script` as follow: 
```
---def---
parameter: {
   successChecker: string
}

// resource status
status: {phase: string}

op.#ConditionalWait & {
   continue: script(parameter.successChecker)
}

---step---
workflow:
    steps:
    - name: "apply"
      properties:
         successChecker: status.phase=="ready"
```

2. Use case of `outputs` exportKey  as follow:
```
---def---
apply: op.#Apply & {
  value: {
         kind: "Service"
   }
}

---step---
workflow:
    steps:
    - name: "apply"
      outputs:
      - exportKey: "apply.value.spec.ClusterIP"
        name: "clusterIP"
          
```