### PR TITLE
Fix: The `outputs` name with symbol `-` cause render error

### DIFF
--- a/pkg/cue/process/handle.go
+++ b/pkg/cue/process/handle.go
@@ -197,7 +197,7 @@ func (ctx *templateContext) BaseContextFile() string {
 	if len(ctx.auxiliaries) > 0 {
 		var auxLines []string
 		for _, auxiliary := range ctx.auxiliaries {
-			auxLines = append(auxLines, fmt.Sprintf("%s: %s", auxiliary.Name, structMarshal(auxiliary.Ins.String())))
+			auxLines = append(auxLines, fmt.Sprintf("\"%s\": %s", auxiliary.Name, structMarshal(auxiliary.Ins.String())))
 		}
 		if len(auxLines) > 0 {
 			buff += fmt.Sprintf(model.OutputsFieldName+": {%s}\n", strings.Join(auxLines, "\n"))

--- a/pkg/cue/process/handle_test.go
+++ b/pkg/cue/process/handle_test.go
@@ -64,6 +64,11 @@ image: "myserver"
 		Name: "service",
 	}
 
+	svcAuxWithAbnormalName := Auxiliary{
+		Ins:  svcIns,
+		Name: "service-1",
+	}
+
 	targetParams := map[string]interface{}{
 		"parameter1": "string",
 		"parameter2": map[string]string{
@@ -98,6 +103,7 @@ image: "myserver"
 	ctx := NewContext("myns", "mycomp", "myapp", "myapp-v1")
 	ctx.SetBase(base)
 	ctx.AppendAuxiliaries(svcAux)
+	ctx.AppendAuxiliaries(svcAuxWithAbnormalName)
 	ctx.SetParameters(targetParams)
 	ctx.PushData(model.ContextDataArtifacts, targetData)
 	ctx.PushData("arbitraryData", targetArbitraryData)
@@ -129,6 +135,10 @@ image: "myserver"
 	assert.Equal(t, `{"image":"myserver"}`, string(inputJs))
 
 	outputsJs, err := ctxInst.Lookup("context", model.OutputsFieldName, "service").MarshalJSON()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\"}", string(outputsJs))
+
+	outputsJs, err = ctxInst.Lookup("context", model.OutputsFieldName, "service-1").MarshalJSON()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\"}", string(outputsJs))
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #2544

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->