### PR TITLE
Feat: add query provider to support observe the status of runtime cluster resources

### DIFF
--- a/docs/examples/velaql-views/componet-pod-view.yaml
+++ b/docs/examples/velaql-views/componet-pod-view.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: component-pod-view
+  namespace: vela-system
+data:
+  template: |
+    import (
+      "vela/ql"
+      "vela/op"
+      "list"
+    )
+
+    parameter: {
+      name:          string
+      namespace:     string
+      componentName: string
+    }
+
+    application: ql.#ListResourcesInApp & {
+      app: {
+        name:      parameter.name
+        namespace: parameter.namespace
+        components: [parameter.componentName]
+      }
+    }
+
+    app:       application.list[0]
+    resources: app.components[0].resources
+
+    podsMap: op.#Steps & {
+      for i, resource in resources {
+        "\(i)": ql.#CollectPods & {
+          value:   resource.object
+          cluster: resource.cluster
+        }
+      }
+    }
+
+    podsWithCluster: {for i, pods in podsMap {
+      "\(i)": [
+        for podObj in pods.list {
+          cluster: pods.cluster
+          obj:     podObj
+        },
+      ]
+    }}
+
+    flatPods: list.FlattenN([ for pods in podsWithCluster {
+      pods
+    }], 1)
+
+    podStatus: op.#Steps & {
+      for i, pod in flatPods {
+        "\(i)": op.#Steps & {
+          name: pod.obj.metadata.name
+          containers: {for container in pod.obj.status.containerStatuses {
+            "\(container.name)": {
+              image: container.image
+              state: container.state
+            }
+          }}
+          events: ql.#SearchEvents & {
+            value:   pod.obj
+            cluster: pod.cluster
+          }
+          metrics: ql.#Read & {
+            cluster: pod.cluster
+            value: {
+              apiVersion: "metrics.k8s.io/v1beta1"
+              kind:       "PodMetrics"
+              metadata: {
+                name:      pod.obj.metadata.name
+                namespace: pod.obj.metadata.namespace
+              }
+            }
+          }
+        }
+      }
+    }
+
+    status: {
+      podList: [ for podInfo in podStatus {
+        name: podInfo.name
+        containers: [ for containerName, container in podInfo.containers {
+          name:  containerName
+          image: container.image
+          state: container.state
+          if podInfo.metrics.err == _|_ {
+            usage: {for containerUsage in podInfo.metrics.value.containers {
+              if containerUsage.name == containerName {
+                cpu:    containerUsage.usage.cpu
+                memory: containerUsage.usage.memory
+              }
+            }}
+          }
+        }]
+        events: [ for event in podInfo.events.list {
+          type:           event.type
+          reason:         event.reason
+          message:        event.message
+          firstTimestamp: event.firstTimestamp
+        }]
+      }]
+    }
+
+

--- a/pkg/stdlib/op.cue
+++ b/pkg/stdlib/op.cue
@@ -117,6 +117,10 @@ import (
 
 #ConvertString: convert.#String
 
+#DateToTimestamp: time.#DateToTimestamp
+
+#TimestampToDate: time.#TimestampToDate
+
 #SendEmail: email.#Send
 
 #Load: oam.#LoadComponets

--- a/pkg/stdlib/packages.go
+++ b/pkg/stdlib/packages.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	//go:embed pkgs op.cue
+	//go:embed pkgs op.cue ql.cue
 	fs embed.FS
 )
 
@@ -43,17 +43,26 @@ func GetPackages(tagTempl string) (map[string]string, error) {
 		return nil, err
 	}
 
-	pkgContent := string(opBytes) + "\n"
+	qlBytes, err := fs.ReadFile("ql.cue")
+	if err != nil {
+		return nil, err
+	}
+
+	opContent := string(opBytes) + "\n"
+	qlContent := string(qlBytes) + "\n"
 	for _, file := range files {
 		body, err := fs.ReadFile("pkgs/" + file.Name())
 		if err != nil {
 			return nil, err
 		}
-		pkgContent += fmt.Sprintf("%s: {\n%s\n}\n", strings.TrimSuffix(file.Name(), ".cue"), string(body))
+		pkgContent := fmt.Sprintf("%s: {\n%s\n}\n", strings.TrimSuffix(file.Name(), ".cue"), string(body))
+		opContent += pkgContent
+		qlContent += pkgContent
 	}
 
 	return map[string]string{
-		"vela/op": pkgContent + "\n" + tagTempl,
+		"vela/op": opContent + "\n" + tagTempl,
+		"vela/ql": qlContent + "\n" + tagTempl,
 	}, nil
 }
 

--- a/pkg/stdlib/pkgs/kube.cue
+++ b/pkg/stdlib/pkgs/kube.cue
@@ -27,6 +27,7 @@
 		matchingLabels?: {...}
 	}
 	list?: {...}
+	...
 }
 
 #Delete: {

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -1,0 +1,27 @@
+#ListResourcesInApp: {
+	#do:       "listResourcesInApp"
+	#provider: "query"
+	app: {
+		name:      string
+		namespace: string
+		components?: [...string]
+		enableHistoryQuery?: bool
+	}
+	...
+}
+
+#CollectPods: {
+	#do:       "collectPods"
+	#provider: "query"
+	value: {...}
+	cluster: string
+	...
+}
+
+#SearchEvents: {
+	#do:       "searchEvents"
+	#provider: "query"
+	value: {...}
+	cluster: string
+	...
+}

--- a/pkg/stdlib/pkgs/time.cue
+++ b/pkg/stdlib/pkgs/time.cue
@@ -1,0 +1,22 @@
+#DateToTimestamp: {
+	#do:       "timestamp"
+	#provider: "time"
+
+	date:   string
+	layout: *"" | string
+
+	timestamp?: int64
+	...
+}
+
+#TimestampToDate: {
+	#do:       "date"
+	#provider: "time"
+
+	timestamp: int64
+	layout:    *"" | string
+	location:  *"" | string
+
+	date?: string
+	...
+}

--- a/pkg/stdlib/ql.cue
+++ b/pkg/stdlib/ql.cue
@@ -1,0 +1,11 @@
+#Read: kube.#Read
+
+#List: kube.#List
+
+#Delete: kube.#Delete
+
+#ListResourcesInApp: query.#ListResourcesInApp
+
+#CollectPods: query.#CollectPods
+
+#SearchEvents: query.#SearchEvents

