### PR TITLE
Lower title level to make definition docs generation adapt to kubevela.io

### DIFF
--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -398,8 +398,8 @@ variable "acl" {
 			},
 			want: want{
 				errMsg:     "",
-				tableName1: "# Properties",
-				tableName2: "## writeConnectionSecretToRef",
+				tableName1: "### Properties",
+				tableName2: "#### writeConnectionSecretToRef",
 			},
 		},
 		"configuration is not valid": {

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -420,7 +420,7 @@ func (ref *MarkdownReference) CreateMarkdown(ctx context.Context, caps []types.C
 				return fmt.Errorf("failed to retrieve `parameters` value from %s with err: %w", c.Name, err)
 			}
 			for _, property := range properties {
-				refContent += ref.prepareParameter("#"+property.Name, property.Parameters, types.HelmCategory)
+				refContent += ref.prepareParameter("###"+property.Name, property.Parameters, types.HelmCategory)
 			}
 		case types.KubeCategory:
 			properties, _, err := ref.GenerateHelmAndKubeProperties(ctx, &caps[i])
@@ -428,7 +428,7 @@ func (ref *MarkdownReference) CreateMarkdown(ctx context.Context, caps []types.C
 				return fmt.Errorf("failed to retrieve `parameters` value from %s with err: %w", c.Name, err)
 			}
 			for _, property := range properties {
-				refContent += ref.prepareParameter("#"+property.Name, property.Parameters, types.KubeCategory)
+				refContent += ref.prepareParameter("###"+property.Name, property.Parameters, types.KubeCategory)
 			}
 		case types.TerraformCategory:
 			refContent, err = ref.GenerateTerraformCapabilityProperties(c)
@@ -440,13 +440,13 @@ func (ref *MarkdownReference) CreateMarkdown(ctx context.Context, caps []types.C
 		}
 		title := fmt.Sprintf("%s\n===============", capNameInTitle)
 
-		description := fmt.Sprintf("\n\n# Description\n\n%s", c.Description)
+		description := fmt.Sprintf("\n\n## Description\n\n%s", c.Description)
 		var sample string
 		sampleContent := ref.generateSample(capName)
 		if sampleContent != "" {
-			sample = fmt.Sprintf("\n\n# Samples\n\n%s", sampleContent)
+			sample = fmt.Sprintf("\n\n## Samples\n\n%s", sampleContent)
 		}
-		specification := fmt.Sprintf("\n\n# Specification\n%s", refContent)
+		specification := fmt.Sprintf("\n\n## Specification\n%s", refContent)
 
 		// it's fine if the conflict info files not found
 		conflictWithAndMoreSection, _ := ref.generateConflictWithAndMore(capName, referenceSourcePath)
@@ -608,7 +608,7 @@ func (ref *ParseReference) parseParameters(paraValue cue.Value, paramKey string,
 
 	switch *displayFormat {
 	case "markdown":
-		tableName := fmt.Sprintf("%s %s", strings.Repeat("#", depth+2), paramKey)
+		tableName := fmt.Sprintf("%s %s", strings.Repeat("#", depth+3), paramKey)
 		ref := MarkdownReference{}
 		refContent = ref.prepareParameter(tableName, params, types.CUECategory) + refContent
 	case "console":
@@ -760,7 +760,7 @@ func (ref *ParseReference) parseTerraformCapabilityParameters(capability types.C
 	}
 	refParameterList = append(refParameterList, writeConnectionSecretToRefReferenceParameter)
 
-	propertiesTableName := fmt.Sprintf("%s %s", strings.Repeat("#", 1), "Properties")
+	propertiesTableName := fmt.Sprintf("%s %s", strings.Repeat("#", 3), "Properties")
 	tables = append(tables, ReferenceParameterTable{
 		Name:       propertiesTableName,
 		Parameters: refParameterList,
@@ -783,7 +783,7 @@ func (ref *ParseReference) parseTerraformCapabilityParameters(capability types.C
 	writeSecretRefNameSpaceParam.Usage = "The secret namespace which the cloud resource connection will be written to"
 
 	writeSecretRefParameterList := []ReferenceParameter{writeSecretRefNameParam, writeSecretRefNameSpaceParam}
-	writeSecretTableName := fmt.Sprintf("%s %s", strings.Repeat("#", 2), TerraformWriteConnectionSecretToRefName)
+	writeSecretTableName := fmt.Sprintf("%s %s", strings.Repeat("#", 4), TerraformWriteConnectionSecretToRefName)
 
 	tables = append(tables, ReferenceParameterTable{
 		Name:       writeSecretTableName,


### PR DESCRIPTION
Lower two levels of the title of workloads/traits docs to adapt to
Kubevela.io

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

