### PR TITLE
Fix: multicluster component revision location

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/generator.go
@@ -134,14 +134,7 @@ func (h *AppHandler) renderComponentFunc(appParser *appfile.Parser, appRev *v1be
 
 func (h *AppHandler) applyComponentFunc(appParser *appfile.Parser, appRev *v1beta1.ApplicationRevision, af *appfile.Appfile) oamProvider.ComponentApply {
 	return func(comp common.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
-		ctx := multicluster.ContextWithClusterName(context.Background(), clusterName)
-		if overrideNamespace != "" {
-			oldNamespace := h.app.Namespace
-			h.app.Namespace = overrideNamespace
-			defer func() {
-				h.app.Namespace = oldNamespace
-			}()
-		}
+		ctx := contextWithComponentRevisionNamespace(multicluster.ContextWithClusterName(context.Background(), clusterName), overrideNamespace)
 
 		wl, manifest, err := h.prepareWorkloadAndManifests(ctx, appParser, comp, appRev, patcher, af)
 		if err != nil {

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -228,6 +228,10 @@ var _ = Describe("Test multicluster scenario", func() {
 				deploys = &v13.DeploymentList{}
 				g.Expect(k8sClient.List(workerCtx, deploys, client.InNamespace(prodNamespace))).Should(Succeed())
 				g.Expect(len(deploys.Items)).Should(Equal(2))
+				// check component revision
+				compRevs := &v13.ControllerRevisionList{}
+				g.Expect(k8sClient.List(workerCtx, compRevs, client.InNamespace(prodNamespace))).Should(Succeed())
+				g.Expect(len(compRevs.Items)).Should(Equal(2))
 			}, time.Minute).Should(Succeed())
 			Expect(hubDeployName).Should(Equal("data-worker"))
 			// delete application
@@ -242,6 +246,10 @@ var _ = Describe("Test multicluster scenario", func() {
 				deploys = &v13.DeploymentList{}
 				g.Expect(k8sClient.List(workerCtx, deploys, client.InNamespace(namespace))).Should(Succeed())
 				g.Expect(len(deploys.Items)).Should(Equal(0))
+				// check component revision
+				compRevs := &v13.ControllerRevisionList{}
+				g.Expect(k8sClient.List(workerCtx, compRevs, client.InNamespace(prodNamespace))).Should(Succeed())
+				g.Expect(len(compRevs.Items)).Should(Equal(0))
 			}, time.Minute).Should(Succeed())
 		})
 
@@ -316,6 +324,19 @@ var _ = Describe("Test multicluster scenario", func() {
 				g.Expect(k8sClient.List(workerCtx, deploys, client.InNamespace(testNamespace))).Should(Succeed())
 				g.Expect(len(deploys.Items)).Should(Equal(1))
 				g.Expect(int(*deploys.Items[0].Spec.Replicas)).Should(Equal(2))
+			}, time.Minute).Should(Succeed())
+			// delete application
+			By("delete application")
+			Expect(k8sClient.Delete(hubCtx, app)).Should(Succeed())
+			By("wait application resource delete")
+			Eventually(func(g Gomega) {
+				// check deployments in clusters
+				deploys := &v13.DeploymentList{}
+				g.Expect(k8sClient.List(hubCtx, deploys, client.InNamespace(testNamespace))).Should(Succeed())
+				g.Expect(len(deploys.Items)).Should(Equal(0))
+				deploys = &v13.DeploymentList{}
+				g.Expect(k8sClient.List(workerCtx, deploys, client.InNamespace(testNamespace))).Should(Succeed())
+				g.Expect(len(deploys.Items)).Should(Equal(0))
 			}, time.Minute).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

In envbinding, the component revisions are placed at the namespace where Application locates in hub cluster. However, it is not necessary for child cluster to have that namespace if user choose to deploy at a different namespace. This PR lets the `overrideNamespace` works for ComponentRevisions as well.
 
Fixes #2546

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->