--- a/pkg/velaql/parse.go
+++ b/pkg/velaql/parse.go
@@ -24,8 +24,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Query contains query data
-type Query struct {
+// QueryView contains query data
+type QueryView struct {
 	View      string
 	Parameter map[string]interface{}
 	Export    string
@@ -56,16 +56,16 @@ func init() {
 	kvRegexp = regexp.MustCompile(PatternKV)
 }
 
-// ParseVelaQL parse velaQL to Query
-func ParseVelaQL(ql string) (Query, error) {
-	query := Query{
+// ParseVelaQL parse velaQL to QueryView
+func ParseVelaQL(ql string) (QueryView, error) {
+	qv := QueryView{
 		Export: DefaultExportValue,
 	}
 
 	groupNames := qlRegexp.SubexpNames()
 	matched := qlRegexp.FindStringSubmatch(ql)
 	if len(matched) != len(groupNames) || (len(matched) != 0 && matched[0] != ql) {
-		return query, errors.New("fail to parse the velaQL")
+		return qv, errors.New("fail to parse the velaQL")
 	}
 
 	result := make(map[string]string, len(groupNames))
@@ -76,19 +76,19 @@ func ParseVelaQL(ql string) (Query, error) {
 	}
 
 	if len(result["view"]) == 0 {
-		return query, errors.New("view name shouldn't be empty")
+		return qv, errors.New("view name shouldn't be empty")
 	}
 
-	query.View = result[KeyWordView]
+	qv.View = result[KeyWordView]
 	if len(result[KeyWordExport]) != 0 {
-		query.Export = result[KeyWordExport]
+		qv.Export = result[KeyWordExport]
 	}
 	var err error
-	query.Parameter, err = ParseParameter(result[KeyWordParameter])
+	qv.Parameter, err = ParseParameter(result[KeyWordParameter])
 	if err != nil {
-		return query, err
+		return qv, err
 	}
-	return query, nil
+	return qv, nil
 }
 
 // ParseParameter parse parameter to map[string]interface{}

--- a/pkg/velaql/parse_test.go
+++ b/pkg/velaql/parse_test.go
@@ -26,7 +26,7 @@ import (
 func TestParseVelaQL(t *testing.T) {
 	testcases := []struct {
 		ql    string
-		query Query
+		query QueryView
 		err   error
 	}{{
 		ql:  `view{test=,test1=hello}.output`,
@@ -39,21 +39,21 @@ func TestParseVelaQL(t *testing.T) {
 		err: errors.New("fail to parse the velaQL"),
 	}, {
 		ql: `view{test=1,app="name"}`,
-		query: Query{
+		query: QueryView{
 			View:   "view",
 			Export: "status",
 		},
 		err: nil,
 	}, {
 		ql: `view{test=1,app="name"}.Export`,
-		query: Query{
+		query: QueryView{
 			View:   "view",
 			Export: "Export",
 		},
 		err: nil,
 	}, {
 		ql: `view{test=true}.output.value.spec`,
-		query: Query{
+		query: QueryView{
 			View:   "view",
 			Export: "output.value.spec",
 		},

--- a/pkg/velaql/providers/query/collector.go
+++ b/pkg/velaql/providers/query/collector.go
@@ -1,0 +1,346 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package query
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	kruise "github.com/openkruise/kruise-api/apps/v1alpha1"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/application/dispatch"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/oam"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
+)
+
+// Collector collect resource created by application
+type Collector struct {
+	k8sClient client.Client
+	opt       Option
+}
+
+// NewCollector create a collector
+func NewCollector(cli client.Client, opt Option) *Collector {
+	return &Collector{
+		k8sClient: cli,
+		opt:       opt,
+	}
+}
+
+// CollectResourceFromApp collect resources created by application
+func (c *Collector) CollectResourceFromApp() ([]AppResources, error) {
+	if c.opt.EnableHistoryQuery {
+		return c.CollectHistoryResourceFromApp()
+	}
+	return c.CollectLatestResourceFromApp()
+}
+
+// CollectLatestResourceFromApp collect resources created by latest application
+func (c *Collector) CollectLatestResourceFromApp() ([]AppResources, error) {
+	ctx := context.Background()
+	app := new(v1beta1.Application)
+	appKey := client.ObjectKey{Name: c.opt.Name, Namespace: c.opt.Namespace}
+	if err := c.k8sClient.Get(ctx, appKey, app); err != nil {
+		return nil, err
+	}
+
+	var revision int64
+	if app.Status.LatestRevision != nil {
+		revision = app.Status.LatestRevision.Revision
+	}
+	appRevName := fmt.Sprintf("%s-v%d", app.Name, revision)
+	comps := make(map[string][]Resource, len(app.Spec.Components))
+	for _, rsrcRef := range app.Status.AppliedResources {
+		compName, obj, err := getObjectCreatedByComponent(c.k8sClient, rsrcRef.ObjectReference, rsrcRef.Cluster, appRevName)
+		if err != nil {
+			return nil, err
+		}
+		if len(compName) == 0 {
+			continue
+		}
+		comps[compName] = append(comps[compName], Resource{
+			Cluster: rsrcRef.Cluster,
+			Object:  obj,
+		})
+	}
+	compResList := c.extractComponentResourceWithOption(comps)
+	if len(compResList) == 0 {
+		return nil, nil
+	}
+
+	return []AppResources{{
+		Revision:   revision,
+		Metadata:   app.ObjectMeta,
+		Components: compResList,
+	}}, nil
+}
+
+// CollectHistoryResourceFromApp collect history resources created by application
+func (c *Collector) CollectHistoryResourceFromApp() ([]AppResources, error) {
+	var appResList []AppResources
+	rts, err := listResourceTrackers(c.k8sClient, c.opt.Name, c.opt.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	appResList = make([]AppResources, 0, len(rts))
+	for _, rt := range rts {
+		if len(rt.Status.TrackedResources) == 0 {
+			continue
+		}
+		appRevName := dispatch.ExtractAppRevisionName(rt.Name, c.opt.Namespace)
+		revision, err := oamutil.ExtractRevisionNum(appRevName, "-")
+		if err != nil {
+			return nil, err
+		}
+		comps := make(map[string][]Resource)
+		for _, trackedResourceRef := range rt.Status.TrackedResources {
+			compName, obj, err := getObjectCreatedByComponent(c.k8sClient, trackedResourceRef, "", appRevName)
+			if err != nil {
+				return nil, err
+			}
+			if len(compName) == 0 {
+				continue
+			}
+			comps[compName] = append(comps[compName], Resource{
+				Cluster: "",
+				Object:  obj,
+			})
+		}
+		compResList := c.extractComponentResourceWithOption(comps)
+		if len(compResList) != 0 {
+			appResList = append(appResList, AppResources{
+				Revision:   int64(revision),
+				Metadata:   rt.ObjectMeta,
+				Components: compResList,
+			})
+		}
+	}
+	return appResList, nil
+}
+
+func (c *Collector) extractComponentResourceWithOption(comps map[string][]Resource) []Component {
+	var result []Component
+
+	// if not specify component, return all components resource created by app
+	if len(c.opt.Components) == 0 {
+		for name, resource := range comps {
+			result = append(result, Component{
+				Name:      name,
+				Resources: resource,
+			})
+		}
+		return result
+	}
+
+	for _, compName := range c.opt.Components {
+		if len(comps[compName]) == 0 {
+			continue
+		}
+		result = append(result, Component{
+			Name:      compName,
+			Resources: comps[compName],
+		})
+	}
+	return result
+}
+
+// listResourceTrackers list all resourceTracker with specified app
+func listResourceTrackers(cli client.Client, appName, appNs string) ([]v1beta1.ResourceTracker, error) {
+	listOpts := []client.ListOption{
+		client.MatchingLabels{
+			oam.LabelAppName:      appName,
+			oam.LabelAppNamespace: appNs,
+		}}
+	rtList := &v1beta1.ResourceTrackerList{}
+	ctx := context.Background()
+	if err := cli.List(ctx, rtList, listOpts...); err != nil {
+		klog.ErrorS(err, "Failed to list Resource tracker of app", "name", appName)
+		return nil, err
+	}
+	return rtList.Items, nil
+}
+
+// getObjectCreatedByComponent get k8s obj created by components
+func getObjectCreatedByComponent(cli client.Client, objRef corev1.ObjectReference, cluster string, appRevName string) (componentName string, obj *unstructured.Unstructured, err error) {
+	ctx := multicluster.ContextWithClusterName(context.Background(), cluster)
+	obj = new(unstructured.Unstructured)
+	obj.SetGroupVersionKind(objRef.GroupVersionKind())
+	obj.SetNamespace(objRef.Namespace)
+	obj.SetName(objRef.Name)
+
+	key := client.ObjectKeyFromObject(obj)
+	if key.Namespace == "" {
+		key.Namespace = "default"
+	}
+	if err = cli.Get(ctx, key, obj); err != nil {
+		if kerrors.IsNotFound(err) {
+			return "", nil, nil
+		}
+		return "", nil, err
+	}
+	if obj.GetLabels()[oam.LabelAppRevision] != appRevName {
+		return
+	}
+	componentName = obj.GetLabels()[oam.LabelAppComponent]
+	return
+}
+
+var standardWorkloads = []schema.GroupVersionKind{
+	appsv1.SchemeGroupVersion.WithKind(reflect.TypeOf(appsv1.Deployment{}).Name()),
+	appsv1.SchemeGroupVersion.WithKind(reflect.TypeOf(appsv1.ReplicaSet{}).Name()),
+	appsv1.SchemeGroupVersion.WithKind(reflect.TypeOf(appsv1.StatefulSet{}).Name()),
+	appsv1.SchemeGroupVersion.WithKind(reflect.TypeOf(appsv1.DaemonSet{}).Name()),
+	batchv1.SchemeGroupVersion.WithKind(reflect.TypeOf(batchv1.Job{}).Name()),
+	kruise.SchemeGroupVersion.WithKind(reflect.TypeOf(kruise.CloneSet{}).Name()),
+}
+
+var podCollectorMap = map[schema.GroupVersionKind]PodCollector{
+	batchv1.SchemeGroupVersion.WithKind(reflect.TypeOf(batchv1.CronJob{}).Name()):           cronJobPodCollector,
+	batchv1beta1.SchemeGroupVersion.WithKind(reflect.TypeOf(batchv1beta1.CronJob{}).Name()): cronJobPodCollector,
+}
+
+// PodCollector collector pod created by workload
+type PodCollector func(cli client.Client, obj *unstructured.Unstructured, cluster string) ([]*unstructured.Unstructured, error)
+
+// NewPodCollector create a PodCollector
+func NewPodCollector(gvk schema.GroupVersionKind) PodCollector {
+	for _, workload := range standardWorkloads {
+		if gvk == workload {
+			return standardWorkloadPodCollector
+		}
+	}
+
+	collector, ok := podCollectorMap[gvk]
+	if !ok {
+		return func(cli client.Client, obj *unstructured.Unstructured, cluster string) ([]*unstructured.Unstructured, error) {
+			return nil, nil
+		}
+	}
+	return collector
+}
+
+// standardWorkloadPodCollector collect pods created by standard workload
+func standardWorkloadPodCollector(cli client.Client, obj *unstructured.Unstructured, cluster string) ([]*unstructured.Unstructured, error) {
+	ctx := multicluster.ContextWithClusterName(context.Background(), cluster)
+	selectorPath := []string{"spec", "selector", "matchLabels"}
+	labels, found, err := unstructured.NestedStringMap(obj.UnstructuredContent(), selectorPath...)
+
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.Errorf("fail to find matchLabels from %s %s", obj.GroupVersionKind().String(), klog.KObj(obj))
+	}
+
+	listOpts := []client.ListOption{
+		client.MatchingLabels(labels),
+		client.InNamespace(obj.GetNamespace()),
+	}
+
+	podList := corev1.PodList{}
+	if err := cli.List(ctx, &podList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	pods := make([]*unstructured.Unstructured, len(podList.Items))
+	for i := range podList.Items {
+		pod, err := util.Object2Unstructured(podList.Items[i])
+		if err != nil {
+			return nil, err
+		}
+		pod.SetGroupVersionKind(
+			corev1.SchemeGroupVersion.WithKind(
+				reflect.TypeOf(corev1.Pod{}).Name(),
+			),
+		)
+		pods[i] = pod
+	}
+	return pods, nil
+}
+
+// cronJobPodCollector collect pods created by cronjob
+func cronJobPodCollector(cli client.Client, obj *unstructured.Unstructured, cluster string) ([]*unstructured.Unstructured, error) {
+	ctx := multicluster.ContextWithClusterName(context.Background(), cluster)
+
+	jobList := new(batchv1.JobList)
+	if err := cli.List(ctx, jobList, client.InNamespace(obj.GetNamespace())); err != nil {
+		return nil, err
+	}
+
+	uid := obj.GetUID()
+	var jobs []batchv1.Job
+	for _, job := range jobList.Items {
+		for _, owner := range job.GetOwnerReferences() {
+			if owner.Kind == reflect.TypeOf(batchv1.CronJob{}).Name() && owner.UID == uid {
+				jobs = append(jobs, job)
+			}
+		}
+	}
+
+	var pods []*unstructured.Unstructured
+	for _, job := range jobs {
+		labels := job.Spec.Selector.MatchLabels
+		listOpts := []client.ListOption{
+			client.MatchingLabels(labels),
+			client.InNamespace(job.GetNamespace()),
+		}
+		podList := corev1.PodList{}
+		if err := cli.List(ctx, &podList, listOpts...); err != nil {
+			return nil, err
+		}
+
+		items := make([]*unstructured.Unstructured, len(podList.Items))
+		for i := range podList.Items {
+			pod, err := util.Object2Unstructured(podList.Items[i])
+			if err != nil {
+				return nil, err
+			}
+			pod.SetGroupVersionKind(
+				corev1.SchemeGroupVersion.WithKind(
+					reflect.TypeOf(corev1.Pod{}).Name(),
+				),
+			)
+			items[i] = pod
+		}
+		pods = append(pods, items...)
+	}
+	return pods, nil
+}
+
+func getEventFieldSelector(obj *unstructured.Unstructured) fields.Selector {
+	field := fields.Set{}
+	field["involvedObject.name"] = obj.GetName()
+	field["involvedObject.namespace"] = obj.GetNamespace()
+	field["involvedObject.kind"] = obj.GetObjectKind().GroupVersionKind().Kind
+	field["involvedObject.uid"] = string(obj.GetUID())
+	return field.AsSelector()
+}

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -1,0 +1,151 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package query
+
+import (
+	stdctx "context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
+	"github.com/oam-dev/kubevela/pkg/workflow/providers"
+	"github.com/oam-dev/kubevela/pkg/workflow/types"
+)
+
+const (
+	// ProviderName is provider name for install.
+	ProviderName = "query"
+)
+
+type provider struct {
+	cli client.Client
+}
+
+// AppResources represent resources created by app
+type AppResources struct {
+	Revision   int64             `json:"revision"`
+	Metadata   metav1.ObjectMeta `json:"metadata"`
+	Components []Component       `json:"components"`
+}
+
+// Component group resources rendered by ApplicationComponent
+type Component struct {
+	Name      string     `json:"name"`
+	Resources []Resource `json:"resources"`
+}
+
+// Resource refer to an object with cluster info
+type Resource struct {
+	Cluster string                     `json:"cluster"`
+	Object  *unstructured.Unstructured `json:"object"`
+}
+
+// Option is the query option
+type Option struct {
+	Name               string   `json:"name"`
+	Namespace          string   `json:"namespace"`
+	Components         []string `json:"components,omitempty"`
+	EnableHistoryQuery bool     `json:"enableHistoryQuery,omitempty"`
+}
+
+// ListResourcesInApp lists CRs created by Application
+func (h *provider) ListResourcesInApp(ctx wfContext.Context, v *value.Value, act types.Action) error {
+	val, err := v.LookupValue("app")
+	if err != nil {
+		return err
+	}
+	opt := Option{}
+	if err = val.UnmarshalTo(&opt); err != nil {
+		return err
+	}
+	collector := NewCollector(h.cli, opt)
+	appResList, err := collector.CollectResourceFromApp()
+	if err != nil {
+		return v.FillObject(err.Error(), "err")
+	}
+	return v.FillObject(appResList, "list")
+}
+
+func (h *provider) CollectPods(ctx wfContext.Context, v *value.Value, act types.Action) error {
+	val, err := v.LookupValue("value")
+	if err != nil {
+		return err
+	}
+	cluster, err := v.GetString("cluster")
+	if err != nil {
+		return err
+	}
+
+	obj := new(unstructured.Unstructured)
+	if err = val.UnmarshalTo(obj); err != nil {
+		return err
+	}
+
+	collector := NewPodCollector(obj.GroupVersionKind())
+	pods, err := collector(h.cli, obj, cluster)
+	if err != nil {
+		return v.FillObject(err.Error(), "err")
+	}
+	return v.FillObject(pods, "list")
+}
+
+func (h *provider) SearchEvents(ctx wfContext.Context, v *value.Value, act types.Action) error {
+	val, err := v.LookupValue("value")
+	if err != nil {
+		return err
+	}
+	cluster, err := v.GetString("cluster")
+	if err != nil {
+		return err
+	}
+	obj := new(unstructured.Unstructured)
+	if err = val.UnmarshalTo(obj); err != nil {
+		return err
+	}
+
+	listCtx := multicluster.ContextWithClusterName(stdctx.Background(), cluster)
+	fieldSelector := getEventFieldSelector(obj)
+	eventList := corev1.EventList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFieldsSelector{
+			Selector: fieldSelector,
+		},
+	}
+	if err := h.cli.List(listCtx, &eventList, listOpts...); err != nil {
+		return v.FillObject(err.Error(), "err")
+	}
+	return v.FillObject(eventList.Items, "list")
+}
+
+// Install register handlers to provider discover.
+func Install(p providers.Providers, cli client.Client) {
+	prd := &provider{
+		cli: cli,
+	}
+
+	p.Register(ProviderName, map[string]providers.Handler{
+		"listResourcesInApp": prd.ListResourcesInApp,
+		"collectPods":        prd.CollectPods,
+		"searchEvents":       prd.SearchEvents,
+	})
+}

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -1,0 +1,623 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package query
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/pkg/oam"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/kubevela/pkg/workflow/providers"
+)
+
+type AppResourcesList struct {
+	List []AppResources `json:"list,omitempty"`
+	App  interface{}    `json:"app"`
+	Err  string         `json:"err,omitempty"`
+}
+
+type PodList struct {
+	List    []*unstructured.Unstructured `json:"list"`
+	Value   interface{}                  `json:"value"`
+	Cluster string                       `json:"cluster"`
+}
+
+var _ = Describe("Test Query Provider", func() {
+	var baseDeploy *v1.Deployment
+	var baseService *corev1.Service
+	var basePod *corev1.Pod
+
+	BeforeEach(func() {
+		baseDeploy = new(v1.Deployment)
+		Expect(yaml.Unmarshal([]byte(deploymentYaml), baseDeploy)).Should(BeNil())
+
+		baseService = new(corev1.Service)
+		Expect(yaml.Unmarshal([]byte(serviceYaml), baseService)).Should(BeNil())
+
+		basePod = new(corev1.Pod)
+		Expect(yaml.Unmarshal([]byte(podYaml), basePod)).Should(BeNil())
+	})
+
+	Context("Test ListResourcesInApp", func() {
+		It("Test list latest resources created by application", func() {
+			namespace := "test"
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+
+			app := v1beta1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common.ApplicationComponent{{
+						Name: "web",
+						Type: "webservice",
+						Properties: util.Object2RawExtension(map[string]string{
+							"image": "busybox",
+						}),
+						Traits: []common.ApplicationTrait{{
+							Type: "expose",
+							Properties: util.Object2RawExtension(map[string]interface{}{
+								"ports": []int{8000},
+							}),
+						}},
+					}},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+			oldApp := new(v1beta1.Application)
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&app), oldApp)).Should(BeNil())
+			oldApp.Status.LatestRevision = &common.Revision{
+				Revision: 1,
+			}
+			oldApp.Status.AppliedResources = []common.ClusterObjectReference{{
+				Cluster: "",
+				Creator: "workflow",
+				ObjectReference: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Namespace:  namespace,
+					Name:       "web",
+				},
+			}, {
+				Cluster: "",
+				Creator: "workflow",
+				ObjectReference: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Namespace:  namespace,
+					Name:       "web",
+				},
+			}}
+			Eventually(func() error {
+				err := k8sClient.Status().Update(ctx, oldApp)
+				if err != nil {
+					return err
+				}
+				return nil
+			}, 300*time.Microsecond, 3*time.Second).Should(BeNil())
+
+			appDeploy := baseDeploy.DeepCopy()
+			appDeploy.SetName("web")
+			appDeploy.SetNamespace(namespace)
+			appDeploy.SetLabels(map[string]string{
+				oam.LabelAppComponent: "web",
+				oam.LabelAppRevision:  "test-v1",
+			})
+			Expect(k8sClient.Create(ctx, appDeploy)).Should(BeNil())
+
+			appService := baseService.DeepCopy()
+			appService.SetName("web")
+			appService.SetNamespace(namespace)
+			appService.SetLabels(map[string]string{
+				oam.LabelAppComponent: "web",
+				oam.LabelAppRevision:  "test-v1",
+			})
+			Expect(k8sClient.Create(ctx, appService)).Should(BeNil())
+
+			prd := provider{cli: k8sClient}
+			opt := `app: {
+				name: "test"
+				namespace: "test"
+				components: ["web"]
+			}`
+			v, err := value.NewValue(opt, nil, "")
+			Expect(err).Should(BeNil())
+			Expect(prd.ListResourcesInApp(nil, v, nil)).Should(BeNil())
+
+			type AppResourcesList struct {
+				List []AppResources `json:"list"`
+				App  interface{}    `json:"app"`
+			}
+			appResList := new(AppResourcesList)
+			Expect(v.UnmarshalTo(appResList)).Should(BeNil())
+
+			Expect(len(appResList.List)).Should(Equal(1))
+			Expect(len(appResList.List[0].Components)).Should(Equal(1))
+			Expect(len(appResList.List[0].Components[0].Resources)).Should(Equal(2))
+
+			Expect(appResList.List[0].Components[0].Resources[0].Object.GroupVersionKind()).Should(Equal(oldApp.Status.AppliedResources[0].GroupVersionKind()))
+			Expect(appResList.List[0].Components[0].Resources[1].Object.GroupVersionKind()).Should(Equal(oldApp.Status.AppliedResources[1].GroupVersionKind()))
+		})
+
+		It("Test list legacy resources created by application", func() {
+			appName := "test-legacy"
+			appNs := "test-legacy"
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: appNs}}
+			Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+			for i := 1; i <= 5; i++ {
+				rt := new(v1beta1.ResourceTracker)
+				rt.SetName(fmt.Sprintf("%s-v%d-%s", appName, i, appNs))
+				rt.SetLabels(map[string]string{
+					oam.LabelAppName:      appName,
+					oam.LabelAppNamespace: appNs,
+				})
+				Expect(k8sClient.Create(ctx, rt)).Should(BeNil())
+				oldRT := new(v1beta1.ResourceTracker)
+				Eventually(func() error {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rt), oldRT); err != nil {
+						return err
+					}
+					oldRT.Status.TrackedResources = []corev1.ObjectReference{{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Namespace:  appNs,
+						Name:       fmt.Sprintf("web-v%d", i),
+					}, {
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Namespace:  appNs,
+						Name:       fmt.Sprintf("web-v%d", i),
+					}}
+					if err := k8sClient.Status().Update(ctx, oldRT); err != nil {
+						return err
+					}
+					return nil
+				}, 3*time.Second, 300*time.Microsecond).Should(BeNil())
+
+				appDeploy := baseDeploy.DeepCopy()
+				appDeploy.SetName(fmt.Sprintf("web-v%d", i))
+				appDeploy.SetNamespace(appNs)
+				appDeploy.SetLabels(map[string]string{
+					oam.LabelAppComponent: "web",
+					oam.LabelAppRevision:  fmt.Sprintf("%s-v%d", appName, i),
+				})
+				Expect(k8sClient.Create(ctx, appDeploy)).Should(BeNil())
+
+				appService := baseService.DeepCopy()
+				appService.SetName(fmt.Sprintf("web-v%d", i))
+				appService.SetNamespace(appNs)
+				appService.SetLabels(map[string]string{
+					oam.LabelAppComponent: "web",
+					oam.LabelAppRevision:  fmt.Sprintf("%s-v%d", appName, i),
+				})
+				Expect(k8sClient.Create(ctx, appService)).Should(BeNil())
+			}
+
+			prd := provider{cli: k8sClient}
+			opt := `app: {
+				name: "test-legacy"
+				namespace: "test-legacy"
+				components: ["web"]
+				enableHistoryQuery: true
+			}`
+			v, err := value.NewValue(opt, nil, "")
+			Expect(err).Should(BeNil())
+			Expect(prd.ListResourcesInApp(nil, v, nil)).Should(BeNil())
+
+			type AppResourcesList struct {
+				List []AppResources `json:"list"`
+				App  interface{}    `json:"app"`
+			}
+			appResList := new(AppResourcesList)
+			Expect(v.UnmarshalTo(appResList)).Should(BeNil())
+
+			Expect(len(appResList.List)).Should(Equal(5))
+			for _, app := range appResList.List {
+				Expect(len(app.Components)).Should(Equal(1))
+				Expect(app.Components[0].Resources[0].Object.GroupVersionKind()).Should(Equal((&corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Service",
+				}).GroupVersionKind()))
+				Expect(app.Components[0].Resources[1].Object.GroupVersionKind()).Should(Equal((&corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				}).GroupVersionKind()))
+			}
+		})
+
+		It("Test list legacy resources meet complex scene", func() {
+			appName := "test-legacy-complex"
+			appNs := "test-legacy-complex"
+			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: appNs}}
+			Expect(k8sClient.Create(ctx, &ns)).Should(BeNil())
+			for i := 1; i <= 2; i++ {
+				rt := new(v1beta1.ResourceTracker)
+				rt.SetName(fmt.Sprintf("%s-v%d-%s", appName, i, appNs))
+				rt.SetLabels(map[string]string{
+					oam.LabelAppName:      appName,
+					oam.LabelAppNamespace: appNs,
+				})
+				Expect(k8sClient.Create(ctx, rt)).Should(BeNil())
+				oldRT := new(v1beta1.ResourceTracker)
+				Eventually(func() error {
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rt), oldRT); err != nil {
+						return err
+					}
+					oldRT.Status.TrackedResources = []corev1.ObjectReference{{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Namespace:  appNs,
+						Name:       fmt.Sprintf("web-v%d", i),
+					}, {
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Namespace:  appNs,
+						Name:       fmt.Sprintf("web-v%d", i),
+					}}
+					if err := k8sClient.Status().Update(ctx, oldRT); err != nil {
+						return err
+					}
+					return nil
+				}, 3*time.Second, 300*time.Microsecond).Should(BeNil())
+
+				appDeploy := baseDeploy.DeepCopy()
+				appDeploy.SetName(fmt.Sprintf("web-v%d", i))
+				appDeploy.SetNamespace(appNs)
+				appDeploy.SetLabels(map[string]string{
+					oam.LabelAppComponent: "web",
+					oam.LabelAppRevision:  fmt.Sprintf("%s-v%d", appName, i),
+				})
+				Expect(k8sClient.Create(ctx, appDeploy)).Should(BeNil())
+
+				appService := baseService.DeepCopy()
+				appService.SetName(fmt.Sprintf("web-v%d", i))
+				appService.SetNamespace(appNs)
+				appService.SetLabels(map[string]string{
+					oam.LabelAppComponent: "web",
+					oam.LabelAppRevision:  fmt.Sprintf("%s-v%d", appName, i),
+				})
+				Expect(k8sClient.Create(ctx, appService)).Should(BeNil())
+			}
+
+			By("create resourceTracker without trackedResource")
+			emptyRT := new(v1beta1.ResourceTracker)
+			emptyRT.SetName(fmt.Sprintf("%s-%s", appName, appNs))
+			emptyRT.SetLabels(map[string]string{
+				oam.LabelAppName:      appName,
+				oam.LabelAppNamespace: appNs,
+			})
+			Expect(k8sClient.Create(ctx, emptyRT)).Should(BeNil())
+
+			prd := provider{cli: k8sClient}
+			opt := `app: {
+				name: "test-legacy-complex"
+				namespace: "test-legacy-complex"
+				components: []
+				enableHistoryQuery: true
+			}`
+			v, err := value.NewValue(opt, nil, "")
+			Expect(err).Should(BeNil())
+			Expect(prd.ListResourcesInApp(nil, v, nil)).Should(BeNil())
+
+			appResList := new(AppResourcesList)
+			Expect(v.UnmarshalTo(appResList)).Should(BeNil())
+			Expect(len(appResList.List)).Should(Equal(2))
+
+			By("create resourceTracker tracked an un-exist resource")
+			rt := new(v1beta1.ResourceTracker)
+			rt.SetName(fmt.Sprintf("%s-v%d-%s", appName, 3, appNs))
+			rt.SetLabels(map[string]string{
+				oam.LabelAppName:      appName,
+				oam.LabelAppNamespace: appNs,
+			})
+			Expect(k8sClient.Create(ctx, rt)).Should(BeNil())
+
+			oldRT := new(v1beta1.ResourceTracker)
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rt), oldRT); err != nil {
+					return err
+				}
+				oldRT.Status.TrackedResources = []corev1.ObjectReference{{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Namespace:  appNs,
+					Name:       fmt.Sprintf("web-v%d", 3),
+				}, {
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Namespace:  appNs,
+					Name:       fmt.Sprintf("web-v%d", 3),
+				}}
+				if err := k8sClient.Status().Update(ctx, oldRT); err != nil {
+					return err
+				}
+				return nil
+			}, 3*time.Second, 300*time.Microsecond).Should(BeNil())
+
+			appService := baseService.DeepCopy()
+			appService.SetName(fmt.Sprintf("web-v%d", 4))
+			appService.SetNamespace(appNs)
+			appService.SetLabels(map[string]string{
+				oam.LabelAppComponent: "web",
+				oam.LabelAppRevision:  fmt.Sprintf("%s-v%d", appName, 4),
+			})
+			Expect(k8sClient.Create(ctx, appService)).Should(BeNil())
+
+			newV, err := value.NewValue(opt, nil, "")
+			Expect(err).Should(BeNil())
+			Expect(prd.ListResourcesInApp(nil, newV, nil)).Should(BeNil())
+			appResList = new(AppResourcesList)
+			Expect(v.UnmarshalTo(appResList)).Should(BeNil())
+			Expect(len(appResList.List)).Should(Equal(2))
+
+			By("create resourceTracker tracked with wrong name")
+			wrongNameRT := new(v1beta1.ResourceTracker)
+			wrongNameRT.SetName("test-1")
+			wrongNameRT.SetLabels(map[string]string{
+				oam.LabelAppName:      appName,
+				oam.LabelAppNamespace: appNs,
+			})
+			Expect(k8sClient.Create(ctx, wrongNameRT)).Should(BeNil())
+
+			oldRT = new(v1beta1.ResourceTracker)
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wrongNameRT), oldRT); err != nil {
+					return err
+				}
+				oldRT.Status.TrackedResources = []corev1.ObjectReference{{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Namespace:  appNs,
+					Name:       fmt.Sprintf("web-v%d", 4),
+				}, {
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Namespace:  appNs,
+					Name:       fmt.Sprintf("web-v%d", 4),
+				}}
+				if err := k8sClient.Status().Update(ctx, oldRT); err != nil {
+					return err
+				}
+				return nil
+			}, 3*time.Second, 300*time.Microsecond).Should(BeNil())
+
+			newV, err = value.NewValue(opt, nil, "")
+			Expect(err).Should(BeNil())
+			Expect(prd.ListResourcesInApp(nil, newV, nil)).Should(BeNil())
+			appResList = new(AppResourcesList)
+			Expect(newV.UnmarshalTo(appResList)).Should(BeNil())
+			Expect(len(appResList.Err)).ShouldNot(Equal(0))
+		})
+
+		It("Test list resource with incomplete parameter", func() {
+			optWithoutApp := ""
+			prd := provider{cli: k8sClient}
+			newV, err := value.NewValue(optWithoutApp, nil, "")
+			Expect(err).Should(BeNil())
+			err = prd.ListResourcesInApp(nil, newV, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(Equal("var(path=app) not exist"))
+		})
+	})
+
+	Context("Test CollectPods", func() {
+		It("Test collect pod from workload deployment", func() {
+			deploy := baseDeploy.DeepCopy()
+			deploy.SetName("test-collect-pod")
+			deploy.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					oam.LabelAppComponent: "test",
+				},
+			}
+			deploy.Spec.Template.ObjectMeta.SetLabels(map[string]string{
+				oam.LabelAppComponent: "test",
+			})
+			Expect(k8sClient.Create(ctx, deploy)).Should(BeNil())
+			for i := 1; i <= 5; i++ {
+				pod := basePod.DeepCopy()
+				pod.SetName(fmt.Sprintf("test-collect-pod-%d", i))
+				pod.SetLabels(map[string]string{
+					oam.LabelAppComponent: "test",
+				})
+				Expect(k8sClient.Create(ctx, pod)).Should(BeNil())
+			}
+
+			prd := provider{cli: k8sClient}
+			unstructuredDeploy, err := util.Object2Unstructured(deploy)
+			Expect(err).Should(BeNil())
+			unstructuredDeploy.SetGroupVersionKind((&corev1.ObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			}).GroupVersionKind())
+
+			deployJson, err := json.Marshal(unstructuredDeploy)
+
+			opt := fmt.Sprintf(`value: %s
+cluster: ""`, deployJson)
+			v, err := value.NewValue(opt, nil, "")
+			Expect(err).Should(BeNil())
+			Expect(prd.CollectPods(nil, v, nil)).Should(BeNil())
+
+			podList := new(PodList)
+			Expect(v.UnmarshalTo(podList)).Should(BeNil())
+			Expect(len(podList.List)).Should(Equal(5))
+			for _, pod := range podList.List {
+				Expect(pod.GroupVersionKind()).Should(Equal((&corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				}).GroupVersionKind()))
+			}
+		})
+
+		It("Test collect pod with incomplete parameter", func() {
+			emptyOpt := ""
+			prd := provider{cli: k8sClient}
+			v, err := value.NewValue(emptyOpt, nil, "")
+			Expect(err).Should(BeNil())
+			err = prd.CollectPods(nil, v, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(Equal("var(path=value) not exist"))
+
+			optWithoutCluster := `value: {}`
+			v, err = value.NewValue(optWithoutCluster, nil, "")
+			Expect(err).Should(BeNil())
+			err = prd.CollectPods(nil, v, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(Equal("var(path=cluster) not exist"))
+
+			optWithWrongValue := `value: {test: 1}
+cluster: "test"`
+			v, err = value.NewValue(optWithWrongValue, nil, "")
+			Expect(err).Should(BeNil())
+			err = prd.CollectPods(nil, v, nil)
+			Expect(err).ShouldNot(BeNil())
+		})
+	})
+
+	Context("Test search event from k8s object", func() {
+		It("Test search event with incomplete parameter", func() {
+			emptyOpt := ""
+			prd := provider{cli: k8sClient}
+			v, err := value.NewValue(emptyOpt, nil, "")
+			Expect(err).Should(BeNil())
+			err = prd.SearchEvents(nil, v, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(Equal("var(path=value) not exist"))
+
+			optWithoutCluster := `value: {}`
+			v, err = value.NewValue(optWithoutCluster, nil, "")
+			Expect(err).Should(BeNil())
+			err = prd.SearchEvents(nil, v, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(Equal("var(path=cluster) not exist"))
+
+			optWithWrongValue := `value: {} 
+cluster: "test"`
+			v, err = value.NewValue(optWithWrongValue, nil, "")
+			Expect(err).Should(BeNil())
+			err = prd.SearchEvents(nil, v, nil)
+			Expect(err).ShouldNot(BeNil())
+		})
+	})
+
+	It("Test install provider", func() {
+		p := providers.NewProviders()
+		Install(p, k8sClient)
+		h, ok := p.GetHandler("query", "listResourcesInApp")
+		Expect(h).ShouldNot(BeNil())
+		Expect(ok).Should(Equal(true))
+		h, ok = p.GetHandler("query", "collectPods")
+		Expect(h).ShouldNot(BeNil())
+		Expect(ok).Should(Equal(true))
+		h, ok = p.GetHandler("query", "searchEvents")
+		Expect(h).ShouldNot(BeNil())
+	})
+})
+
+var deploymentYaml = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.oam.dev/app-revision-hash: ee69f7ed168cd8fa
+    app.oam.dev/appRevision: first-vela-app-v1
+    app.oam.dev/component: express-server
+    app.oam.dev/name: first-vela-app
+    app.oam.dev/resourceType: WORKLOAD
+    app.oam.dev/revision: express-server-v1
+    oam.dev/render-hash: ee2d39b553b6ef03
+    workload.oam.dev/type: webservice
+  name: express-server
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.oam.dev/component: express-server
+  template:
+    metadata:
+      labels:
+        app.oam.dev/component: express-server
+    spec:
+      containers:
+      - image: crccheck/hello-world
+        imagePullPolicy: Always
+        name: express-server
+        ports:
+        - containerPort: 8000
+          protocol: TCP
+`
+
+var serviceYaml = `
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.oam.dev/app-revision-hash: ee69f7ed168cd8fa
+    app.oam.dev/appRevision: first-vela-app-v1
+    app.oam.dev/component: express-server
+    app.oam.dev/name: first-vela-app
+    app.oam.dev/resourceType: TRAIT
+    app.oam.dev/revision: express-server-v1
+    oam.dev/render-hash: bebe99ac3e9607d0
+    trait.oam.dev/resource: service
+    trait.oam.dev/type: ingress-1-20
+  name: express-server
+  namespace: default
+spec:
+  ports:
+  - port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app.oam.dev/component: express-server
+`
+
+var podYaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.oam.dev/component: express-server
+  name: express-server-b77f4476b-4mt5m
+  namespace: default
+spec:
+  containers:
+  - image: crccheck/hello-world
+    imagePullPolicy: Always
+    name: express-server-1
+    ports:
+    - containerPort: 8000
+      protocol: TCP
+`

