### PR TITLE
Feat: add vela live-diff, dry-run, cue-packages into vela commands

### DIFF
--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -99,6 +99,15 @@ func NewCommand() *cobra.Command {
 		// Addons
 		NewAddonCommand(commandArgs, ioStream),
 
+		// live-diff
+		NewLiveDiffCommand(commandArgs, ioStream),
+
+		// dry-run
+		NewDryRunCommand(commandArgs, ioStream),
+
+		// cue-packages
+		NewCUEPackageCommand(commandArgs, ioStream),
+
 		// Helper
 		SystemCommandGroup(commandArgs, ioStream),
 		NewDashboardCommand(commandArgs, ioStream, fake.FrontendSource),

--- a/references/cli/cue_packages.go
+++ b/references/cli/cue_packages.go
@@ -21,12 +21,24 @@ import (
 	"strings"
 
 	"github.com/gosuri/uitable"
-
 	"github.com/spf13/cobra"
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
 )
+
+// NewSystemCUEPackageCommand is deprecated
+func NewSystemCUEPackageCommand(_ common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "cue-packages",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ioStreams.Info("vela system cue-packages is deprecated, please use vela cue-packages instead")
+			return nil
+		},
+	}
+	cmd.SetOut(ioStreams.Out)
+	return cmd
+}
 
 // NewCUEPackageCommand creates `cue-package` command
 func NewCUEPackageCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
@@ -35,7 +47,7 @@ func NewCUEPackageCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Com
 		DisableFlagsInUseLine: true,
 		Short:                 "List cue package",
 		Long:                  "List cue package",
-		Example:               `vela system cue-packages`,
+		Example:               `vela cue-packages`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return c.SetConfig()
 		},

--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -46,6 +46,20 @@ type DryRunCmdOptions struct {
 	DefinitionFile  string
 }
 
+// NewSystemDryRunCommand is deprecated
+func NewSystemDryRunCommand(_ common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	o := &DryRunCmdOptions{IOStreams: ioStreams}
+	cmd := &cobra.Command{
+		Use: "dry-run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.Info("vela system dry-run is deprecated, please use vela dry-run instead")
+			return nil
+		},
+	}
+	cmd.SetOut(ioStreams.Out)
+	return cmd
+}
+
 // NewDryRunCommand creates `dry-run` command
 func NewDryRunCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 	o := &DryRunCmdOptions{IOStreams: ioStreams}

--- a/references/cli/livediff.go
+++ b/references/cli/livediff.go
@@ -40,6 +40,23 @@ type LiveDiffCmdOptions struct {
 	Context  int
 }
 
+// NewSystemLiveDiffCommand is deprecated
+func NewSystemLiveDiffCommand(_ common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
+	o := &LiveDiffCmdOptions{
+		DryRunCmdOptions: DryRunCmdOptions{
+			IOStreams: ioStreams,
+		}}
+	cmd := &cobra.Command{
+		Use: "live-diff",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.Info("vela system live-diff is deprecated, please use vela live-diff instead")
+			return nil
+		},
+	}
+	cmd.SetOut(ioStreams.Out)
+	return cmd
+}
+
 // NewLiveDiffCommand creates `live-diff` command
 func NewLiveDiffCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command {
 	o := &LiveDiffCmdOptions{

--- a/references/cli/system.go
+++ b/references/cli/system.go
@@ -58,10 +58,10 @@ func SystemCommandGroup(c common.Args, ioStream cmdutil.IOStreams) *cobra.Comman
 			types.TagCommandType: types.TypeSystem,
 		},
 	}
-	cmd.AddCommand(NewLiveDiffCommand(c, ioStream))
-	cmd.AddCommand(NewDryRunCommand(c, ioStream))
+	cmd.AddCommand(NewSystemLiveDiffCommand(c, ioStream))
+	cmd.AddCommand(NewSystemDryRunCommand(c, ioStream))
 	cmd.AddCommand(NewAdminInfoCommand(ioStream))
-	cmd.AddCommand(NewCUEPackageCommand(c, ioStream))
+	cmd.AddCommand(NewSystemCUEPackageCommand(c, ioStream))
 	return cmd
 }
 


### PR DESCRIPTION
We already have `live-diff` and `dry-run` command in `vela system`, now we add it into `vela` commands, then users can use it by:

```
vela live-diff ...
vela dry-run ...
vela cue-packages ...
```