### PR TITLE
Fix (CUE): patch any key using `retainKeys` strategy

### DIFF
--- a/pkg/cue/model/sets/operation.go
+++ b/pkg/cue/model/sets/operation.go
@@ -103,8 +103,8 @@ func listMergeProcess(field *ast.Field, key string, baseList, patchList *ast.Lis
 
 func strategyPatchHandle(baseNode ast.Node) interceptor {
 	return func(lnode ast.Node) (ast.Node, error) {
-		walker := newWalker(func(node ast.Node, ctx walkCtx) {
-			field, ok := node.(*ast.Field)
+		walker := newWalker(func(patchNode ast.Node, ctx walkCtx) {
+			field, ok := patchNode.(*ast.Field)
 			if !ok {
 				return
 			}
@@ -136,7 +136,7 @@ func strategyPatchHandle(baseNode ast.Node) interceptor {
 				}
 				listMergeProcess(field, key, baselist, val)
 
-			case *ast.StructLit:
+			default:
 				if !isStrategyRetainKeys(field) {
 					return
 				}
@@ -148,20 +148,19 @@ func strategyPatchHandle(baseNode ast.Node) interceptor {
 						for _, elt := range v.Elts {
 							if fe, ok := elt.(*ast.Field); ok &&
 								labelStr(fe.Label) == labelStr(field.Label) {
-								fe.Value = ast.NewStruct()
+								fe.Value = field.Value
 							}
 						}
-					case *ast.File:
+					case *ast.File: // For the top level element
 						for _, decl := range v.Decls {
 							if fe, ok := decl.(*ast.Field); ok &&
 								labelStr(fe.Label) == labelStr(field.Label) {
-								fe.Value = ast.NewStruct()
+								fe.Value = field.Value
 							}
 						}
 					}
 				}
 			}
-
 		})
 		walker.walk(lnode)
 		return lnode, nil

--- a/pkg/cue/model/sets/operation_test.go
+++ b/pkg/cue/model/sets/operation_test.go
@@ -428,8 +428,32 @@ spec: {
 		envs: [{
 			name:  "e1"
 			value: "v2"
-		}]
-	}]
+		}, ...]
+	}, ...]
+}
+`}, {
+			base: `
+kind: "Old"
+metadata: {
+	name: "Old"
+	labels: keep: "true"
+}
+`,
+			patch: `// +patchStrategy=retainKeys
+kind: "New"
+metadata: {
+	// +patchStrategy=retainKeys
+	name: "New"
+}
+`,
+			result: `	// +patchStrategy=retainKeys
+kind: "New"
+metadata: {
+	// +patchStrategy=retainKeys
+	name: "New"
+	labels: {
+		keep: "true"
+	}
 }
 `},
 	}


### PR DESCRIPTION
Fix https://github.com/oam-dev/kubevela/issues/2144

This will enable users to patch any keys, not just list. For example, patch metadata.name, or even kind.

@tatianguiqu @kinsolee 