--- a/pkg/velaql/providers/query/suite_test.go
+++ b/pkg/velaql/providers/query/suite_test.go
@@ -1,0 +1,76 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"k8s.io/utils/pointer"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx context.Context
+
+var _ = BeforeSuite(func(done Done) {
+	By("bootstrapping test environment")
+
+	testEnv = &envtest.Environment{
+		ControlPlaneStartTimeout: time.Minute * 3,
+		ControlPlaneStopTimeout:  time.Minute,
+		UseExistingCluster:       pointer.BoolPtr(false),
+		CRDDirectoryPaths:        []string{"../../../../charts/vela-core/crds"},
+	}
+
+	By("start kube test env")
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	By("new kube client")
+	cfg.Timeout = time.Minute * 2
+	k8sClient, err = client.New(cfg, client.Options{Scheme: common.Scheme})
+
+	Expect(err).Should(BeNil())
+	Expect(k8sClient).ToNot(BeNil())
+
+	ctx = context.Background()
+	Expect(err).To(BeNil())
+	close(done)
+}, 240)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+func TestQueryProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VelaQL Suite")
+}

--- a/pkg/velaql/suite_test.go
+++ b/pkg/velaql/suite_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/clients"
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
@@ -43,8 +42,8 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 var viewHandler *ViewHandler
 var pod corev1.Pod
