### PR TITLE
Feat: Add ConfigMap annotations for all addons

### DIFF
--- a/charts/vela-core/templates/addons/fluxcd.yaml
+++ b/charts/vela-core/templates/addons/fluxcd.yaml
@@ -6023,6 +6023,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.fluxcd.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: Flux is a set of continuous and progressive delivery
       solutions for Kubernetes
     addons.oam.dev/name: fluxcd

--- a/charts/vela-core/templates/addons/istio.yaml
+++ b/charts/vela-core/templates/addons/istio.yaml
@@ -248,6 +248,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.istio.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: istio Controller is a Kubernetes Controller for manage
       traffic.
     addons.oam.dev/name: istio

--- a/charts/vela-core/templates/addons/keda.yaml
+++ b/charts/vela-core/templates/addons/keda.yaml
@@ -29,6 +29,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.keda.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: KEDA is a Kubernetes-based Event Driven Autoscaler.
     addons.oam.dev/name: keda
   labels:

--- a/charts/vela-core/templates/addons/kruise.yaml
+++ b/charts/vela-core/templates/addons/kruise.yaml
@@ -173,6 +173,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.kruise.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: Kruise is a Kubernetes extended suite for application
       automations
     addons.oam.dev/name: kruise

--- a/charts/vela-core/templates/addons/observability.yaml
+++ b/charts/vela-core/templates/addons/observability.yaml
@@ -234,6 +234,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.observability.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: An out of the box solution for KubeVela observability
     addons.oam.dev/name: observability
   labels:

--- a/charts/vela-core/templates/addons/ocm-cluster-manager.yaml
+++ b/charts/vela-core/templates/addons/ocm-cluster-manager.yaml
@@ -506,6 +506,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.ocmClusterManager.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: ocm-cluster-manager can deploy an OCM hub cluster
       environment.
     addons.oam.dev/name: ocm-cluster-manager

--- a/charts/vela-core/templates/addons/prometheus.yaml
+++ b/charts/vela-core/templates/addons/prometheus.yaml
@@ -30,6 +30,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.prometheus.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: Prometheus is an open-source systems monitoring and
       alerting toolkit
     addons.oam.dev/name: prometheus

--- a/charts/vela-core/templates/addons/terraform-provider-alibaba.yaml
+++ b/charts/vela-core/templates/addons/terraform-provider-alibaba.yaml
@@ -46,6 +46,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.terraformProviderAlibaba.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: Kubernetes Terraform Controller for Alibaba Cloud
     addons.oam.dev/name: terraform/provider-alibaba
   labels:

--- a/charts/vela-core/templates/addons/terraform-provider-aws.yaml
+++ b/charts/vela-core/templates/addons/terraform-provider-aws.yaml
@@ -46,6 +46,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.terraformProviderAws.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: Kubernetes Terraform Controller for AWS
     addons.oam.dev/name: terraform/provider-aws
   labels:

--- a/charts/vela-core/templates/addons/terraform-provider-azure.yaml
+++ b/charts/vela-core/templates/addons/terraform-provider-azure.yaml
@@ -46,6 +46,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.terraformProviderAzure.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: Kubernetes Terraform Controller for Azure
     addons.oam.dev/name: terraform/provider-azure
   labels:

--- a/charts/vela-core/templates/addons/terraform.yaml
+++ b/charts/vela-core/templates/addons/terraform.yaml
@@ -346,6 +346,9 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
+{{- with .Values.addons.terraform.configMapAnnotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
     addons.oam.dev/description: Terraform Controller is a Kubernetes Controller for
       Terraform.
     addons.oam.dev/name: terraform

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -131,3 +131,27 @@ multicluster:
     secureTLS:
       enabled: true
       certPath: /etc/k8s-cluster-gateway-certs
+
+addons:
+  fluxcd:
+    configMapAnnotations: {}
+  istio:
+    configMapAnnotations: {}
+  keda:
+    configMapAnnotations: {}
+  kruise:
+    configMapAnnotations: {}
+  observability:
+    configMapAnnotations: {}
+  ocmClusterManager:
+    configMapAnnotations: {}
+  prometheus:
+    configMapAnnotations: {}
+  terraformProviderAlibaba:
+    configMapAnnotations: {}
+  terraformProviderAws:
+    configMapAnnotations: {}
+  terraformProviderAzure:
+    configMapAnnotations: {}
+  terraform:
+    configMapAnnotations: {}


### PR DESCRIPTION
Allows additional annotations to be added to the ConfigMap resources for all addons in the `vela-core` helm chart.

Fixes #2559 

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [X] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I've successfully deployed this version of the `vela-core` helm chart against our cluster with additional annotations passed in via Helm.
