### PR TITLE
Fix: load component cue action  can set patchedApp override default app

### DIFF
--- a/pkg/stdlib/op.cue
+++ b/pkg/stdlib/op.cue
@@ -107,6 +107,12 @@ import (
 
 #ApplyEnvBindApp: multicluster.#ApplyEnvBindApp
 
+#LoadPolicies: oam.#LoadPolicies
+
+#MakePlacementDecisions: multicluster.#MakePlacementDecisions
+
+#PatchApplication: multicluster.#PatchApplication
+
 #HTTPGet: http.#Do & {method: "GET"}
 
 #HTTPPost: http.#Do & {method: "POST"}

--- a/pkg/workflow/providers/oam/apply_test.go
+++ b/pkg/workflow/providers/oam/apply_test.go
@@ -167,6 +167,30 @@ func TestLoadComponent(t *testing.T) {
 	}
 }
 `)
+	overrideApp := `app: {
+	apiVersion: "core.oam.dev/v1beta1"
+	kind:       "Application"
+	metadata: {
+		name:      "test"
+		namespace: "default"
+	}
+	spec: {
+		components: [{
+			name: "c2"
+			type: "web"
+			properties: {
+				image: "busybox"
+			}
+		}]
+	}
+}
+`
+	overrideValue, err := value.NewValue(overrideApp, nil, "")
+	r.NoError(err)
+	err = p.LoadComponent(nil, overrideValue, nil)
+	r.NoError(err)
+	_, err = overrideValue.LookupValue("value", "c2")
+	r.NoError(err)
 }
 
 var testHealthy bool


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1.  load component cue action  can set patchedApp override default app
2. export some multiCluster cue action, let user can specify user defined workflow.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->