-var readView v1beta1.WorkflowStepDefinition
-var applyView v1beta1.WorkflowStepDefinition
+var readView corev1.ConfigMap
+var applyView corev1.ConfigMap
 
 var _ = BeforeSuite(func(done Done) {
 	rand.Seed(time.Now().UnixNano())

--- a/pkg/velaql/testdata/apply-object.yaml
+++ b/pkg/velaql/testdata/apply-object.yaml
@@ -1,33 +1,29 @@
-apiVersion: core.oam.dev/v1beta1
-kind: WorkflowStepDefinition
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  annotations:
-    definition.oam.dev/description: Apply raw kubernetes objects for your workflow steps
   name: apply-object
   namespace: vela-system
-spec:
-  schematic:
-    cue:
-      template: |
-        import (
-        	"vela/op"
-        )
+data:
+  template: |
+    import (
+        "vela/op"
+    )
 
-        apply: op.#Apply & {
-        	value: {
-              apiVersion: parameter.apiVersion
-              kind: parameter.kind
-              metadata: {
-                name: parameter.name
-              }
-            }
+    apply: op.#Apply & {
+        value: {
+          apiVersion: parameter.apiVersion
+          kind: parameter.kind
+          metadata: {
+            name: parameter.name
+          }
         }
+    }
 
-        objStatus: {
-          apply.value
-        }
-        parameter: {
-          apiVersion: string
-          kind: string
-          name: string
-        }
+    objStatus: {
+      apply.value
+    }
+    parameter: {
+      apiVersion: string
+      kind: string
+      name: string
+    }

--- a/pkg/workflow/providers/kube/handle.go
+++ b/pkg/workflow/providers/kube/handle.go
@@ -19,12 +19,11 @@ package kube
 import (
 	"context"
 
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/pkg/cue/model"
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/multicluster"

--- a/pkg/workflow/providers/time/date.go
+++ b/pkg/workflow/providers/time/date.go
@@ -1,0 +1,89 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package time
+
+import (
+	"time"
+
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
+	"github.com/oam-dev/kubevela/pkg/workflow/providers"
+	"github.com/oam-dev/kubevela/pkg/workflow/types"
+)
+
+const (
+	// ProviderName is provider name for install.
+	ProviderName = "time"
+)
+
+type provider struct {
+}
+
+func (h *provider) Timestamp(ctx wfContext.Context, v *value.Value, act types.Action) error {
+	date, err := v.GetString("date")
+	if err != nil {
+		return err
+	}
+	layout, err := v.GetString("layout")
+	if err != nil {
+		return err
+	}
+	if layout == "" {
+		layout = time.RFC3339
+	}
+	t, err := time.Parse(layout, date)
+	if err != nil {
+		return err
+	}
+	return v.FillObject(t.Unix(), "timestamp")
+}
+
+func (h *provider) Date(ctx wfContext.Context, v *value.Value, act types.Action) error {
+	timestamp, err := v.GetInt64("timestamp")
+	if err != nil {
+		return err
+	}
+	layout, err := v.GetString("layout")
+	if err != nil {
+		return err
+	}
+	locationName, err := v.GetString("location")
+	if err != nil {
+		return err
+	}
+
+	if layout == "" {
+		layout = time.RFC3339
+	}
+
+	location, err := time.LoadLocation(locationName)
+	if err != nil {
+		return err
+	}
+	t := time.Unix(timestamp, 0)
+	t.In(location)
+	return v.FillObject(t.Format(layout), "date")
+}
+
+// Install register handlers to provider discover.
+func Install(p providers.Providers) {
+	prd := &provider{}
+	p.Register(ProviderName, map[string]providers.Handler{
+		"timestamp": prd.Timestamp,
+		"date":      prd.Date,
+	})
+}

--- a/pkg/workflow/providers/time/date_test.go
+++ b/pkg/workflow/providers/time/date_test.go
@@ -1,0 +1,170 @@
+/*
+ Copyright 2021. The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package time
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+	"github.com/oam-dev/kubevela/pkg/workflow/providers"
+)
+
+func TestTimestamp(t *testing.T) {
+	testcases := map[string]struct {
+		from        string
+		expected    int64
+		expectedErr error
+	}{
+		"test convert date with default time layout": {
+			from: `date: "2021-11-07T01:47:51Z"
+layout: ""`,
+			expected:    1636249671,
+			expectedErr: nil,
+		},
+		"test convert date with RFC3339 layout": {
+			from: `date: "2021-11-07T01:47:51Z"
+layout: "2006-01-02T15:04:05Z07:00"`,
+			expected:    1636249671,
+			expectedErr: nil,
+		},
+		"test convert date with RFC1123 layout": {
+			from: `date: "Fri, 01 Mar 2019 15:00:00 GMT"
+layout: "Mon, 02 Jan 2006 15:04:05 MST"`,
+			expected:    1551452400,
+			expectedErr: nil,
+		},
+		"test convert date without time layout": {
+			from:        `date: "2021-11-07T01:47:51Z"`,
+			expected:    0,
+			expectedErr: errors.New("var(path=layout) not exist"),
+		},
+		"test convert without date": {
+			from:        ``,
+			expected:    0,
+			expectedErr: errors.New("var(path=date) not exist"),
+		},
+		"test convert date with wrong time layout": {
+			from: `date: "2021-11-07T01:47:51Z"
+layout: "Mon, 02 Jan 2006 15:04:05 MST"`,
+			expected:    0,
+			expectedErr: errors.New(`parsing time "2021-11-07T01:47:51Z" as "Mon, 02 Jan 2006 15:04:05 MST": cannot parse "2021-11-07T01:47:51Z" as "Mon"`),
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			v, err := value.NewValue(tc.from, nil, "")
+			r.NoError(err)
+			prd := &provider{}
+			err = prd.Timestamp(nil, v, nil)
+			if tc.expectedErr != nil {
+				r.Equal(tc.expectedErr.Error(), err.Error())
+				return
+			}
+			r.NoError(err)
+			expected, err := v.LookupValue("timestamp")
+			r.NoError(err)
+			ret, err := expected.CueValue().Int64()
+			r.NoError(err)
+			r.Equal(tc.expected, ret)
+		})
+	}
+}
+
+func TestDate(t *testing.T) {
+	testcases := map[string]struct {
+		from        string
+		expected    string
+		expectedErr error
+	}{
+		"test convert timestamp to default time layout": {
+			from: `timestamp: 1636249671
+layout: ""
+location: ""`,
+			expected:    "2021-11-07T09:47:51+08:00",
+			expectedErr: nil,
+		},
+		"test convert date to RFC3339 layout": {
+			from: `timestamp: 1636249671
+layout: "2006-01-02T15:04:05Z07:00"
+location: ""`,
+			expected:    "2021-11-07T09:47:51+08:00",
+			expectedErr: nil,
+		},
+		"test convert date to RFC1123 layout": {
+			from: `timestamp: 1551452400
+layout: "Mon, 02 Jan 2006 15:04:05 MST"
+location: ""`,
+			expected:    "Fri, 01 Mar 2019 23:00:00 CST",
+			expectedErr: nil,
+		},
+		"test convert date without time layout": {
+			from: `timestamp: 1551452400
+location: ""`,
+			expected:    "",
+			expectedErr: errors.New("var(path=layout) not exist"),
+		},
+		"test convert date without time location": {
+			from: `timestamp: 1551452400
+layout: "Mon, 02 Jan 2006 15:04:05 MST"`,
+			expected:    "",
+			expectedErr: errors.New("var(path=location) not exist"),
+		},
+		"test convert without timestamp": {
+			from:        ``,
+			expected:    "",
+			expectedErr: errors.New("var(path=timestamp) not exist"),
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			v, err := value.NewValue(tc.from, nil, "")
+			r.NoError(err)
+			prd := &provider{}
+			err = prd.Date(nil, v, nil)
+			if tc.expectedErr != nil {
+				r.Equal(tc.expectedErr.Error(), err.Error())
+				return
+			}
+			r.NoError(err)
+			expected, err := v.LookupValue("date")
+			r.NoError(err)
+			ret, err := expected.CueValue().String()
+			r.NoError(err)
+			r.Equal(tc.expected, ret)
+		})
+	}
+}
+
+func TestInstall(t *testing.T) {
+	p := providers.NewProviders()
+	Install(p)
+	h, ok := p.GetHandler("time", "timestamp")
+	r := require.New(t)
+	r.Equal(ok, true)
+	r.Equal(h != nil, true)
+
+	h, ok = p.GetHandler("time", "date")
+	r.Equal(ok, true)
+	r.Equal(h != nil, true)
+}

--- a/pkg/workflow/tasks/template/load_test.go
+++ b/pkg/workflow/tasks/template/load_test.go
@@ -51,7 +51,7 @@ func TestLoad(t *testing.T) {
 		},
 	}
 	tdm := mock.NewMockDiscoveryMapper()
-	loader := NewTemplateLoader(cli, tdm)
+	loader := NewWorkflowStepTemplateLoader(cli, tdm)
 
 	tmpl, err := loader.LoadTaskTemplate(context.Background(), "builtin-apply-component")
 	assert.NilError(t, err)

--- a/test/e2e-apiserver-test/testdata/component-pod-view.yaml
+++ b/test/e2e-apiserver-test/testdata/component-pod-view.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: component-pod-view
+  namespace: vela-system
+data:
+  template: |
+    import (
+      "vela/ql"
+      "vela/op"
+      "list"
+    )
+
+    parameter: {
+      name:          string
+      namespace:     string
+      componentName: string
+    }
+
+    application: ql.#ListResourcesInApp & {
+      app: {
+        name:      parameter.name
+        namespace: parameter.namespace
+        components: [parameter.componentName]
+      }
+    }
+
+    app:       application.list[0]
+    resources: app.components[0].resources
+
+    podsMap: op.#Steps & {
+      for i, resource in resources {
+        "\(i)": ql.#CollectPods & {
+          value:   resource.object
+          cluster: resource.cluster
+        }
+      }
+    }
+
+    podsWithCluster: {for i, pods in podsMap {
+      "\(i)": [
+        for podObj in pods.list {
+          cluster: pods.cluster
+          obj:     podObj
+        },
+      ]
+    }}
+
+    flatPods: list.FlattenN([ for pods in podsWithCluster {
+      pods
+    }], 1)
+
+    podStatus: op.#Steps & {
+      for i, pod in flatPods {
+        "\(i)": op.#Steps & {
+          name: pod.obj.metadata.name
+          containers: {for container in pod.obj.status.containerStatuses {
+            "\(container.name)": {
+              image: container.image
+              state: container.state
+            }
+          }}
+          events: ql.#SearchEvents & {
+            value:   pod.obj
+            cluster: pod.cluster
+          }
+          metrics: ql.#Read & {
+            cluster: pod.cluster
+            value: {
+              apiVersion: "metrics.k8s.io/v1beta1"
+              kind:       "PodMetrics"
+              metadata: {
+                name:      pod.obj.metadata.name
+                namespace: pod.obj.metadata.namespace
+              }
+            }
+          }
+        }
+      }
+    }
+
+    status: {
+      podList: [ for podInfo in podStatus {
+        name: podInfo.name
+        containers: [ for containerName, container in podInfo.containers {
+          containerName
+        }]
+        events: podInfo.events.list
+      }]
+    }
+
+

--- a/test/e2e-apiserver-test/testdata/read-view.yaml
+++ b/test/e2e-apiserver-test/testdata/read-view.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: read-object
+  name: read-view
   namespace: vela-system
 data:
   template: |
@@ -39,9 +39,7 @@ data:
             }
         }
     }
-    objStatus: {
-      output.value.status
-    }
+
     parameter: {
         // +usage=Specify the apiVersion of the object, defaults to core.oam.dev/v1beta1
         apiVersion?: string

--- a/test/e2e-apiserver-test/velaql_test.go
+++ b/test/e2e-apiserver-test/velaql_test.go
@@ -22,27 +22,50 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
+	common2 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	apiv1 "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 )
+
+type PodStatus struct {
+	Name       string      `json:"name"`
+	Containers []string    `json:"containers"`
+	Events     interface{} `json:"events"`
+}
+type Status struct {
+	PodList []PodStatus `json:"podList"`
+}
 
 var _ = Describe("Test velaQL rest api", func() {
 	namespace := "test-velaql"
 	appName := "example-app"
+	component1Name := "ql-webservice"
+	component2Name := "ql-worker"
 	var app v1beta1.Application
+	var readView corev1.ConfigMap
 
 	It("Test query application status via view", func() {
+		Expect(common.ReadYamlToObject("./testdata/read-view.yaml", &readView)).Should(BeNil())
+		Expect(k8sClient.Create(context.Background(), &readView)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
 		Expect(common.ReadYamlToObject("./testdata/example-app.yaml", &app)).Should(BeNil())
+		app.Spec.Components[0].Name = component1Name
+		app.Spec.Components[1].Name = component2Name
+
 		req := apiv1.ApplicationRequest{
 			Components: app.Spec.Components,
-			Policies:   app.Spec.Policies,
-			Workflow:   app.Spec.Workflow,
 		}
 		bodyByte, err := json.Marshal(req)
 		Expect(err).Should(BeNil())
@@ -55,9 +78,19 @@ var _ = Describe("Test velaQL rest api", func() {
 		Expect(res).ShouldNot(BeNil())
 		Expect(res.StatusCode).Should(Equal(200))
 
-		Expect(err).Should(BeNil())
+		oldApp := new(v1beta1.Application)
+		Eventually(func() error {
+			if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: appName, Namespace: namespace}, oldApp); err != nil {
+				return err
+			}
+			if oldApp.Status.Phase != common2.ApplicationRunning {
+				return errors.New("application is not ready")
+			}
+			return nil
+		}, 3*time.Second, 300*time.Microsecond).Should(BeNil())
+
 		queryRes, err := http.Get(
-			fmt.Sprintf("http://127.0.0.1:8000/api/v1/query?velaql=%s{name=%s,namespace=%s}.%s", "read-object", appName, namespace, "output.value.spec"),
+			fmt.Sprintf("http://127.0.0.1:8000/api/v1/query?velaql=%s{name=%s,namespace=%s}.%s", "read-view", appName, namespace, "output.value.spec"),
 		)
 		Expect(err).Should(BeNil())
 		Expect(queryRes.StatusCode).Should(Equal(200))
@@ -71,7 +104,6 @@ var _ = Describe("Test velaQL rest api", func() {
 		Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: appName, Namespace: namespace}, &existApp)).Should(BeNil())
 
 		Expect(len(appSpec.Components)).Should(Equal(len(existApp.Spec.Components)))
-		Expect(len(appSpec.Workflow.Steps)).Should(Equal(len(existApp.Spec.Workflow.Steps)))
 	})
 
 	It("Test query application status with wrong velaQL", func() {
@@ -81,4 +113,155 @@ var _ = Describe("Test velaQL rest api", func() {
 		Expect(err).Should(BeNil())
 		Expect(queryRes.StatusCode).Should(Equal(400))
 	})
+
+	It("Test query application component view", func() {
+		componentView := new(corev1.ConfigMap)
+		Expect(common.ReadYamlToObject("./testdata/component-pod-view.yaml", componentView)).Should(BeNil())
+		Expect(k8sClient.Create(context.Background(), componentView)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+		oldApp := new(v1beta1.Application)
+		Eventually(func() error {
+			if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: appName, Namespace: namespace}, oldApp); err != nil {
+				return err
+			}
+			if oldApp.Status.Phase != common2.ApplicationRunning {
+				return errors.New("application is not ready")
+			}
+			return nil
+		}, 3*time.Second, 300*time.Microsecond).Should(BeNil())
+
+		queryRes, err := http.Get(
+			fmt.Sprintf("http://127.0.0.1:8000/api/v1/query?velaql=%s{name=%s,namespace=%s,componentName=%s}.%s", "component-pod-view", appName, namespace, component1Name, "status"),
+		)
+		Expect(err).Should(BeNil())
+		Expect(queryRes.StatusCode).Should(Equal(200))
+
+		defer queryRes.Body.Close()
+		status := new(Status)
+		err = json.NewDecoder(queryRes.Body).Decode(status)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(len(status.PodList)).Should(Equal(1))
+		Expect(status.PodList[0].Containers[0]).Should(Equal(component1Name))
+
+		Eventually(func() error {
+			queryRes1, err := http.Get(
+				fmt.Sprintf("http://127.0.0.1:8000/api/v1/query?velaql=%s{name=%s,namespace=%s,componentName=%s}.%s", "component-pod-view", appName, namespace, component2Name, "status"),
+			)
+			if err != nil {
+				return err
+			}
+			if queryRes1.StatusCode != 200 {
+				return errors.Errorf("status code is %d", queryRes1.StatusCode)
+			}
+			defer queryRes1.Body.Close()
+			status1 := new(Status)
+			err = json.NewDecoder(queryRes1.Body).Decode(status1)
+			if err != nil {
+				return err
+			}
+			if len(status1.PodList) != 1 {
+				return errors.New("pod number is zero")
+			}
+			if status1.PodList[0].Containers[0] != component2Name {
+				return errors.New("container name is not correct")
+			}
+			return nil
+		}, 10*time.Second, 300*time.Microsecond).Should(BeNil())
+	})
+
+	It("Test collect pod from cronJob", func() {
+		cronJob := new(v1beta1.ComponentDefinition)
+		Expect(yaml.Unmarshal([]byte(cronJobComponentDefinition), cronJob)).Should(BeNil())
+		Expect(k8sClient.Create(context.Background(), cronJob)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+		oldApp := new(v1beta1.Application)
+		Eventually(func() error {
+			if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: appName, Namespace: namespace}, oldApp); err != nil {
+				return err
+			}
+			oldApp.Spec.Components[1].Type = "cronjob"
+			oldApp.Spec.Components[1].Properties = util.Object2RawExtension(map[string]interface{}{
+				"image": "busybox",
+				"cmd":   []string{"sleep", "1"},
+			})
+			if err := k8sClient.Update(context.Background(), oldApp); err != nil {
+				return err
+			}
+			return nil
+		}, 3*time.Second, 300*time.Microsecond).Should(BeNil())
+
+		newApp := new(v1beta1.Application)
+		Eventually(func() error {
+			if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(oldApp), newApp); err != nil {
+				return err
+			}
+			if newApp.Status.Phase != common2.ApplicationRunning {
+				return errors.New("application is not ready")
+			}
+			return nil
+		}, 3*time.Second, 300*time.Microsecond).Should(BeNil())
+
+		newWorkload := new(batchv1beta1.CronJob)
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), client.ObjectKey{Name: component2Name, Namespace: namespace}, newWorkload)
+		}, 10*time.Second, 300*time.Microsecond).Should(BeNil())
+
+		Eventually(func() error {
+			queryRes, err := http.Get(
+				fmt.Sprintf("http://127.0.0.1:8000/api/v1/query?velaql=%s{name=%s,namespace=%s,componentName=%s}.%s", "component-pod-view", appName, namespace, component2Name, "status"),
+			)
+			if err != nil {
+				return err
+			}
+			if queryRes.StatusCode != 200 {
+				return errors.Errorf("status code is %d", queryRes.StatusCode)
+			}
+			defer queryRes.Body.Close()
+			status := new(Status)
+			err = json.NewDecoder(queryRes.Body).Decode(status)
+			if err != nil {
+				return err
+			}
+			if len(status.PodList) == 0 {
+				return errors.New("pod list is 0")
+			}
+			return nil
+		}, 2*time.Minute, 3*time.Microsecond).Should(BeNil())
+	})
 })
+
+var cronJobComponentDefinition = `
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  annotations: {}
+  name: cronjob
+  namespace: vela-system
+spec:
+  schematic:
+    cue:
+      template: |
+        output: {
+                apiVersion: "batch/v1beta1"
+                kind:       "CronJob"
+                metadata: name: context.name
+                spec: {
+                        schedule: "*/1 * * * *"
+                        jobTemplate: spec: template: spec: {
+                                containers: [{
+                                        name:            context.name
+                                        image:           parameter.image
+                                        imagePullPolicy: "IfNotPresent"
+                                        command:         parameter.cmd
+                                }]
+                                restartPolicy: "OnFailure"
+                        }
+                }
+        }
+        parameter: {
+                image: string
+                cmd: [...string]
+        }
+  workload:
+    type: autodetects.core.oam.dev
+`


### PR DESCRIPTION
### Description of your changes

This PR add `query` provider  to support observe the status of runtime cluster resources. 

### `Query` provider 

`query` provider now supports 3 kinds of query capabilities:

1. **`#ListResourcesInApp`**  can list all resources created by the app.  the query results are fedback to the `list` field.

