### PR TITLE
Feat: add create cloud cluster interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8
+	github.com/agiledragon/gomonkey/v2 v2.3.0
 	github.com/alibabacloud-go/cs-20151215/v2 v2.4.5
 	github.com/alibabacloud-go/darabonba-openapi v0.1.4
 	github.com/alibabacloud-go/tea v1.1.15
-	github.com/agiledragon/gomonkey/v2 v2.3.0
 	github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/briandowns/spinner v1.11.1

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -139,6 +139,17 @@ type ConnectCloudClusterRequest struct {
 	Labels          map[string]string `json:"labels,omitempty"`
 }
 
+// CreateCloudClusterRequest request parameters to create a cloud cluster (buy one)
+type CreateCloudClusterRequest struct {
+	AccessKeyID       string `json:"accessKeyID"`
+	AccessKeySecret   string `json:"accessKeySecret"`
+	Name              string `json:"name" validate:"checkname"`
+	Zone              string `json:"zone"`
+	WorkerNumber      int    `json:"workerNumber"`
+	CPUCoresPerWorker int64  `json:"cpuCoresPerWorker"`
+	MemoryPerWorker   int64  `json:"memoryPerWorker"`
+}
+
 // ClusterResourceInfo resource info of cluster
 type ClusterResourceInfo struct {
 	WorkerNumber     int      `json:"workerNumber"`
@@ -169,6 +180,17 @@ type ListClusterResponse struct {
 type ListCloudClusterResponse struct {
 	Clusters []cloudprovider.CloudCluster `json:"clusters"`
 	Total    int                          `json:"total"`
+}
+
+// CreateCloudClusterResponse return values for cloud cluster create request
+type CreateCloudClusterResponse struct {
+	ClusterID string `json:"clusterID"`
+	Status    string `json:"status"`
+}
+
+// ListCloudClusterCreationResponse return the cluster names of creation process of cloud clusters
+type ListCloudClusterCreationResponse struct {
+	Creations []string `json:"creations"`
 }
 
 // ClusterBase cluster base model

--- a/pkg/apiserver/rest/utils/bcode/cluster.go
+++ b/pkg/apiserver/rest/utils/bcode/cluster.go
@@ -43,5 +43,17 @@ var ErrLocalClusterReserved = NewBcode(400, 40007, "local cluster is reserved")
 // ErrLocalClusterImmutable local cluster kubeConfig is immutable
 var ErrLocalClusterImmutable = NewBcode(400, 40008, "local cluster is immutable")
 
+// ErrCloudClusterAlreadyExists cloud cluster already exists
+var ErrCloudClusterAlreadyExists = NewBcode(400, 40009, "cloud cluster already exists")
+
+// ErrTerraformConfigurationNotFound cannot find terraform configuration
+var ErrTerraformConfigurationNotFound = NewBcode(404, 40010, "cannot find terraform configuration")
+
+// ErrClusterIDNotFoundInTerraformConfiguration cannot find cluster_id in terraform configuration
+var ErrClusterIDNotFoundInTerraformConfiguration = NewBcode(500, 40011, "cannot find cluster_id in terraform configuration")
+
+// ErrBootstrapTerraformConfiguration failed to bootstrap terraform configuration
+var ErrBootstrapTerraformConfiguration = NewBcode(500, 40012, "failed to bootstrap terraform configuration")
+
 // ErrInvalidAccessKeyOrSecretKey access key or secret key is invalid
 var ErrInvalidAccessKeyOrSecretKey = NewBcode(400, 40013, "access key or secret key is invalid")

--- a/pkg/cloudprovider/cluster.go
+++ b/pkg/cloudprovider/cluster.go
@@ -17,7 +17,15 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// CloudClusterCreatorLabelKey labels the creator of cloud cluster
+	CloudClusterCreatorLabelKey = "api.core.oam.dev/cloud-cluster-creator"
 )
 
 // CloudClusterProvider abstracts the cloud provider to provide cluster access
@@ -26,13 +34,14 @@ type CloudClusterProvider interface {
 	ListCloudClusters(pageNumber int, pageSize int) ([]*CloudCluster, int, error)
 	GetClusterKubeConfig(clusterID string) (string, error)
 	GetClusterInfo(clusterID string) (*CloudCluster, error)
+	CreateCloudCluster(ctx context.Context, clusterName string, zone string, worker int, cpu int64, mem int64) (string, error)
 }
 
 // GetClusterProvider creates interface for getting cloud cluster provider
-func GetClusterProvider(provider string, accessKeyID string, accessKeySecret string) (CloudClusterProvider, error) {
+func GetClusterProvider(provider string, accessKeyID string, accessKeySecret string, k8sClient client.Client) (CloudClusterProvider, error) {
 	switch provider {
 	case ProviderAliyun:
-		return NewAliyunCloudProvider(accessKeyID, accessKeySecret)
+		return NewAliyunCloudProvider(accessKeyID, accessKeySecret, k8sClient)
 	default:
 		return nil, errors.Errorf("cluster provider %s is not implemented", provider)
 	}

--- a/pkg/cloudprovider/terraform.go
+++ b/pkg/cloudprovider/terraform.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+
+	types "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
+	v1beta12 "github.com/oam-dev/terraform-controller/api/v1beta1"
+	"github.com/pkg/errors"
+	v12 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func computeProviderHashKey(provider string, accessKeyID string, accessKeySecret string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join([]string{provider, accessKeyID, accessKeySecret}, "::"))))[:8] // #nosec
+}
+
+// GetCloudClusterFullName construct the full name of cloud cluster which will be used as the name of terraform configuration
+func GetCloudClusterFullName(provider string, clusterName string) string {
+	return fmt.Sprintf("cloud-cluster-%s-%s", provider, clusterName)
+}
+
+func bootstrapTerraformProvider(ctx context.Context, k8sClient client.Client, ns string, provider string, tfProvider string, accessKeyID string, accessKeySecret string, region string) (string, error) {
+	hashKey := computeProviderHashKey(provider, accessKeyID, accessKeySecret)
+	secretName := fmt.Sprintf("tf-provider-cred-%s-%s", provider, hashKey)
+	terraformProviderName := fmt.Sprintf("tf-provider-%s-%s", provider, hashKey)
+	secret := v12.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      secretName,
+			Namespace: ns,
+		},
+		StringData: map[string]string{"credentials": fmt.Sprintf("accessKeyID: %s\naccessKeySecret: %s\nsecurityToken:\n", accessKeyID, accessKeySecret)},
+		Type:       v12.SecretTypeOpaque,
+	}
+	var err error
+	if err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&secret), &v12.Secret{}); err != nil {
+		if kerrors.IsNotFound(err) {
+			err = k8sClient.Create(ctx, &secret)
+		}
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to upsert terraform provider secret")
+		}
+	}
+
+	terraformProvider := v1beta12.Provider{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      terraformProviderName,
+			Namespace: ns,
+		},
+		Spec: v1beta12.ProviderSpec{
+			Credentials: v1beta12.ProviderCredentials{
+				SecretRef: &types.SecretKeySelector{
+					Key: "credentials",
+					SecretReference: types.SecretReference{
+						Name:      secretName,
+						Namespace: ns,
+					},
+				},
+				Source: types.CredentialsSourceSecret,
+			},
+			Provider: tfProvider,
+			Region:   region,
+		},
+	}
+	if err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&terraformProvider), &v1beta12.Provider{}); err != nil {
+		if kerrors.IsNotFound(err) {
+			err = k8sClient.Create(ctx, &terraformProvider)
+		}
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to upsert terraform provider")
+		}
+	}
+	return terraformProviderName, nil
+}

--- a/pkg/utils/util/k8s.go
+++ b/pkg/utils/util/k8s.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io/ioutil"
+
+	"github.com/oam-dev/kubevela/apis/types"
+)
+
+// GetRuntimeNamespace get namespace of the current running pod, fall back to default vela system
+func GetRuntimeNamespace() string {
+	ns, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return types.DefaultKubeVelaNS
+	}
+	return string(ns)
+}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Add create cloud cluster API and support ACK.
+ Create ACK Cluster
+ Get creation status
+ List all creation
+ Cancel creation

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

This part of API does not have unit-test since creating cluster is heavy and is not suitable for being used in test. It has been tested manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

**Implementation**:

Since currently the terraform part (terraform-controller:v0.2.6) do not support multi-tenant natively, the implementation of these APIs are directly working with underlying Terraform Configuration CRDs.

To create an ACK cluster, the creation API executes the following steps:
1. APIServer creates a secret containing AK/SK for providers to use.
2. APIServer creates a Terraform Provider to use the AK/SK.
3. APIServer creates a Terraform Configuration which leverages the provider established in step 2.
4. Terraform Controller will observe the Terraform Configuration and create a job to apply the resource through Terraform.

Step 1 & 2 uses the hash of [AK;SK] as its key, so that later requests with same AK/SK can reuse it.
Configuration created by Step 3 can be manipulated through GET/LIST/DELETE APIs. The DELETE API will trigger the deletion process of the target ACK cluster.

Several things to notice which are not addressed in this PR:
1. There is no AK/SK GC.
2. There is no paging for the list API.
3. The creation process could hang due to invalid resource request, which in return will block the DELETE as well. See #2598. 

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->