### PR TITLE
Fix: fix cluster-gateway image tag in chart

### DIFF
--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -117,7 +117,7 @@ multicluster:
     port: 9443
     image:
       repository: oamdev/cluster-gateway
-      tag: latest
+      tag: v1.1.1
       pullPolicy: Always
     resource:
       limits:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Previously, using `latest` tag for cluster-gateway will be automatically set to the tag of chart when release pipeline is triggered by [Github Action](https://github.com/oam-dev/kubevela/blob/8407c0bf4d01db70f580910c03c7792c2dd6798c/.github/workflows/release.yml#L29). This binds the KubeVela version to cluster-gateway.

Currently, as a quick fix, we retag the cluster-gateway:latest to cluster-gateway:v1.1.1. But in long term, they should be decoupled.  

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

Related to https://github.com/oam-dev/cluster-gateway/issues/4 

