### PR TITLE
Feat: bootstrap multicluster testing

### DIFF
--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -1,0 +1,102 @@
+name: E2E MultiCluster Test
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  workflow_dispatch: {}
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+env:
+  # Common versions
+  GO_VERSION: '1.16'
+  GOLANGCI_VERSION: 'v1.38'
+  KIND_VERSION: 'v0.7.0'
+
+jobs:
+
+  detect-noop:
+    runs-on: ubuntu-20.04
+    outputs:
+      noop: ${{ steps.noop.outputs.should_skip }}
+    steps:
+      - name: Detect No-op Changes
+        id: noop
+        uses: fkirc/skip-duplicate-actions@v3.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          paths_ignore: '["**.md", "**.mdx", "**.png", "**.jpg"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+          concurrent_skipping: false
+
+  e2e-tests:
+    runs-on: aliyun
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Setup Kind
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          skipClusterCreation: true
+
+      - name: Setup Kind Cluster (Worker)
+        run: |
+          kind delete cluster --name worker
+          kind create cluster --image kindest/node:v1.18.15@sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4 --name worker
+          kubectl version
+          kubectl cluster-info
+          kind get kubeconfig --name worker --internal > /tmp/worker.kubeconfig
+
+      - name: Setup Kind Cluster (Hub)
+        run: |
+          kind delete cluster
+          kind create cluster --image kindest/node:v1.18.15@sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4
+          kubectl version
+          kubectl cluster-info
+
+      - name: Load Image to kind cluster (Hub)
+        run: make kind-load
+
+      - name: Cleanup for e2e tests
+        run: |
+          make e2e-cleanup
+          make e2e-setup-core
+
+      - name: Run e2e multicluster tests
+        run: make e2e-multicluster-test
+
+      - name: Stop kubevela, get profile
+        run: make end-e2e-core
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: /tmp/e2e-profile.out,/tmp/e2e_multicluster_test.out
+          flags: e2e-multicluster-test
+          name: codecov-umbrella
+
+      - name: Clean e2e profile
+        run: rm /tmp/e2e-profile.out
+
+      - name: Cleanup image
+        if: ${{ always() }}
+        run: make image-cleanup

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -33,7 +33,7 @@ jobs:
           do_not_skip: '["workflow_dispatch", "schedule", "push"]'
           concurrent_skipping: false
 
-  e2e-tests:
+  e2e-multi-cluster-tests:
     runs-on: aliyun
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -64,6 +64,7 @@ jobs:
           kubectl version
           kubectl cluster-info
           kind get kubeconfig --name worker --internal > /tmp/worker.kubeconfig
+          kind get kubeconfig --name worker > /tmp/worker.client.kubeconfig
 
       - name: Setup Kind Cluster (Hub)
         run: |

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ docker-push:
 e2e-setup-core:
 	sh ./hack/e2e/modify_charts.sh
 	helm upgrade --install --create-namespace --namespace vela-system --set image.pullPolicy=IfNotPresent --set image.repository=vela-core-test --set applicationRevisionLimit=5 --set dependCheckWait=10s --set image.tag=$(GIT_COMMIT) --set multicluster.enabled=true --wait kubevela ./charts/vela-core
-	kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=vela-core,app.kubernetes.io/instance=kubevela -n vela-system --timeout=600s
+	kubectl wait --for=condition=Available deployment/kubevela-vela-core -n vela-system --timeout=180s
 
 e2e-setup:
 	helm install kruise https://github.com/openkruise/kruise/releases/download/v0.9.0/kruise-chart.tgz --set featureGates="PreDownloadImageForInPlaceUpdate=true"

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/oam-dev/terraform-controller v0.2.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.14.0
+	github.com/onsi/gomega v1.16.0
 	github.com/opencontainers/runc v1.0.0-rc95 // indirect
 	github.com/openkruise/kruise-api v0.9.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1244,8 +1244,9 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
 github.com/onsi/gomega v1.12.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
