### PR TITLE
Docs: Updated broken Getting Started links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ KubeVela is a modern application platform that makes deploying and managing appl
 ## Getting Started
 
 - [Introduction](https://kubevela.io/docs)
-- [Installation](https://kubevela.io/docs/getting-started/quick-install)
-- [Design Your First Deployment Plan](https://kubevela.io/docs/getting-started/first-application)
+- [Installation](https://kubevela.io/docs/install)
+- [Design Your First Deployment Plan](https://kubevela.io/docs/quick-start)
 
 ## Documentation
 


### PR DESCRIPTION
Docs: Fix 2 broken links in README

**What this PR does / why we need it**:

it fixes 2 broken links of of the 3 links in the README section "Getting started"

**Which issue(s) this PR fixes**:

Clicking on the links "Installation" or "Design your first Deployment Plan" causes a 404 page not found

Fixes #

- Replaced with working links.
