### PR TITLE
fix(cli) fix bug when vela show componetdefinition's workload type is AutoDetectWorkloadDefinition

### DIFF
--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -304,15 +304,25 @@ func GetCapabilityByName(ctx context.Context, c common.Args, capabilityName stri
 	}
 
 	if foundCapability {
-		dm, err := c.GetDiscoveryMapper()
-		if err != nil {
-			return nil, err
+		var refName string
+
+		// if workload type of ComponentDefinition is unclear,
+		// set the DefinitionReference's Name to AutoDetectWorkloadDefinition
+		if componentDef.Spec.Workload.Type == types.AutoDetectWorkloadDefinition {
+			refName = types.AutoDetectWorkloadDefinition
+		} else {
+			dm, err := c.GetDiscoveryMapper()
+			if err != nil {
+				return nil, err
+			}
+			ref, err := util.ConvertWorkloadGVK2Definition(dm, componentDef.Spec.Workload.Definition)
+			if err != nil {
+				return nil, err
+			}
+			refName = ref.Name
 		}
-		ref, err := util.ConvertWorkloadGVK2Definition(dm, componentDef.Spec.Workload.Definition)
-		if err != nil {
-			return nil, err
-		}
-		capability, err = GetCapabilityByComponentDefinitionObject(componentDef, ref.Name)
+
+		capability, err = GetCapabilityByComponentDefinitionObject(componentDef, refName)
 		if err != nil {
 			return nil, err
 		}

--- a/references/plugins/cluster_test.go
+++ b/references/plugins/cluster_test.go
@@ -147,12 +147,14 @@ var _ = Describe("test GetCapabilityByName", func() {
 		cd1        corev1beta1.ComponentDefinition
 		cd2        corev1beta1.ComponentDefinition
 		cd3        corev1beta1.ComponentDefinition
+		cd4        corev1beta1.ComponentDefinition
 		td1        corev1beta1.TraitDefinition
 		td2        corev1beta1.TraitDefinition
 		td3        corev1beta1.TraitDefinition
 		component1 string
 		component2 string
 		component3 string
+		component4 string
 		trait1     string
 		trait2     string
 		trait3     string
@@ -169,6 +171,7 @@ var _ = Describe("test GetCapabilityByName", func() {
 		component1 = "cd1"
 		component2 = "cd2"
 		component3 = "cd3"
+		component4 = "cd4"
 
 		trait1 = "td1"
 		trait2 = "td2"
@@ -184,6 +187,10 @@ var _ = Describe("test GetCapabilityByName", func() {
 		yaml.Unmarshal(data, &cd2)
 		data2, _ := ioutil.ReadFile("testdata/kube-worker.yaml")
 		yaml.Unmarshal(data2, &cd3)
+
+		helmYaml, _ := ioutil.ReadFile("testdata/helm.yaml")
+		yaml.Unmarshal(helmYaml, &cd4)
+
 		cd1.Namespace = ns
 		cd1.Name = component1
 		Expect(k8sClient.Create(ctx, &cd1)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
@@ -195,6 +202,10 @@ var _ = Describe("test GetCapabilityByName", func() {
 		cd3.Namespace = ns
 		cd3.Name = component3
 		Expect(k8sClient.Create(ctx, &cd3)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+		cd4.Namespace = ns
+		cd4.Name = component4
+		Expect(k8sClient.Create(ctx, &cd4)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
 
 		By("create TraitDefinition")
 		data, _ = ioutil.ReadFile("testdata/manualscalars.yaml")
@@ -234,6 +245,10 @@ var _ = Describe("test GetCapabilityByName", func() {
 			Expect(string(jsontmp)).Should(ContainSubstring("spec.template.spec.containers[0].image"))
 			Expect(string(jsontmp)).Should(ContainSubstring("port"))
 			Expect(string(jsontmp)).Should(ContainSubstring("the specific container port num which can accept external request."))
+		})
+		Context("ComponentDefinition's workload type is AutoDetectWorkloadDefinition", func() {
+			_, err := GetCapabilityByName(ctx, c, component4, ns)
+			Expect(err).Should(BeNil())
 		})
 
 		Context("TraitDefinition is in the current namespace", func() {

--- a/references/plugins/testdata/helm.yaml
+++ b/references/plugins/testdata/helm.yaml
@@ -1,0 +1,143 @@
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: helm
+spec:
+  workload:
+    type: autodetects.core.oam.dev
+  schematic:
+    cue:
+      template: |
+        output: {
+        	apiVersion: "source.toolkit.fluxcd.io/v1beta1"
+        	metadata: {
+        		name: context.name
+        	}
+        	if parameter.repoType == "git" {
+        		kind: "GitRepository"
+        		spec: {
+        			url: parameter.url
+        			if parameter.git.branch != _|_ {
+        				ref: branch: parameter.git.branch
+        			}
+        			_secret
+        			_sourceCommonArgs
+        		}
+        	}
+        	if parameter.repoType == "oss" {
+        		kind: "Bucket"
+        		spec: {
+        			endpoint:   parameter.url
+        			bucketName: parameter.oss.bucketName
+        			provider:   parameter.oss.provider
+        			if parameter.oss.region != _|_ {
+        				region: parameter.oss.region
+        			}
+        			_secret
+        			_sourceCommonArgs
+        		}
+        	}
+        	if parameter.repoType == "helm" {
+        		kind: "HelmRepository"
+        		spec: {
+        			url: parameter.url
+        			_secret
+        			_sourceCommonArgs
+        		}
+        	}
+        }
+
+        outputs: release: {
+        	apiVersion: "helm.toolkit.fluxcd.io/v2beta1"
+        	kind:       "HelmRelease"
+        	metadata: {
+        		name: context.name
+        	}
+        	spec: {
+        		interval: parameter.pullInterval
+        		chart: {
+        			spec: {
+        				chart:   parameter.chart
+        				version: parameter.version
+        				sourceRef: {
+        					if parameter.repoType == "git" {
+        						kind: "GitRepository"
+        					}
+        					if parameter.repoType == "helm" {
+        						kind: "HelmRepository"
+        					}
+        					if parameter.repoType == "oss" {
+        						kind: "Bucket"
+        					}
+        					name:      context.name
+        					namespace: context.namespace
+        				}
+        				interval: parameter.pullInterval
+        			}
+        		}
+        		if parameter.targetNamespace != _|_ {
+        			targetNamespace: parameter.targetNamespace
+        		}
+        		if parameter.releaseName != _|_ {
+        			releaseName: parameter.releaseName
+        		}
+        		if parameter.values != _|_ {
+        			values: parameter.values
+        		}
+        	}
+        }
+
+        _secret: {
+        	if parameter.secretRef != _|_ {
+        		secretRef: {
+        			name: parameter.secretRef
+        		}
+        	}
+        }
+
+        _sourceCommonArgs: {
+        	interval: parameter.pullInterval
+        	if parameter.timeout != _|_ {
+        		timeout: parameter.timeout
+        	}
+        }
+
+        parameter: {
+        	repoType: *"helm" | "git" | "oss"
+        	// +usage=The interval at which to check for repository/bucket and relese updates, default to 5m
+        	pullInterval: *"5m" | string
+        	// +usage=The Git or Helm repository URL, OSS endpoint, accept HTTP/S or SSH address as git url,
+        	url: string
+        	// +usage=The name of the secret containing authentication credentials
+        	secretRef?: string
+        	// +usage=The timeout for operations like download index/clone repository, optional
+        	timeout?: string
+
+        	git?: {
+        		// +usage=The Git reference to checkout and monitor for changes, defaults to master branch
+        		branch: string
+        	}
+        	oss?: {
+        		// +usage=The bucket's name, required if repoType is oss
+        		bucketName: string
+        		// +usage="generic" for Minio, Amazon S3, Google Cloud Storage, Alibaba Cloud OSS, "aws" for retrieve credentials from the EC2 service when credentials not specified, default "generic"
+        		provider: *"generic" | "aws"
+        		// +usage=The bucket region, optional
+        		region?: string
+        	}
+
+        	// +usage=1.The relative path to helm chart for git/oss source. 2. chart name for helm resource 3. relative path for chart package(e.g. ./charts/podinfo-1.2.3.tgz)
+        	chart: string
+        	// +usage=Chart version
+        	version: *"*" | string
+        	// +usage=The namespace for helm chart, optional
+        	targetNamespace?: string
+        	// +usage=The release name
+        	releaseName?: string
+        	// +usage=Chart values
+        	values?: #nestedmap
+        }
+
+        #nestedmap: {
+        	...
+        }


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

this PR fix bug which vela show will not show the parameters of componentDefinition, when componetdefinition's workload type is AutoDetectWorkloadDefinition.



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/oam-dev/kubevela/issues/2034

**Special notes for your reviewer**:

