### PR TITLE
Feat: rewrite Addon API to support new format

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -137,6 +137,12 @@
     "parameters": [
      {
       "type": "string",
+      "description": "filter addons from given registry",
+      "name": "registry",
+      "in": "query"
+     },
+     {
+      "type": "string",
       "description": "Fuzzy search based on name and description.",
       "name": "query",
       "in": "query"
@@ -248,6 +254,14 @@
     "summary": "enable an addon",
     "operationId": "enableAddon",
     "parameters": [
+     {
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1.EnableAddonRequest"
+      }
+     },
      {
       "type": "string",
       "description": "addon name to enable",
@@ -2247,8 +2261,8 @@
    "required": [
     "rollingState",
     "batchRollingState",
-    "upgradedReplicas",
     "currentBatch",
+    "upgradedReplicas",
     "upgradedReadyReplicas",
     "lastTargetAppRevision"
    ],
@@ -2939,6 +2953,196 @@
     }
    }
   },
+  "regexp.Regexp": {
+   "required": [
+    "expr",
+    "prog",
+    "onepass",
+    "numSubexp",
+    "maxBitStateLen",
+    "subexpNames",
+    "prefix",
+    "prefixBytes",
+    "prefixRune",
+    "prefixEnd",
+    "mpool",
+    "matchcap",
+    "prefixComplete",
+    "cond",
+    "minInputLen",
+    "longest"
+   ],
+   "properties": {
+    "cond": {
+     "type": "integer",
+     "format": "byte"
+    },
+    "expr": {
+     "type": "string"
+    },
+    "longest": {
+     "type": "boolean"
+    },
+    "matchcap": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "maxBitStateLen": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "minInputLen": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "mpool": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "numSubexp": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "onepass": {
+     "$ref": "#/definitions/regexp.onePassProg"
+    },
+    "prefix": {
+     "type": "string"
+    },
+    "prefixBytes": {
+     "type": "string"
+    },
+    "prefixComplete": {
+     "type": "boolean"
+    },
+    "prefixEnd": {
+     "type": "integer",
+     "format": "integer"
+    },
+    "prefixRune": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "prog": {
+     "$ref": "#/definitions/syntax.Prog"
+    },
+    "subexpNames": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "regexp.onePassInst": {
+   "required": [
+    "Op",
+    "Out",
+    "Arg",
+    "Rune",
+    "Next"
+   ],
+   "properties": {
+    "Arg": {
+     "type": "integer",
+     "format": "integer"
+    },
+    "Next": {
+     "type": "array",
+     "items": {
+      "type": "integer"
+     }
+    },
+    "Op": {
+     "type": "integer",
+     "format": "byte"
+    },
+    "Out": {
+     "type": "integer",
+     "format": "integer"
+    },
+    "Rune": {
+     "type": "array",
+     "items": {
+      "type": "integer"
+     }
+    }
+   }
+  },
+  "regexp.onePassProg": {
+   "required": [
+    "Inst",
+    "Start",
+    "NumCap"
+   ],
+   "properties": {
+    "Inst": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/regexp.onePassInst"
+     }
+    },
+    "NumCap": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "Start": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  },
+  "syntax.Inst": {
+   "required": [
+    "Op",
+    "Out",
+    "Arg",
+    "Rune"
+   ],
+   "properties": {
+    "Arg": {
+     "type": "integer",
+     "format": "integer"
+    },
+    "Op": {
+     "type": "integer",
+     "format": "byte"
+    },
+    "Out": {
+     "type": "integer",
+     "format": "integer"
+    },
+    "Rune": {
+     "type": "array",
+     "items": {
+      "type": "integer"
+     }
+    }
+   }
+  },
+  "syntax.Prog": {
+   "required": [
+    "Inst",
+    "Start",
+    "NumCap"
+   ],
+   "properties": {
+    "Inst": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/syntax.Inst"
+     }
+    },
+    "NumCap": {
+     "type": "integer",
+     "format": "int32"
+    },
+    "Start": {
+     "type": "integer",
+     "format": "int32"
+    }
+   }
+  },
   "types.Parameter": {
    "required": [
     "name"
@@ -2989,15 +3193,58 @@
     }
    }
   },
+  "v1.AddonDependency": {
+   "properties": {
+    "name": {
+     "type": "string"
+    }
+   }
+  },
+  "v1.AddonDeployTo": {
+   "required": [
+    "control_plane",
+    "runtime_cluster"
+   ],
+   "properties": {
+    "control_plane": {
+     "type": "boolean"
+    },
+    "runtime_cluster": {
+     "type": "boolean"
+    }
+   }
+  },
+  "v1.AddonElementFile": {
+   "required": [
+    "Data",
+    "Name"
+   ],
+   "properties": {
+    "Data": {
+     "type": "string"
+    },
+    "Name": {
+     "type": "string"
+    }
+   }
+  },
   "v1.AddonMeta": {
    "required": [
     "name",
     "version",
     "description",
-    "icon",
-    "tags"
+    "icon"
    ],
    "properties": {
+    "dependencies": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.AddonDependency"
+     }
+    },
+    "deploy_to": {
+     "$ref": "#/definitions/v1.AddonDeployTo"
+    },
     "description": {
      "type": "string"
     },
@@ -3012,6 +3259,9 @@
      "items": {
       "type": "string"
      }
+    },
+    "url": {
+     "type": "string"
     },
     "version": {
      "type": "string"
@@ -3528,10 +3778,10 @@
   },
   "v1.CreateApplicationEnvPlanRequest": {
    "required": [
+    "clusterSelector",
     "componentSelector",
     "name",
-    "alias",
-    "clusterSelector"
+    "alias"
    ],
    "properties": {
     "alias": {
@@ -3820,6 +4070,24 @@
     }
    }
   },
+  "v1.Definition": {
+   "required": [
+    "kind",
+    "name",
+    "description"
+   ],
+   "properties": {
+    "description": {
+     "type": "string"
+    },
+    "kind": {
+     "type": "string"
+    },
+    "name": {
+     "type": "string"
+    }
+   }
+  },
   "v1.DefinitionBase": {
    "required": [
     "name",
@@ -3840,16 +4108,53 @@
   },
   "v1.DefinitionProperties": {
    "required": [
-    "default",
-    "description",
     "title",
-    "type"
+    "type",
+    "compiledPattern"
    ],
    "properties": {
+    "compiledPattern": {
+     "$ref": "#/definitions/regexp.Regexp"
+    },
     "default": {
-     "type": "string"
+     "$ref": "#/definitions/v1.DefinitionProperties.default"
     },
     "description": {
+     "type": "string"
+    },
+    "enum": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.DefinitionProperties.enum"
+     }
+    },
+    "example": {
+     "$ref": "#/definitions/v1.DefinitionProperties.example"
+    },
+    "items": {
+     "$ref": "#/definitions/v1.DefinitionSchema"
+    },
+    "maxLength": {
+     "type": "integer",
+     "format": "integer"
+    },
+    "maximum": {
+     "type": "number",
+     "format": "double"
+    },
+    "minLength": {
+     "type": "integer",
+     "format": "integer"
+    },
+    "minimum": {
+     "type": "number",
+     "format": "double"
+    },
+    "multipleOf": {
+     "type": "number",
+     "format": "double"
+    },
+    "pattern": {
      "type": "string"
     },
     "title": {
@@ -3860,6 +4165,9 @@
     }
    }
   },