```
// definition 
#ListResourcesInApp: {
	#do:       "listResourcesInApp"
	#provider: "query"
	app: {
		name:      string
		namespace: string
		// component wants to query 
		components?: [...string]
		enableHistoryQuery: false | bool
	}
	// list return the query results
	list?: [...#App]
}

#App: {
	components: [...{
		name: string // component name
		resources: [...{
			cluster: string // which cluster the resource is deployed to
			object: {...} // k8s object
		}]
	}]
	metadata: {...} // metadata of application
	revision: int // revision num of application
}

// usage
applications: ql.#ListResourcesInApp & {
  app: {
    name:      parameter.name
    namespace: parameter.namespace
    components: [parameter.componentName]
  }
}

result: applications.list
```

2. **`#CollectPods`** collect pods created by workloads

```
// definition 
#CollectPods: {
	#do:       "collectPods"
	#provider: "query"
	// workloads
	value: {...}
	cluster: string
	// list return the query results
	list?: [...#Pod]
}
// k8s pod object 
#Pod: {...}

//usage
pods: ql.#CollectPods: {
	value: {
		apiVersion: "apps/v1"
		kind: "Deployment"
		metadata: {
			name: "test"
			namespace: "default"
		}
	}
	cluster: "pro-cluster"
}

result: pods.list
```