-github.com/onsi/gomega v1.14.0 h1:ep6kpPVwmr/nTbklSx2nrLNSIO62DoYAhnPNIMhK8gI=
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
+github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/hack/e2e/end_e2e.sh
+++ b/hack/e2e/end_e2e.sh
@@ -1,24 +1,4 @@
-CONTAINER_ID=$(docker exec kind-control-plane crictl ps | grep 'kubevela\s' | grep --regexp  '^.............' -o)
-DOCKER_DIR=$(docker exec kind-control-plane crictl inspect --output go-template --template '{{range .info.runtimeSpec.mounts}}{{if (eq .destination "/workspace/data")}}{{.source}}{{end}}{{end}}' "${CONTAINER_ID}")
-echo "${CONTAINER_ID}"
-echo "${DOCKER_DIR}"
-
-docker exec kind-control-plane crictl exec "${CONTAINER_ID}" kill -2 1
-
-file=$DOCKER_DIR/e2e-profile.out
-echo $file
-n=1
-while [ $n -le 60 ];do
-    if_exist=$(docker exec kind-control-plane sh -c "test -f $file && echo 'ok'")
-    echo $if_exist
-    if [ -n  "$if_exist" ];then
-        docker exec kind-control-plane cat $file > /tmp/e2e-profile.out
-        break
-    fi
-    echo file not generated yet
-    n=$(expr $n + 1)
-    sleep 1
-done
+. ./hack/e2e/end_e2e_core.sh
 
 OAM_CONTAINER_ID=$(docker exec kind-control-plane crictl ps | grep oam-runtime | grep --regexp  '^.............' -o)
 OAM_DOCKER_DIR=$(docker exec kind-control-plane crictl inspect --output go-template --template '{{range .info.runtimeSpec.mounts}}{{if (eq .destination "/workspace/data")}}{{.source}}{{end}}{{end}}' "${OAM_CONTAINER_ID}")

--- a/hack/e2e/end_e2e_core.sh
+++ b/hack/e2e/end_e2e_core.sh
@@ -1,0 +1,21 @@
+CONTAINER_ID=$(docker exec kind-control-plane crictl ps | grep 'kubevela\s' | grep --regexp  '^.............' -o)
+DOCKER_DIR=$(docker exec kind-control-plane crictl inspect --output go-template --template '{{range .info.runtimeSpec.mounts}}{{if (eq .destination "/workspace/data")}}{{.source}}{{end}}{{end}}' "${CONTAINER_ID}")
+echo "${CONTAINER_ID}"
+echo "${DOCKER_DIR}"
+
+docker exec kind-control-plane crictl exec "${CONTAINER_ID}" kill -2 1
+
+file=$DOCKER_DIR/e2e-profile.out
+echo $file
+n=1
+while [ $n -le 60 ];do
+    if_exist=$(docker exec kind-control-plane sh -c "test -f $file && echo 'ok'")
+    echo $if_exist
+    if [ -n  "$if_exist" ];then
+        docker exec kind-control-plane cat $file > /tmp/e2e-profile.out
+        break
+    fi
+    echo file not generated yet
+    n=$(expr $n + 1)
+    sleep 1
+done

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -1,0 +1,66 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package e2e_multicluster_test
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/oam-dev/kubevela/references/cli"
+)
+
+func execCommand(args ...string) (string, error) {
+	command := cli.NewCommand()
+	command.SetArgs(args)
+	var buf bytes.Buffer
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	err := command.Execute()
+	return buf.String(), err
+}
+
+var _ = Describe("multicluster related e2e-test.", func() {
+
+	Context("Test vela cluster command", func() {
+
+		It("Test adding cluster by kubeconfig", func() {
+			const oldClusterName = "worker-cluster"
+			const newClusterName = "cluster-worker"
+			_, err := execCommand("cluster", "list")
+			Expect(err).Should(Succeed())
+			_, err = execCommand("cluster", "join", "/tmp/worker.kubeconfig", "--name", oldClusterName)
+			Expect(err).Should(Succeed())
+			out, err := execCommand("cluster", "list")
+			Expect(err).Should(Succeed())
+			Expect(out).Should(ContainSubstring(oldClusterName))
+			_, err = execCommand("cluster", "rename", oldClusterName, newClusterName)
+			Expect(err).Should(Succeed())
+			out, err = execCommand("cluster", "list")
+			Expect(err).Should(Succeed())
+			Expect(out).Should(ContainSubstring(newClusterName))
+			_, err = execCommand("cluster", "detach", newClusterName)
+			Expect(err).Should(Succeed())
+			out, err = execCommand("cluster", "list")
+			Expect(err).Should(Succeed())
+			Expect(out).ShouldNot(ContainSubstring(newClusterName))
+		})
+
+	})
+
+})

