### PR TITLE
Fix: dockerfile e2e test command lack environment configuration

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -24,6 +24,7 @@ ARG VERSION
 ARG GITVERSION
 
 RUN  apk add gcc musl-dev libc-dev ;\
+     GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
      go test -c -o manager-${TARGETARCH}  -cover -covermode=atomic -coverpkg ./... .
 
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Previous Dockerfile.e2e file run test without environment variable configured which may cause docker image build problems.

P.S. On Mac M1, the previous version Dockerfile.e2e is unable to build probably due to the arch problem.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

