### PR TITLE
Chore: remove e2e-api-test in rollout test to speed up

### DIFF
--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -80,9 +80,6 @@ jobs:
           helm lint ./charts/vela-core
           helm test -n vela-system kubevela --timeout 5m
 
-      - name: Run api e2e tests
-        run: make e2e-api-test
-
       - name: Run e2e tests
         run: make e2e-rollout-test
 


### PR DESCRIPTION


**What this PR does / why we need it**:

Remove `make e2e-api-test` in e2e-rollout-test, which are tested in e2e-test. e2e-rollout-test are always the slowest, this can speed up the whole test.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