+  "v1.DefinitionProperties.default": {},
+  "v1.DefinitionProperties.enum": {},
+  "v1.DefinitionProperties.example": {},
   "v1.DefinitionSchema": {
    "required": [
     "properties",
@@ -3890,11 +4198,31 @@
     "version",
     "description",
     "icon",
-    "tags"
+    "definitions",
+    "parameters",
+    "cue_templates"
    ],
    "properties": {
-    "deploy_data": {
-     "type": "string"
+    "cue_templates": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.AddonElementFile"
+     }
+    },
+    "definitions": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.Definition"
+     }
+    },
+    "dependencies": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.AddonDependency"
+     }
+    },
+    "deploy_to": {
+     "$ref": "#/definitions/v1.AddonDeployTo"
     },
     "description": {
      "type": "string"
@@ -3908,28 +4236,40 @@
     "name": {
      "type": "string"
     },
+    "parameters": {
+     "type": "string"
+    },
     "tags": {
      "type": "array",
      "items": {
       "type": "string"
      }
     },
+    "url": {
+     "type": "string"
+    },
     "version": {
      "type": "string"
+    },
+    "yaml_templates": {
+     "type": "array",
+     "items": {
+      "$ref": "#/definitions/v1.AddonElementFile"
+     }
     }
    }
   },
   "v1.DetailApplicationPlanResponse": {
    "required": [
-    "name",
+    "createTime",
+    "status",
     "namespace",
-    "icon",
-    "gatewayRule",
     "alias",
     "description",
-    "createTime",
     "updateTime",
-    "status",
+    "icon",
+    "gatewayRule",
+    "name",
     "policies",
     "status",
     "resourceInfo",
@@ -3999,20 +4339,20 @@
   },
   "v1.DetailClusterResponse": {
    "required": [
-    "reason",
-    "provider",
-    "updateTime",
-    "description",
-    "dashboardURL",
-    "kubeConfigSecret",
-    "createTime",
     "name",
     "icon",
-    "apiServerURL",
+    "provider",
+    "kubeConfigSecret",
     "alias",
-    "labels",
     "status",
+    "labels",
+    "description",
+    "reason",
+    "apiServerURL",
+    "dashboardURL",
     "kubeConfig",
+    "createTime",
+    "updateTime",
     "resourceInfo"
    ],
    "properties": {
@@ -4070,12 +4410,12 @@
   },
   "v1.DetailComponentPlanResponse": {
    "required": [
+    "creator",
     "createTime",
     "updateTime",
+    "name",
     "alias",
     "appPrimaryKey",
-    "creator",
-    "name",
     "type"
    ],
    "properties": {
@@ -4164,13 +4504,13 @@
   },
   "v1.DetailPolicyResponse": {
    "required": [
+    "creator",
     "properties",
     "createTime",
     "updateTime",
     "name",
     "type",
-    "description",
-    "creator"
+    "description"
    ],
    "properties": {
     "createTime": {
@@ -4200,13 +4540,13 @@
   },
   "v1.DetailWorkflowPlanResponse": {
    "required": [
+    "alias",
     "description",
     "enable",
     "default",
     "createTime",
     "updateTime",
     "name",
-    "alias",
     "workflowRecord"
    ],
    "properties": {
@@ -4294,6 +4634,16 @@
    }
   },
   "v1.EmptyResponse": {},
+  "v1.EnableAddonRequest": {
+   "properties": {
+    "args": {
+     "type": "object",
+     "additionalProperties": {
+      "type": "string"
+     }
+    }
+   }
+  },
   "v1.EnablingProgress": {
    "required": [
     "enabled_components",

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -78,13 +78,40 @@ type ListAddonResponse struct {
 	Addons []*AddonMeta `json:"addons"`
 }
 
+// AddonDeployTo defines where the addon to deploy to
+type AddonDeployTo struct {
+	ControlPlane   bool `json:"control_plane"`
+	RuntimeCluster bool `json:"runtime_cluster"`
+}
+
+// AddonDependency defines the other addons it depends on
+type AddonDependency struct {
+	Name string `json:"name,omitempty"`
+}
+
 // AddonMeta defines the format for a single addon
 type AddonMeta struct {
-	Name        string   `json:"name"`
-	Version     string   `json:"version"`
-	Description string   `json:"description"`
-	Icon        string   `json:"icon"`
-	Tags        []string `json:"tags"`
+	Name         string             `json:"name" validate:"required"`
+	Version      string             `json:"version"`
+	Description  string             `json:"description"`
+	Icon         string             `json:"icon"`
+	URL          string             `json:"url,omitempty"`
+	Tags         []string           `json:"tags,omitempty"`
+	DeployTo     *AddonDeployTo     `json:"deploy_to,omitempty"`
+	Dependencies []*AddonDependency `json:"dependencies,omitempty"`
+}
+
+// Definition defines the metadata for a single X-Definition
+type Definition struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// AddonElementFile can be addon's definition or addon's component
+type AddonElementFile struct {
+	Data string
+	Name string
 }
 
 // DetailAddonResponse defines the format for showing the addon details
@@ -94,8 +121,12 @@ type DetailAddonResponse struct {
 	// More details about the addon, e.g. README
 	Detail string `json:"detail,omitempty"`
 
-	// DeployData is the object to apply to enable addon, e.g. Application
-	DeployData string `json:"deploy_data,omitempty"`
+	Definitions []*Definition `json:"definitions"`
+
+	Parameters string `json:"parameters"`
+
+	CUETemplates  []AddonElementFile `json:"cue_templates"`
+	YAMLTemplates []AddonElementFile `json:"yaml_templates,omitempty"`
 }
 
 // AddonStatusResponse defines the format of addon status response

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -112,6 +112,7 @@ type Definition struct {
 type AddonElementFile struct {
 	Data string
 	Name string
+	Path []string
 }
 
 // DetailAddonResponse defines the format for showing the addon details

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	cuemodel "github.com/oam-dev/kubevela/pkg/cue/model"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -14,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cueyaml "cuelang.org/go/encoding/yaml"
 	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
@@ -23,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	cuemodel "github.com/oam-dev/kubevela/pkg/cue/model"
+	"github.com/oam-dev/kubevela/pkg/oam"
 	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
@@ -219,6 +220,9 @@ func renderApplication(addon *restapis.DetailAddonResponse, args *apis.EnableAdd
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      addon.Name,
 			Namespace: types.DefaultKubeVelaNS,
+			Labels:    map[string]string{
+				oam.LabelAddonName: addon.Name
+			},
 		},
 		Spec: v1beta1.ApplicationSpec{
 			Components: []common2.ApplicationComponent{},

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -107,7 +107,7 @@ func (u *addonUsecaseImpl) StatusAddon(name string) (*apis.AddonStatusResponse, 
 	var app v1beta1.Application
 	err := u.kubeClient.Get(context.Background(), client.ObjectKey{
 		Namespace: types.DefaultKubeVelaNS,
-		Name:      name,
+		Name:      restutils.AddonName2AppName(name),
 	}, &app)
 	if err != nil {
 		if errors2.IsNotFound(err) {
@@ -218,7 +218,7 @@ func renderApplication(addon *restapis.DetailAddonResponse, args *apis.EnableAdd
 	app := &v1beta1.Application{
 		TypeMeta: metav1.TypeMeta{APIVersion: "core.oam.dev/v1beta1", Kind: "Application"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      addon.Name,
+			Name:      restutils.AddonName2AppName(addon.Name),
 			Namespace: types.DefaultKubeVelaNS,
 			Labels: map[string]string{
 				oam.LabelAddonName: addon.Name,
@@ -294,7 +294,7 @@ func (u *addonUsecaseImpl) DisableAddon(ctx context.Context, name string) error 
 	app := &v1beta1.Application{
 		TypeMeta: metav1.TypeMeta{APIVersion: "core.oam.dev/v1beta1", Kind: "Application"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      restutils.AddonName2AppName(name),
 			Namespace: types.DefaultKubeVelaNS,
 		},
 	}

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -103,13 +103,8 @@ func (u *addonUsecaseImpl) GetAddon(ctx context.Context, name string, registry s
 }
 
 func (u *addonUsecaseImpl) StatusAddon(name string) (*apis.AddonStatusResponse, error) {
-	_, err := u.GetAddon(context.Background(), name, "", false)
-	if err != nil {
-		return nil, err
-	}
-
 	var app v1beta1.Application
-	err = u.kubeClient.Get(context.Background(), client.ObjectKey{
+	err := u.kubeClient.Get(context.Background(), client.ObjectKey{
 		Namespace: types.DefaultKubeVelaNS,
 		Name:      name,
 	}, &app)

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -12,18 +12,16 @@ import (
 	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cueyaml "cuelang.org/go/encoding/yaml"
 	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8syaml "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	cuemodel "github.com/oam-dev/kubevela/pkg/cue/model"
-	"github.com/oam-dev/kubevela/pkg/oam"
 	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
@@ -35,7 +33,9 @@ import (
 	restapis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	restutils "github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
+	cuemodel "github.com/oam-dev/kubevela/pkg/cue/model"
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils"
 	addonutil "github.com/oam-dev/kubevela/pkg/utils/addon"
@@ -221,7 +221,7 @@ func renderApplication(addon *restapis.DetailAddonResponse, args *apis.EnableAdd
 			Name:      addon.Name,
 			Namespace: types.DefaultKubeVelaNS,
 			Labels:    map[string]string{
-				oam.LabelAddonName: addon.Name
+				oam.LabelAddonName: addon.Name,
 			},
 		},
 		Spec: v1beta1.ApplicationSpec{

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -87,7 +87,7 @@ type addonUsecaseImpl struct {
 	apply      apply.Applicator
 }
 
-// GetAddon will get
+// GetAddon will get addon information, if detailed is not set, addon's componennt and internal definition won't be returned
 func (u *addonUsecaseImpl) GetAddon(ctx context.Context, name string, registry string, detailed bool) (*apis.DetailAddonResponse, error) {
 	addons, err := u.ListAddons(ctx, detailed, registry, "")
 	if err != nil {

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -1,24 +1,27 @@
 package usecase
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	cuemodel "github.com/oam-dev/kubevela/pkg/cue/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/url"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
-	"text/template"
 	"time"
 
-	"github.com/Masterminds/sprig"
+	cueyaml "cuelang.org/go/encoding/yaml"
 	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	k8syaml "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
@@ -28,18 +31,28 @@ import (
 	"github.com/oam-dev/kubevela/pkg/apiserver/log"
 	"github.com/oam-dev/kubevela/pkg/apiserver/model"
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+	restapis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	restutils "github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils"
 	addonutil "github.com/oam-dev/kubevela/pkg/utils/addon"
 	"github.com/oam-dev/kubevela/pkg/utils/apply"
 )
 
 const (
-	// AddonFileName is the addon file name
-	AddonFileName string = "addon.yaml"
 	// AddonReadmeFileName is the addon readme file name
 	AddonReadmeFileName string = "readme.md"
+
+	// AddonMetadataFileName is the addon meatadata.yaml file name
+	AddonMetadataFileName string = "metadata.yaml"
+
+	// AddonTemplateDirName is the addon template/ dir name
+	AddonTemplateDirName string = "template"
+
+	// AddonDefinitionsDirName is the addon definitions/ dir name
+	AddonDefinitionsDirName string = "definitions"
 )
 
 // AddonUsecase addon usecase
@@ -48,9 +61,9 @@ type AddonUsecase interface {
 	CreateAddonRegistry(ctx context.Context, req apis.CreateAddonRegistryRequest) (*apis.AddonRegistryMeta, error)
 	DeleteAddonRegistry(ctx context.Context, name string) error
 	ListAddonRegistries(ctx context.Context) ([]*apis.AddonRegistryMeta, error)
-	ListAddons(ctx context.Context, detailed bool, query string) ([]*apis.DetailAddonResponse, error)
+	ListAddons(ctx context.Context, detailed bool, registry, query string) ([]*apis.DetailAddonResponse, error)
 	StatusAddon(name string) (*apis.AddonStatusResponse, error)
-	GetAddon(ctx context.Context, name string) (*apis.DetailAddonResponse, error)
+	GetAddon(ctx context.Context, name string, registry string) (*apis.DetailAddonResponse, error)
 	EnableAddon(ctx context.Context, name string, args apis.EnableAddonRequest) error
 	DisableAddon(ctx context.Context, name string) error
 }
@@ -74,8 +87,8 @@ type addonUsecaseImpl struct {
 	apply      apply.Applicator
 }
 
-func (u *addonUsecaseImpl) GetAddon(ctx context.Context, name string) (*apis.DetailAddonResponse, error) {
-	addons, err := u.ListAddons(ctx, true, "")
+func (u *addonUsecaseImpl) GetAddon(ctx context.Context, name string, registry string) (*apis.DetailAddonResponse, error) {
+	addons, err := u.ListAddons(ctx, true, registry, "")
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +102,7 @@ func (u *addonUsecaseImpl) GetAddon(ctx context.Context, name string) (*apis.Det
 }
 
 func (u *addonUsecaseImpl) StatusAddon(name string) (*apis.AddonStatusResponse, error) {
-	_, err := u.GetAddon(context.TODO(), name)
+	_, err := u.GetAddon(context.Background(), name, "")
 	if err != nil {
 		return nil, err
 	}
@@ -123,26 +136,23 @@ func (u *addonUsecaseImpl) StatusAddon(name string) (*apis.AddonStatusResponse, 
 	}
 }
 
-func (u *addonUsecaseImpl) ListAddons(ctx context.Context, detailed bool, query string) ([]*apis.DetailAddonResponse, error) {
-	// Backward compatibility with ConfigMap addons.
-	// We will deprecate ConfigMap and use Git based registry.
-	addons, err := getAddonsFromConfigMap(detailed)
-	if err != nil {
-		return nil, err
-	}
-
+func (u *addonUsecaseImpl) ListAddons(ctx context.Context, detailed bool, registry, query string) ([]*apis.DetailAddonResponse, error) {
+	var addons []*apis.DetailAddonResponse
 	rs, err := u.ListAddonRegistries(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for _, r := range rs {
+		if registry != "" && r.Name != registry {
+			continue
+		}
 		gitAddons, err := getAddonsFromGit(r.Git.URL, r.Git.Path, r.Git.Token, detailed)
 		if err != nil {
-			log.Logger.Errorf("list addons from registry %s failure %s", r.Name, err.Error())
-			continue
+			return nil, err
 		}
 		addons = mergeAddons(addons, gitAddons)
 	}
+
 	if query != "" {
 		var new []*apis.DetailAddonResponse
 		for i, addon := range addons {
@@ -152,6 +162,7 @@ func (u *addonUsecaseImpl) ListAddons(ctx context.Context, detailed bool, query 
 		}
 		addons = new
 	}
+
 	sort.Slice(addons, func(i, j int) bool {
 		return addons[i].Name < addons[j].Name
 	})
@@ -177,7 +188,6 @@ func (u *addonUsecaseImpl) CreateAddonRegistry(ctx context.Context, req apis.Cre
 		Name: r.Name,
 		Git:  r.Git,
 	}, nil
-
 }
 
 func (u *addonUsecaseImpl) GetAddonRegistryModel(ctx context.Context, name string) (*model.AddonRegistry, error) {
@@ -204,87 +214,112 @@ func (u *addonUsecaseImpl) ListAddonRegistries(ctx context.Context) ([]*apis.Add
 	return list, nil
 }
 
+func renderApplication(addon *restapis.DetailAddonResponse, args *apis.EnableAddonRequest) (*v1beta1.Application, error) {
+	if args == nil {
+		args = &apis.EnableAddonRequest{Args: map[string]string{}}
+	}
+	app := &v1beta1.Application{
+		TypeMeta: metav1.TypeMeta{APIVersion: "core.oam.dev/v1beta1", Kind: "Application"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      addon.Name,
+			Namespace: types.DefaultKubeVelaNS,
+		},
+		Spec: v1beta1.ApplicationSpec{
+			Components: []common2.ApplicationComponent{},
+		},
+	}
+	for _, tmpl := range addon.YAMLTemplates {
+		comp, err := renderRawComponent(tmpl)
+		if err != nil {
+			return nil, err
+		}
+		app.Spec.Components = append(app.Spec.Components, *comp)
+	}
+	for _, tmpl := range addon.CUETemplates {
+		yamlData, err := renderCUETemplate(tmpl.Data, addon.Parameters, args.Args)
+		if err != nil {
+			log.Logger.Errorf("failed to render CUE template: %v", err)
+			return nil, bcode.ErrAddonRenderFail
+		}
+		comp, err := renderRawComponent(apis.AddonElementFile{Data: yamlData, Name: tmpl.Name})
+		if err != nil {
+			return nil, err
+		}
+		app.Spec.Components = append(app.Spec.Components, *comp)
+	}
+	return app, nil
+}
+
+func renderCUETemplate(template string, parameters string, args map[string]string) (string, error) {
+	bt, err := json.Marshal(args)
+	if err != nil {
+		return "", err
+	}
+	var paramFile = cuemodel.ParameterFieldName + ": {}"
+	if string(bt) != "null" {
+		paramFile = fmt.Sprintf("%s: %s", cuemodel.ParameterFieldName, string(bt))
+	}
+	param := fmt.Sprintf("%s\n%s", paramFile, parameters)
+	v, err := value.NewValue(param, nil, "")
+	if err != nil {
+		return "", err
+	}
+	out, err := v.LookupByScript(fmt.Sprintf("{%s}", template))
+	if err != nil {
+		return "", err
+	}
+	b, err := cueyaml.Encode(out.CueValue())
+	return string(b), err
+}
+
 func (u *addonUsecaseImpl) EnableAddon(ctx context.Context, name string, args apis.EnableAddonRequest) error {
-	addon, err := u.GetAddon(ctx, name)
+	addon, err := u.GetAddon(ctx, name, "")
 	if err != nil {
 		return err
 	}
-	err = u.applyAddonData(addon.DeployData, args)
+	app, err := renderApplication(addon, &args)
 	if err != nil {
 		return err
+	}
+	err = u.kubeClient.Create(ctx, app)
+	if err != nil {
+		log.Logger.Errorf("apply application fail: %s", err.Error())
+		return bcode.ErrAddonApplyFail
 	}
 	return nil
 
 }
 
 func (u *addonUsecaseImpl) DisableAddon(ctx context.Context, name string) error {
-	addon, err := u.GetAddon(ctx, name)
-	if err != nil {
-		return err
+	app := &v1beta1.Application{
+		TypeMeta: metav1.TypeMeta{APIVersion: "core.oam.dev/v1beta1", Kind: "Application"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: types.DefaultKubeVelaNS,
+		},
 	}
-	err = u.deleteAddonData(addon.DeployData)
+	err := u.kubeClient.Delete(ctx, app)
 	if err != nil {
+		log.Logger.Errorf("delete application fail: %s", err.Error())
 		return err
 	}
 	return nil
 }
 
-func (u *addonUsecaseImpl) applyAddonData(data string, request apis.EnableAddonRequest) error {
-	app, err := renderAddonApp(data, &request)
-	if err != nil {
-		return err
+// renderRawComponent will return a component in raw type from string
+func renderRawComponent(elem apis.AddonElementFile) (*common2.ApplicationComponent, error) {
+	baseRawComponent := common2.ApplicationComponent{
+		Type: "raw",
+		Name: elem.Name,
 	}
-	applicator := apply.NewAPIApplicator(u.kubeClient)
-	err = applicator.Apply(context.TODO(), app)
-	if err != nil {
-		log.Logger.Errorf("apply application fail: %s", err.Error())
-		return bcode.ErrAddonApplyFail
-	}
-	return nil
-}
-
-func (u *addonUsecaseImpl) deleteAddonData(data string) error {
-	app, err := renderAddonApp(data, nil)
-	if err != nil {
-		return err
-	}
-	err = u.kubeClient.Get(context.Background(), client.ObjectKey{
-		Namespace: app.GetNamespace(),
-		Name:      app.GetName(),
-	}, app)
-	if err != nil {
-		return bcode.ErrAddonNotEnabled
-	}
-	err = u.kubeClient.Delete(context.Background(), app)
-	if err != nil {
-		return bcode.ErrAddonDisableFail
-	}
-	return nil
-
-}
-
-// renderAddonApp can render string to unstructured, args can be nil
-func renderAddonApp(data string, args *apis.EnableAddonRequest) (*unstructured.Unstructured, error) {
-	if args == nil {
-		args = &apis.EnableAddonRequest{Args: map[string]string{}}
-	}
-
-	t, err := template.New("addon-template").Delims("[[", "]]").Funcs(sprig.TxtFuncMap()).Parse(data)
-	if err != nil {
-		return nil, bcode.ErrAddonRenderFail
-	}
-	buf := bytes.Buffer{}
-	err = t.Execute(&buf, args)
-	if err != nil {
-		return nil, bcode.ErrAddonRenderFail
-	}
-	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	obj := &unstructured.Unstructured{}
-	_, _, err = dec.Decode(buf.Bytes(), nil, obj)
+	dec := k8syaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	_, _, err := dec.Decode([]byte(elem.Data), nil, obj)
 	if err != nil {
-		return nil, bcode.ErrAddonRenderFail
+		fmt.Println(err)
 	}
-	return obj, nil
+	baseRawComponent.Properties = util.Object2RawExtension(obj)
+	return &baseRawComponent, nil
 }
 
 func addonRegistryModelFromCreateAddonRegistryRequest(req apis.CreateAddonRegistryRequest) *model.AddonRegistry {
@@ -313,109 +348,205 @@ func hasAddon(addons []*apis.DetailAddonResponse, name string) bool {
 	return false
 }
 
+type gitHelper struct {
+	Client *github.Client
+	Meta   *utils.Content
+}
+
 func getAddonsFromGit(baseURL, dir, token string, detailed bool) ([]*apis.DetailAddonResponse, error) {
-	addons := []*apis.DetailAddonResponse{}
-	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	var addons []*apis.DetailAddonResponse
+
+	gith, err := createGitHelper(baseURL, dir, token)
+	if err != nil {
+		return nil, err
+	}
+	dirs, err := readRepo(gith)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, subItems := range dirs {
+		if subItems.GetType() != "dir" {
+			continue
+		}
+		addonRes := &apis.DetailAddonResponse{}
+		_, files, _, err := gith.Client.Repositories.GetContents(context.Background(), gith.Meta.Owner, gith.Meta.Repo, subItems.GetPath(), nil)
+		if err != nil {
+			log.Logger.Errorf("failed to read dir %s: %v", subItems.GetPath(), err)
+			continue
+		}
+		for _, file := range files {
+			var err error
+
+			switch strings.ToLower(file.GetName()) {
+			case AddonReadmeFileName:
+				if !detailed {
+					break
+				}
+				err = readReadme(addonRes, gith, file)
+			case AddonMetadataFileName:
+				err = readMetadata(addonRes, gith, file)
+				addonRes.Name = addonutil.TransAddonName(addonRes.Name)
+			case AddonDefinitionsDirName:
+				if !detailed {
+					break
+				}
+				err = readDefinitions(addonRes, gith, file)
+			case AddonTemplateDirName:
+				if !detailed {
+					break
+				}
+				err = readTemplates(addonRes, gith, file)
+			}
+
+			if err != nil {
+				log.Logger.Errorf("failed to read file %s: %v", file.GetPath(), err)
+				continue
+			}
+		}
+
+		addons = append(addons, addonRes)
+	}
+	return addons, nil
+}
+
+func readTemplates(addon *apis.DetailAddonResponse, h *gitHelper, dir *github.RepositoryContent) error {
+	dirName := dir.GetName()
+	_, files, _, err := h.Client.Repositories.GetContents(context.Background(), h.Meta.Owner, h.Meta.Repo, *dir.Path, nil)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		switch file.GetType() {
+		case "file":
+			content, _, _, err := h.Client.Repositories.GetContents(context.Background(), h.Meta.Owner, h.Meta.Repo, *file.Path, nil)
+			if err != nil {
+				return err
+			}
+			b, err := content.GetContent()
+			if err != nil {
+				return err
+			}
+
+			if file.GetName() == "parameter.cue" {
+				addon.Parameters = b
+				break
+			}
+			switch filepath.Ext(file.GetName()) {
+			case ".cue":
+				addon.CUETemplates = append(addon.CUETemplates, apis.AddonElementFile{Data: b, Name: strings.Join([]string{dirName, file.GetName()}, "-")})
+			default:
+				addon.YAMLTemplates = append(addon.YAMLTemplates, apis.AddonElementFile{Data: b, Name: strings.Join([]string{dirName, file.GetName()}, "-")})
+			}
+		case "dir":
+			err = readTemplates(addon, h, file)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func readDefinitions(addon *apis.DetailAddonResponse, h *gitHelper, dir *github.RepositoryContent) error {
+	_, files, _, err := h.Client.Repositories.GetContents(context.Background(), h.Meta.Owner, h.Meta.Repo, *dir.Path, nil)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		switch file.GetType() {
+		case "file":
+			content, _, _, err := h.Client.Repositories.GetContents(context.Background(), h.Meta.Owner, h.Meta.Repo, *file.Path, nil)
+			if err != nil {
+				return err
+			}
+			b, err := content.GetContent()
+			if err != nil {
+				return err
+			}
+			d, err := getDefinitionMetaFromYAML(b)
+			if err != nil {
+				return err
+			}
+			addon.Definitions = append(addon.Definitions, d)
+		case "dir":
+			err = readDefinitions(addon, h, file)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func getDefinitionMetaFromYAML(data string) (*apis.Definition, error) {
+	dec := k8syaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	obj := &unstructured.Unstructured{}
+	_, _, err := dec.Decode([]byte(data), nil, obj)
+	if err != nil {
+		return nil, bcode.ErrAddonRenderFail
+	}
+	d := &apis.Definition{
+		Name: obj.GetName(),
+		Kind: obj.GetKind(),
+	}
+	if ann := obj.GetAnnotations(); ann != nil {
+		d.Description = ann[types.AnnDescription]
+	}
+	return d, nil
+}
+
+func readMetadata(addon *apis.DetailAddonResponse, h *gitHelper, file *github.RepositoryContent) error {
+	content, _, _, err := h.Client.Repositories.GetContents(context.Background(), h.Meta.Owner, h.Meta.Repo, *file.Path, nil)
+	if err != nil {
+		return err
+	}
+	b, err := content.GetContent()
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal([]byte(b), &addon.AddonMeta)
+}
+
+func readReadme(addon *apis.DetailAddonResponse, h *gitHelper, file *github.RepositoryContent) error {
+	content, _, _, err := h.Client.Repositories.GetContents(context.Background(), h.Meta.Owner, h.Meta.Repo, *file.Path, nil)
+	if err != nil {
+		return err
+	}
+	addon.Detail, err = content.GetContent()
+	return err
+}
+
+func createGitHelper(baseURL, dir, token string) (*gitHelper, error) {
 	var ts oauth2.TokenSource
 	if token != "" {
 		ts = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	}
 	tc := oauth2.NewClient(context.Background(), ts)
 	tc.Timeout = time.Second * 10
-	clt := github.NewClient(tc)
-	// TODO add error handling
+	cli := github.NewClient(tc)
+
 	baseURL = strings.TrimSuffix(baseURL, ".git")
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
 	}
 	u.Path = path.Join(u.Path, dir)
-	_, content, err := utils.Parse(u.String())
+	_, gitmeta, err := utils.Parse(u.String())
 	if err != nil {
 		return nil, err
 	}
-	_, dirs, _, err := clt.Repositories.GetContents(context.Background(), content.Owner, content.Repo, content.Path, nil)
+
+	return &gitHelper{
+		Client: cli,
+		Meta:   gitmeta,
+	}, nil
+}
+
+func readRepo(h *gitHelper) ([]*github.RepositoryContent, error) {
+	_, dirs, _, err := h.Client.Repositories.GetContents(context.Background(), h.Meta.Owner, h.Meta.Repo, h.Meta.Path, nil)
 	if err != nil {
 		return nil, err
 	}
-	for _, subItems := range dirs {
-		if *subItems.Type == "file" {
-			continue
-		}
-		addonRes := apis.DetailAddonResponse{
-			AddonMeta: apis.AddonMeta{
-				Name: converAddonName(*subItems.Name),
-			},
-		}
-		var err error
-		_, files, _, err := clt.Repositories.GetContents(context.Background(), content.Owner, content.Repo, *subItems.Path, nil)
-		// get addon.yaml and readme.md
-		for _, file := range files {
-			switch *file.Name {
-			case AddonFileName:
-				addonContent, _, _, err := clt.Repositories.GetContents(context.Background(), content.Owner, content.Repo, *file.Path, nil)
-				if err != nil {
-					break
-				}
-				addonStr, _ := addonContent.GetContent()
-				obj := &unstructured.Unstructured{}
-				_, _, err = dec.Decode([]byte(addonStr), nil, obj)
-				if err != nil {
-					break
-				}
-				addonRes.AddonMeta.Description = obj.GetAnnotations()[addonutil.DescAnnotation]
-				addonRes.DeployData = addonStr
-			case AddonReadmeFileName:
-				if detailed {
-					detailContent, _, _, err := clt.Repositories.GetContents(context.Background(), content.Owner, content.Repo, *file.Path, nil)
-					if err != nil {
-						break
-					}
-					addonRes.Detail, err = detailContent.GetContent()
-					if err != nil {
-						break
-					}
-				}
-			default:
-				continue
-			}
-
-		}
-		if err != nil {
-			continue
-		}
-		addons = append(addons, &addonRes)
-	}
-	return addons, nil
-}
-
-func getAddonsFromConfigMap(detailed bool) ([]*apis.DetailAddonResponse, error) {
-	repo, err := addonutil.NewAddonRepo()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get configMap addon repo: %w", err)
-	}
-	cliAddons := repo.ListAddons()
-	addons := []*apis.DetailAddonResponse{}
-	for _, addon := range cliAddons {
-		d := &apis.DetailAddonResponse{
-			AddonMeta: apis.AddonMeta{
-				Name: converAddonName(addon.Name),
-				// TODO add actual Version, Icon, tags
-				Version:     "v1alpha1",
-				Description: addon.Description,
-				Icon:        "",
-				Tags:        nil,
-			},
-			DeployData: addon.Data,
-		}
-		if detailed {
-			d.Detail = addon.Detail
-		}
-		addons = append(addons, d)
-	}
-	return addons, nil
-}
-
-func converAddonName(name string) string {
-	return strings.ReplaceAll(name, "/", "-")
+	return dirs, nil
 }

--- a/pkg/apiserver/rest/utils/bcode/addon.go
+++ b/pkg/apiserver/rest/utils/bcode/addon.go
@@ -17,7 +17,6 @@ limitations under the License.
 package bcode
 
 var (
-
 	// ErrAddonNotExist addon not exist
 	ErrAddonNotExist = NewBcode(404, 50001, "addon not exist")
 
@@ -30,14 +29,8 @@ var (
 	// ErrAddonApplyFail fail to apply application to cluster
 	ErrAddonApplyFail = NewBcode(500, 50011, "fail to apply addon application")
 
-	// ErrGetClientFail fail to get k8s client
-	ErrGetClientFail = NewBcode(500, 50012, "fail to initialize kubernetes client")
-
 	// ErrGetApplicationFail fail to get addon application
 	ErrGetApplicationFail = NewBcode(500, 50013, "fail to get addon application")
-
-	// ErrGetConfigMapAddonFail fail to get addon info in configmap
-	ErrGetConfigMapAddonFail = NewBcode(500, 50014, "fail to get addon information in ConfigMap")
 
 	// ErrAddonDisableFail fail to disable addon
 	ErrAddonDisableFail = NewBcode(500, 50016, "fail to disable addon")

--- a/pkg/apiserver/rest/utils/convert.go
+++ b/pkg/apiserver/rest/utils/convert.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"github.com/oam-dev/kubevela/pkg/apiserver/model"
 	apisv1 "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+	"strings"
 )
 
 // ConvertAddonRegistryModel2AddonRegistryMeta will convert from model to AddonRegistryMeta
@@ -11,4 +12,13 @@ func ConvertAddonRegistryModel2AddonRegistryMeta(r *model.AddonRegistry) *apisv1
 		Name: r.Name,
 		Git:  r.Git,
 	}
+}
+
+const addonAppPrefix = "addon-"
+
+func AddonName2AppName(name string) string {
+	return addonAppPrefix + name
+}
+func AppName2addonName(name string) string {
+	return strings.TrimPrefix(name, addonAppPrefix)
 }

--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -118,7 +118,7 @@ func (s *addonWebService) listAddons(req *restful.Request, res *restful.Response
 
 func (s *addonWebService) detailAddon(req *restful.Request, res *restful.Response) {
 	name := req.PathParameter("name")
-	addon, err := s.addonUsecase.GetAddon(req.Request.Context(), name, "")
+	addon, err := s.addonUsecase.GetAddon(req.Request.Context(), name, "", true)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return

--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -164,7 +164,6 @@ func (s *addonWebService) disableAddon(req *restful.Request, res *restful.Respon
 	s.statusAddon(req, res)
 }
 
-// TODO refactor to return addon status without render whole app
 func (s *addonWebService) statusAddon(req *restful.Request, res *restful.Response) {
 	name := req.PathParameter("name")
 	status, err := s.addonUsecase.StatusAddon(name)

--- a/pkg/apiserver/rest/webservice/addon_registry.go
+++ b/pkg/apiserver/rest/webservice/addon_registry.go
@@ -20,7 +20,6 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 
-	"github.com/oam-dev/kubevela/pkg/apiserver/log"
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/usecase"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"
@@ -90,7 +89,6 @@ func (s *addonRegistryWebService) createAddonRegistry(req *restful.Request, res 
 	// Call the usecase layer code
 	meta, err := s.addonUsecase.CreateAddonRegistry(req.Request.Context(), createReq)
 	if err != nil {
-		log.Logger.Errorf("create addon registry failure %s", err.Error())
 		bcode.ReturnError(req, res, err)
 		return
 	}

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -61,6 +61,9 @@ const (
 
 	// LabelAddonsName records the name of initializer stored in configMap
 	LabelAddonsName = "addons.oam.dev/type"
+
+	// LabelAddonName indicates the name of the corresponding Addon
+	LabelAddonName = "addons.oam.dev/name"
 )
 
 const (

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -82,7 +82,9 @@ var _ = Describe("Test addon rest api", func() {
 	It("should enable and disable an addon", func() {
 		defer GinkgoRecover()
 		req := apis.EnableAddonRequest{
-			Args: map[string]string{},
+			Args: map[string]string{
+				"example":"test-args",
+			},
 		}
 		testAddon := "example"
 		res := post("/api/v1/addons/"+testAddon+"/enable", req)

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -2,15 +2,19 @@ package e2e_apiserver
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/oam-dev/kubevela/pkg/apiserver/model"
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
@@ -73,7 +77,17 @@ var _ = Describe("Test addon rest api", func() {
 	})
 
 	It("should enable and disable an addon", func() {
-		Skip("flux-system namespace won't be created so this won't work, we should add a application template in format")
+		// todo(qiaozp) we should remove this namespace creation. This should be solved with a application template.
+		ns := v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "flux-system",
+			},
+		}
+		args := common.Args{}
+		client, err := args.GetClient()
+		Expect(err).Should(BeNil())
+		Expect(client.Create(context.Background(), &ns)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
 		defer GinkgoRecover()
 		req := apis.EnableAddonRequest{
 			Args: map[string]string{

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Test addon rest api", func() {
 			Name: "test-addon-registry-1",
 			Git: &model.GitAddonSource{
 				URL:   "https://github.com/oam-dev/catalog",
-				Path:  "addon/",
+				Path:  "addons/",
 				Token: os.Getenv("GITHUB_TOKEN"),
 			},
 		}
@@ -68,7 +68,7 @@ var _ = Describe("Test addon rest api", func() {
 		Expect(err).Should(BeNil())
 		Expect(lres.Addons).ShouldNot(BeZero())
 		firstAddon := lres.Addons[0]
-		Expect(firstAddon.Name).Should(Equal("fluxcd"))
+		Expect(firstAddon.Name).Should(Equal("example"))
 
 		By("delete registry")
 		deleteReq, err := http.NewRequest(http.MethodDelete, baseURL+"/api/v1/addon_registries/"+createReq.Name, nil)
@@ -120,6 +120,5 @@ var _ = Describe("Test addon rest api", func() {
 
 		err = json.NewDecoder(res.Body).Decode(&statusRes)
 		Expect(err).Should(BeNil())
-
 	})
 })

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Test addon rest api", func() {
 		req := apis.EnableAddonRequest{
 			Args: map[string]string{},
 		}
-		testAddon := "fluxcd"
+		testAddon := "example"
 		res := post("/api/v1/addons/"+testAddon+"/enable", req)
 		Expect(res).ShouldNot(BeNil())
 		Expect(res.StatusCode).Should(Equal(200))

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Test addon rest api", func() {
 		defer res.Body.Close()
 
 		var statusRes apis.AddonStatusResponse
-		err := json.NewDecoder(res.Body).Decode(&statusRes)
+		err = json.NewDecoder(res.Body).Decode(&statusRes)
 
 		Expect(err).Should(BeNil())
 		Expect(statusRes.Phase).Should(Equal(apis.AddonPhaseEnabling))

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Test addon rest api", func() {
 	})
 
 	It("should enable and disable an addon", func() {
-		//Skip("404 error to be found out")
+		Skip("flux-system namespace won't be created so this won't work, we should add a application template in format")
 		defer GinkgoRecover()
 		req := apis.EnableAddonRequest{
 			Args: map[string]string{

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Test addon rest api", func() {
 	})
 
 	It("should enable and disable an addon", func() {
+		//Skip("404 error to be found out")
 		defer GinkgoRecover()
 		req := apis.EnableAddonRequest{
 			Args: map[string]string{


### PR DESCRIPTION
1. Parses new Addon format
2. Remove ConfigMap reading path
3. enable/disable to bundle templates and definitions into one Application
4. add `registry` to list addon request
5. define Definition API

Addon 信息返回如下：

![20211103154530](https://user-images.githubusercontent.com/920884/140024607-be86bb37-dfc8-4969-8ea2-a68aa614063f.jpg)