--- a/test/e2e-multicluster-test/suite_test.go
+++ b/test/e2e-multicluster-test/suite_test.go
@@ -17,13 +17,60 @@ limitations under the License.
 package e2e_multicluster_test
 
 import (
+	"bytes"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/references/cli"
 )
+
+const (
+	WorkerClusterName = "cluster-worker"
+	WorkerClusterKubeConfigPath = "/tmp/worker.kubeconfig"
+)
+
+var (
+	k8sClient client.Client
+)
+
+func execCommand(args ...string) (string, error) {
+	command := cli.NewCommand()
+	command.SetArgs(args)
+	var buf bytes.Buffer
+	command.SetOut(&buf)
+	command.SetErr(&buf)
+	err := command.Execute()
+	return buf.String(), err
+}
 
 func TestMulticluster(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "KubeVela MultiCluster Test Suite")
 }
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// initialize clients
+	options := client.Options{Scheme: common.Scheme}
+	config := config.GetConfigOrDie()
+	config.Wrap(multicluster.NewSecretModeMultiClusterRoundTripper)
+	k8sClient, err = client.New(config, options)
+	Expect(err).Should(Succeed())
+
+	// join worker cluster
+	_, err = execCommand("cluster", "join", WorkerClusterKubeConfigPath, "--name", WorkerClusterName)
+	Expect(err).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	_, err := execCommand("cluster", "detach", WorkerClusterName)
+	Expect(err).Should(Succeed())
+})

--- a/test/e2e-multicluster-test/suite_test.go
+++ b/test/e2e-multicluster-test/suite_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
@@ -32,7 +31,7 @@ import (
 )
 
 const (
-	WorkerClusterName = "cluster-worker"
+	WorkerClusterName           = "cluster-worker"
 	WorkerClusterKubeConfigPath = "/tmp/worker.kubeconfig"
 )
 

--- a/test/e2e-multicluster-test/suite_test.go
+++ b/test/e2e-multicluster-test/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_multicluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMulticluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "KubeVela MultiCluster Test Suite")
+}

--- a/test/e2e-multicluster-test/testdata/app/example-envbinding-app.yaml
+++ b/test/e2e-multicluster-test/testdata/app/example-envbinding-app.yaml
@@ -1,0 +1,64 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: example-app
+  namespace: default
+spec:
+  components:
+    - name: hello-world-server
+      type: webservice
+      properties:
+        image: crccheck/hello-world
+        port: 8000
+      traits:
+        - type: scaler
+          properties:
+            replicas: 1
+    - name: data-worker
+      type: worker
+      properties:
+        image: busybox
+        cmd:
+          - sleep
+          - '1000000'
+  policies:
+    - name: example-multi-env-policy
+      type: env-binding
+      properties:
+        envs:
+          - name: staging
+            placement: # selecting the cluster to deploy to
+              clusterSelector:
+                name: local
+            selector:
+              components:
+                - data-worker
+
+          - name: prod
+            placement:
+              clusterSelector:
+                name: cluster-worker
+            patch: # overlay patch on above components
+              components:
+                - name: hello-world-server
+                  type: webservice
+                  traits:
+                    - type: scaler
+                      properties:
+                        replicas: 3
+
+  workflow:
+    steps:
+      # deploy to staging env
+      - name: deploy-staging
+        type: deploy2env
+        properties:
+          policy: example-multi-env-policy
+          env: staging
+
+      # deploy to prod env
+      - name: deploy-prod
+        type: deploy2env
+        properties:
+          policy: example-multi-env-policy
+          env: prod


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/oam-dev/kubevela/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Application: Add health check for application.
   If it's a fix or feature relevant for the changelog describe the user impact in the title.
   The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

1. Bootstrap new CI action to run e2e test for multi-cluster.
2. Multi-cluster e2e test will start 2 kind clusters while running. One cluster (Hub) will install KubeVela as normal. The other one will be an empty cluster.
3. Multi-cluster e2e test use simplified setup process which only install vela-core without oam-runtime or any addon (like flux or terraform).
4. The e2e test coverage report will be uploaded so that multi-cluster related Vela CLI test could be implemented and covered.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