3. **`#SearchEvents`**  search all Events related  to the target object

```
// definition 
#SearchEvents: {
	#do:       "searchEvents"
	#provider: "query"
	value: {...}
	cluster: string
	list?: [...#Event]
}

// k8s event object 
#Event: {...}

//usage
events: ql.#SearchEvents: {
	value: {
		apiVersion: "core/v1"
		kind: "Pod"
		metadata: {
			name: "test"
			namespace: "default"
		}
	}
	cluster: "pro-cluster"
}

result: events.list
```

### How to use `query` provider 

Combined with query capabilities of `query` provider, we can use velaQL monitor the health status of pods created by applications.

1. First we need to write the query view `component-pod-view` - [componet-pod-view.yaml]( https://github.com/oam-dev/kubevela/blob/3ca2785874ba05e0d75d03f4f9e96bfe2e314451/docs/examples/velaql-views/componet-pod-view.yaml)
 > By default, velaQL will finds the template of the view with the same name from the configMap under ns `vela-system`

2. Query view
```
api/v1/query?velaql=component-pod-view{name=first-app,compName=express-server}.status
```
3. Get query Result

```json
{
    "podList": [
        {
            "containers": [
                {
                    "image": "docker.io/crccheck/hello-world:latest",
                    "name": "express-server-1",
                    "state": {
                        "running": {
                            "startedAt": "2021-11-07T06:46:15Z"
                        }
                    },
                    "usage": {
                        "cpu": "1853920n",
                        "memory": "320Ki"
                    }
                }
            ],
            "events": [
                {
                    "firstTimestamp": null,
                    "message": "Successfully assigned default/express-server-1-b77f4476b-4mt5m to kind-control-plane",
                    "reason": "Scheduled",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:45:57Z",
                    "message": "Pulling image \"crccheck/hello-world\"",
                    "reason": "Pulling",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:45:58Z",
                    "message": "Failed to pull image \"crccheck/hello-world\": rpc error: code = Unknown desc = failed to pull and unpack image \"docker.io/crccheck/hello-world:latest\": failed to resolve reference \"docker.io/crccheck/hello-world:latest\": failed to do request: Head \"https://registry-1.docker.io/v2/crccheck/hello-world/manifests/latest\": EOF",
                    "reason": "Failed",
                    "type": "Warning"
                },
                {
                    "firstTimestamp": "2021-11-07T06:45:58Z",
                    "message": "Error: ErrImagePull",
                    "reason": "Failed",
                    "type": "Warning"
                },
                {
                    "firstTimestamp": "2021-11-07T06:45:59Z",
                    "message": "Back-off pulling image \"crccheck/hello-world\"",
                    "reason": "BackOff",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:45:59Z",
                    "message": "Error: ImagePullBackOff",
                    "reason": "Failed",
                    "type": "Warning"
                },
                {
                    "firstTimestamp": "2021-11-07T06:46:15Z",
                    "message": "Successfully pulled image \"crccheck/hello-world\" in 4.202163177s",
                    "reason": "Pulled",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:46:15Z",
                    "message": "Created container express-server-1",
                    "reason": "Created",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:46:15Z",
                    "message": "Started container express-server-1",
                    "reason": "Started",
                    "type": "Normal"
                }
            ],
            "name": "express-server-1-b77f4476b-4mt5m"
        },
        {
            "containers": [
                {
                    "image": "docker.io/crccheck/hello-world:latest",
                    "name": "express-server-1",
                    "state": {
                        "running": {
                            "startedAt": "2021-11-07T06:46:02Z"
                        }
                    },
                    "usage": {
                        "cpu": "0",
                        "memory": "316Ki"
                    }
                }
            ],
            "events": [
                {
                    "firstTimestamp": null,
                    "message": "Successfully assigned default/express-server-1-b77f4476b-vbrd9 to kind-control-plane",
                    "reason": "Scheduled",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:45:57Z",
                    "message": "Pulling image \"crccheck/hello-world\"",
                    "reason": "Pulling",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:46:02Z",
                    "message": "Successfully pulled image \"crccheck/hello-world\" in 4.825586677s",
                    "reason": "Pulled",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:46:02Z",
                    "message": "Created container express-server-1",
                    "reason": "Created",
                    "type": "Normal"
                },
                {
                    "firstTimestamp": "2021-11-07T06:46:02Z",
                    "message": "Started container express-server-1",
                    "reason": "Started",
                    "type": "Normal"
                }
            ],
            "name": "express-server-1-b77f4476b-vbrd9"
        }
    ]
}
```

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->