### PR TITLE
Feat: vela logs support multicluster

### DIFF
--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	oamcore "github.com/oam-dev/kubevela/apis/core.oam.dev"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	oamstandard "github.com/oam-dev/kubevela/apis/standard.oam.dev/v1alpha1"
 	velacue "github.com/oam-dev/kubevela/pkg/cue"
 	"github.com/oam-dev/kubevela/pkg/cue/model"
@@ -237,6 +238,51 @@ func RealtimePrintCommandOutput(cmd *exec.Cmd, logFile string) error {
 		return err
 	}
 	return nil
+}
+
+// ClusterObject2Map convert ClusterObjectReference to a readable map
+func ClusterObject2Map(refs ...common.ClusterObjectReference) map[string]string {
+	clusterResourceRefTmpl := "Cluster %s Namespace: %s GVK: %s/%s Name:%s"
+	objs := make(map[string]string, len(refs))
+	for _, r := range refs {
+		if r.Cluster == "" {
+			r.Cluster = "local"
+		}
+		objs[r.Name] = fmt.Sprintf(clusterResourceRefTmpl, r.Cluster, r.Namespace, r.APIVersion, r.ResourceVersion, r.Name)
+	}
+	return objs
+}
+
+// AskToChooseOneAppliedResource will ask users to select one applied resource of the application if more than one
+// resources is a map for component to applied resources
+// return the selected ClusterObjectReference
+func AskToChooseOneAppliedResource(resources []common.ClusterObjectReference) (*common.ClusterObjectReference, error) {
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("no applied resources exist in the application")
+	}
+	if len(resources) == 1 {
+		return &resources[0], nil
+	}
+	opMap := ClusterObject2Map(resources...)
+	var ops []string
+	for _, r := range opMap {
+		ops = append(ops, r)
+	}
+	prompt := &survey.Select{
+		Message: "You have multiple applied resources in your app. Please choose one:",
+		Options: ops,
+	}
+	var selectedRsc string
+	err := survey.AskOne(prompt, &selectedRsc)
+	if err != nil {
+		return nil, fmt.Errorf("choosing resource err %w", err)
+	}
+	for k, resource := range ops {
+		if selectedRsc == resource {
+			return &resources[k], nil
+		}
+	}
+	return nil, fmt.Errorf("choosing resource err %w", err)
 }
 
 // AskToChooseOneService will ask users to select one service of the application if more than one exidi

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -242,7 +242,7 @@ func RealtimePrintCommandOutput(cmd *exec.Cmd, logFile string) error {
 
 // ClusterObject2Map convert ClusterObjectReference to a readable map
 func ClusterObject2Map(refs ...common.ClusterObjectReference) map[string]string {
-	clusterResourceRefTmpl := "Cluster %s | Namespace: %s | GVK: %s/%s | Name:%s"
+	clusterResourceRefTmpl := "Cluster: %s | Namespace: %s | GVK: %s/%s | Name: %s"
 	objs := make(map[string]string, len(refs))
 	for _, r := range refs {
 		if r.Cluster == "" {

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -241,7 +241,7 @@ func RealtimePrintCommandOutput(cmd *exec.Cmd, logFile string) error {
 }
 
 // ClusterObject2Map convert ClusterObjectReference to a readable map
-func ClusterObject2Map(refs ...common.ClusterObjectReference) map[string]string {
+func ClusterObject2Map(refs []common.ClusterObjectReference) map[string]string {
 	clusterResourceRefTmpl := "Cluster: %s | Namespace: %s | GVK: %s/%s | Name: %s"
 	objs := make(map[string]string, len(refs))
 	for _, r := range refs {
@@ -263,7 +263,7 @@ func AskToChooseOneAppliedResource(resources []common.ClusterObjectReference) (*
 	if len(resources) == 1 {
 		return &resources[0], nil
 	}
-	opMap := ClusterObject2Map(resources...)
+	opMap := ClusterObject2Map(resources)
 	var ops []string
 	for _, r := range opMap {
 		ops = append(ops, r)

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -242,7 +242,7 @@ func RealtimePrintCommandOutput(cmd *exec.Cmd, logFile string) error {
 
 // ClusterObject2Map convert ClusterObjectReference to a readable map
 func ClusterObject2Map(refs ...common.ClusterObjectReference) map[string]string {
-	clusterResourceRefTmpl := "Cluster %s Namespace: %s GVK: %s/%s Name:%s"
+	clusterResourceRefTmpl := "Cluster %s | Namespace: %s | GVK: %s/%s | Name:%s"
 	objs := make(map[string]string, len(refs))
 	for _, r := range refs {
 		if r.Cluster == "" {

--- a/references/appfile/app.go
+++ b/references/appfile/app.go
@@ -24,6 +24,8 @@ import (
 	"reflect"
 	"sort"
 
+	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
@@ -84,7 +86,12 @@ func LoadApplication(namespace, appName string, c common.Args) (*v1beta1.Applica
 	return app, nil
 }
 
-// GetComponents will get oam components from Appfile.
+// GetAppliedResources get applied resources form v1beta1.Application.
+func GetAppliedResources(app *v1beta1.Application) []common2.ClusterObjectReference {
+	return app.Status.AppliedResources
+}
+
+// GetComponents will get oam components from v1beta1.Application.
 func GetComponents(app *v1beta1.Application) []string {
 	var components []string
 	for _, cmp := range app.Spec.Components {

--- a/references/appfile/app.go
+++ b/references/appfile/app.go
@@ -24,8 +24,6 @@ import (
 	"reflect"
 	"sort"
 
-	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha2"
@@ -84,11 +82,6 @@ func LoadApplication(namespace, appName string, c common.Args) (*v1beta1.Applica
 		return nil, err
 	}
 	return app, nil
-}
-
-// GetAppliedResources get applied resources form v1beta1.Application.
-func GetAppliedResources(app *v1beta1.Application) []common2.ClusterObjectReference {
-	return app.Status.AppliedResources
 }
 
 // GetComponents will get oam components from v1beta1.Application.

--- a/references/cli/logs.go
+++ b/references/cli/logs.go
@@ -42,7 +42,7 @@ import (
 
 // NewLogsCommand creates `logs` command to tail logs of application
 func NewLogsCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
-	largs := &Args{C: c}
+	largs := &Args{Args: c}
 	cmd := &cobra.Command{
 		Use:   "logs <appName>",
 		Short: "Tail logs for application in multicluster",
@@ -52,8 +52,8 @@ func NewLogsCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
 			if err := c.SetConfig(); err != nil {
 				return err
 			}
-			largs.C = c
-			largs.C.Config.Wrap(multicluster.NewSecretModeMultiClusterRoundTripper)
+			largs.Args = c
+			largs.Args.Config.Wrap(multicluster.NewSecretModeMultiClusterRoundTripper)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -81,7 +81,7 @@ func NewLogsCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
 // Args creates arguments for `logs` command
 type Args struct {
 	Output    string
-	C         common.Args
+	Args      common.Args
 	Namespace string
 	App       *v1beta1.Application
 }
@@ -89,11 +89,11 @@ type Args struct {
 // Run refer to the implementation at https://github.com/oam-dev/stern/blob/master/stern/main.go
 func (l *Args) Run(ctx context.Context, ioStreams util.IOStreams) error {
 
-	clientSet, err := kubernetes.NewForConfig(l.C.Config)
+	clientSet, err := kubernetes.NewForConfig(l.Args.Config)
 	if err != nil {
 		return err
 	}
-	appliedResources := appfile.GetAppliedResources(l.App)
+	appliedResources := l.App.Status.AppliedResources
 
 	selectedRes, err := common.AskToChooseOneAppliedResource(appliedResources)
 	if err != nil {

--- a/references/cli/logs.go
+++ b/references/cli/logs.go
@@ -81,7 +81,6 @@ func NewLogsCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
 // Args creates arguments for `logs` command
 type Args struct {
 	Output    string
-	Env       *types.EnvMeta
 	C         common.Args
 	Namespace string
 	App       *v1beta1.Application

--- a/references/cli/logs.go
+++ b/references/cli/logs.go
@@ -100,7 +100,7 @@ func (l *Args) Run(ctx context.Context, ioStreams util.IOStreams) error {
 	if err != nil {
 		return err
 	}
-	multicluster.ContextWithClusterName(ctx, selectedRes.Cluster)
+	ctx = multicluster.ContextWithClusterName(ctx, selectedRes.Cluster)
 	// TODO(wonderflow): we could get labels from service to narrow the pods scope selected
 	labelSelector := labels.Everything()
 	pod, err := regexp.Compile(selectedRes.Name + "-.*")
@@ -108,7 +108,7 @@ func (l *Args) Run(ctx context.Context, ioStreams util.IOStreams) error {
 		return fmt.Errorf("fail to compile '%s' for logs query", selectedRes.Name+".*")
 	}
 	container := regexp.MustCompile(".*")
-	namespace := l.Env.Namespace
+	namespace := selectedRes.Namespace
 	added, removed, err := stern.Watch(ctx, clientSet.CoreV1().Pods(namespace), pod, container, nil, stern.RUNNING, labelSelector)
 	if err != nil {
 		return err

--- a/references/cli/logs.go
+++ b/references/cli/logs.go
@@ -24,6 +24,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -41,51 +43,48 @@ import (
 // NewLogsCommand creates `logs` command to tail logs of application
 func NewLogsCommand(c common.Args, ioStreams util.IOStreams) *cobra.Command {
 	largs := &Args{C: c}
-	cmd := &cobra.Command{}
-	cmd.Use = "logs"
-	cmd.Short = "Tail logs for application"
-	cmd.Long = "Tail logs for application"
-	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if err := c.SetConfig(); err != nil {
-			return err
-		}
-		largs.C = c
-		return nil
-	}
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			ioStreams.Errorf("please specify app name")
+	cmd := &cobra.Command{
+		Use:   "logs <appName>",
+		Short: "Tail logs for application in multicluster",
+		Long:  "Tail logs for application in multicluster",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := c.SetConfig(); err != nil {
+				return err
+			}
+			largs.C = c
+			largs.C.Config.Wrap(multicluster.NewSecretModeMultiClusterRoundTripper)
 			return nil
-		}
-		env, err := GetFlagEnvOrCurrent(cmd, c)
-		if err != nil {
-			return err
-		}
-		app, err := appfile.LoadApplication(env.Namespace, args[0], c)
-		if err != nil {
-			return err
-		}
-		largs.App = app
-		largs.Env = env
-		ctx := context.Background()
-		if err := largs.Run(ctx, ioStreams); err != nil {
-			return err
-		}
-		return nil
-	}
-	cmd.Annotations = map[string]string{
-		types.TagCommandType: types.TypeApp,
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := appfile.LoadApplication(largs.Namespace, args[0], c)
+			if err != nil {
+				return err
+			}
+			largs.App = app
+			ctx := context.Background()
+			if err := largs.Run(ctx, ioStreams); err != nil {
+				return err
+			}
+			return nil
+		},
+		Annotations: map[string]string{
+			types.TagCommandType: types.TypeApp,
+		},
 	}
 	cmd.Flags().StringVarP(&largs.Output, "output", "o", "default", "output format for logs, support: [default, raw, json]")
+	cmd.Flags().StringVarP(&largs.Namespace, "namespace", "n", "default", "application namespace")
+
 	return cmd
 }
 
 // Args creates arguments for `logs` command
 type Args struct {
-	Output string
-	Env    *types.EnvMeta
-	C      common.Args
-	App    *v1beta1.Application
+	Output    string
+	Env       *types.EnvMeta
+	C         common.Args
+	Namespace string
+	App       *v1beta1.Application
 }
 
 // Run refer to the implementation at https://github.com/oam-dev/stern/blob/master/stern/main.go
@@ -95,15 +94,18 @@ func (l *Args) Run(ctx context.Context, ioStreams util.IOStreams) error {
 	if err != nil {
 		return err
 	}
-	compName, err := common.AskToChooseOneService(appfile.GetComponents(l.App))
+	appliedResources := appfile.GetAppliedResources(l.App)
+
+	selectedRes, err := common.AskToChooseOneAppliedResource(appliedResources)
 	if err != nil {
 		return err
 	}
+	multicluster.ContextWithClusterName(ctx, selectedRes.Cluster)
 	// TODO(wonderflow): we could get labels from service to narrow the pods scope selected
 	labelSelector := labels.Everything()
-	pod, err := regexp.Compile(compName + "-.*")
+	pod, err := regexp.Compile(selectedRes.Name + "-.*")
 	if err != nil {
-		return fmt.Errorf("fail to compile '%s' for logs query", compName+".*")
+		return fmt.Errorf("fail to compile '%s' for logs query", selectedRes.Name+".*")
 	}
 	container := regexp.MustCompile(".*")
 	namespace := l.Env.Namespace


### PR DESCRIPTION
### Description of your changes

`vela logs` are now available for multicluster.
![image](https://user-images.githubusercontent.com/47812250/139664181-0111029a-bf11-4ad1-9a3b-8eaa7561ea35.png)

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->