### PR TITLE
initilize KubeVela codeowner file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@ runtime/rollout                                             @wangyikewxgm
 # Owner of definition controller
 pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition  @yangsoon
 pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition        @yangsoon
-pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition   @yangsoon
+pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition   @yangsoon @zzxwill 
 pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition           @yangsoon
 
 # Owner of health scope controller

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,5 +29,5 @@ pkg/controller/core.oam.dev/v1alpha2/core/scopes/healthscope     @captainroy-hy
 vela-templates/                     @Somefive
 
 # Owner of vela CLI
-references/cli/                     @Somefive
+references/cli/                     @Somefive @zzxwill 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@ runtime/rollout                                             @wangyikewxgm
 pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition  @yangsoon
 pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition        @yangsoon
 pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition   @yangsoon @zzxwill 
-pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition           @yangsoon
+pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition           @yangsoon @zzxwill 
 
 # Owner of health scope controller
 pkg/controller/core.oam.dev/v1alpha2/core/scopes/healthscope     @captainroy-hy

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
+
+*                                  @hongchaodeng @wonderflow
+design/                            @hongchaodeng @resouer @wonderflow
+
+# Owner of CUE
+pkg/cue                            @leejanee
+pkg/stdlib                         @leejanee
+
+# Owner of Workflow
+pkg/workflow                       @leejanee
+
+# Owner of rollout
+pkg/controller/common/rollout/                              @wangyikewxgm
+pkg/controller/core.oam.dev/v1alpha2/applicationrollout     @wangyikewxgm
+pkg/controller/standard.oam.dev/v1alpha1/rollout            @wangyikewxgm
+runtime/rollout                                             @wangyikewxgm
+
+# Owner of definition controller
+pkg/controller/core.oam.dev/v1alpha2/core/workflow/workflowstepdefinition  @yangsoon
+pkg/controller/core.oam.dev/v1alpha2/core/policies/policydefinition        @yangsoon
+pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition   @yangsoon
+pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition           @yangsoon
+
+# Owner of health scope controller
+pkg/controller/core.oam.dev/v1alpha2/core/scopes/healthscope     @captainroy-hy
+
+# Owner of vela templates
+vela-templates/                     @Somefive
+
+# Owner of vela CLI
+references/cli/                     @Somefive
+


### PR DESCRIPTION
Use github ownerfiles mechanism for code review. https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file

A code owner must have the write permission for the repo.

