### PR TITLE
Chore(cli): remove useless deploy.yaml

### DIFF
--- a/hack/appfile/test.sh
+++ b/hack/appfile/test.sh
@@ -12,8 +12,4 @@ echo "========"
 cd examples/testapp
 vela up
 
-echo "cat deploy yaml"
-echo "========"
-cat .vela/deploy.yaml
-
 cd ../..

--- a/references/apiserver/appHandlers.go
+++ b/references/apiserver/appHandlers.go
@@ -123,7 +123,7 @@ func (s *APIServer) CreateApplication(c *gin.Context) {
 		IO:      ioStream,
 		Env:     env,
 	}
-	buildResult, data, err := o.ExportFromAppFile(&body, env.Namespace, false, s.c)
+	buildResult, _, err := o.ExportFromAppFile(&body, env.Namespace, false, s.c)
 	if err != nil {
 		util.HandleError(c, util.StatusInternalServerError, err.Error())
 		return

--- a/references/apiserver/appHandlers.go
+++ b/references/apiserver/appHandlers.go
@@ -128,7 +128,7 @@ func (s *APIServer) CreateApplication(c *gin.Context) {
 		util.HandleError(c, util.StatusInternalServerError, err.Error())
 		return
 	}
-	err = o.BaseAppFileRun(buildResult, data, s.c)
+	err = o.BaseAppFileRun(buildResult, s.c)
 	if err != nil {
 		util.HandleError(c, util.StatusInternalServerError, err.Error())
 		return

--- a/references/common/application.go
+++ b/references/common/application.go
@@ -438,21 +438,11 @@ func (o *AppfileOptions) Run(filePath, namespace string, c common.Args) error {
 	if err != nil {
 		return err
 	}
-	return o.BaseAppFileRun(result, data, c)
+	return o.BaseAppFileRun(result, c)
 }
 
 // BaseAppFileRun starts an application according to Appfile
-func (o *AppfileOptions) BaseAppFileRun(result *BuildResult, data []byte, args common.Args) error {
-	deployFilePath := ".vela/deploy.yaml"
-	o.IO.Infof("Writing deploy config to (%s)\n", deployFilePath)
-	if err := os.MkdirAll(filepath.Dir(deployFilePath), 0700); err != nil {
-		return err
-	}
-
-	if err := os.WriteFile(deployFilePath, data, 0600); err != nil {
-		return errors.Wrap(err, "write deploy config manifests failed")
-	}
-
+func (o *AppfileOptions) BaseAppFileRun(result *BuildResult, args common.Args) error {
 	if err := o.saveToAppDir(result.appFile); err != nil {
 		return errors.Wrap(err, "save to app dir failed")
 	}

--- a/references/common/application.go
+++ b/references/common/application.go
@@ -434,7 +434,7 @@ func (o *AppfileOptions) Export(filePath, namespace string, quiet bool, c common
 
 // Run starts an application according to Appfile
 func (o *AppfileOptions) Run(filePath, namespace string, c common.Args) error {
-	result, data, err := o.Export(filePath, namespace, false, c)
+	result, _, err := o.Export(filePath, namespace, false, c)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When using `vela up`, data will be write into a file at `.vela/deploy.yaml`. If creating another application, it will be overwrite. That's useless and confusing for users.\

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

