### PR TITLE
Fix: cluster url automatically patch port and scheme

### DIFF
--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// ParseAPIServerEndpoint automatically construct the full url of APIServer
+// It will patch port and scheme if not exists
+func ParseAPIServerEndpoint(server string) (string, error) {
+	r := regexp.MustCompile(`^((?P<scheme>http|https)://)?(?P<host>[^:\s]+)(:(?P<port>[0-9]+))?$`)
+	if !r.MatchString(server) {
+		return "", fmt.Errorf("invalid endpoint url: %s", server)
+	}
+	var scheme, port, host string
+	results := r.FindStringSubmatch(server)
+	for i, name := range r.SubexpNames() {
+		switch name {
+		case "scheme":
+			scheme = results[i]
+		case "host":
+			host = results[i]
+		case "port":
+			port = results[i]
+		}
+	}
+	if scheme == "" {
+		if port == "80" {
+			scheme = "http"
+		} else {
+			scheme = "https"
+		}
+	}
+	if port == "" {
+		if scheme == "http" {
+			port = "80"
+		} else {
+			port = "443"
+		}
+	}
+	return fmt.Sprintf("%s://%s:%s", scheme, host, port), nil
+}

--- a/pkg/utils/url_test.go
+++ b/pkg/utils/url_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEndpoint(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Output   string
+		HasError bool
+	}{{
+		Input:  "127.0.0.1",
+		Output: "https://127.0.0.1:443",
+	}, {
+		Input:  "http://127.0.0.1",
+		Output: "http://127.0.0.1:80",
+	}, {
+		Input:  "127.0.0.1:6443",
+		Output: "https://127.0.0.1:6443",
+	}, {
+		Input:  "127.0.0.1:80",
+		Output: "http://127.0.0.1:80",
+	}, {
+		Input:  "localhost",
+		Output: "https://localhost:443",
+	}, {
+		Input:  "https://worker-control-plane:6443",
+		Output: "https://worker-control-plane:6443",
+	}, {
+		Input:    "invalid url",
+		HasError: true,
+	}}
+	r := require.New(t)
+	for _, testCase := range testCases {
+		output, err := ParseAPIServerEndpoint(testCase.Input)
+		if testCase.HasError {
+			r.Error(err)
+			continue
+		}
+		r.NoError(err)
+		r.Equal(testCase.Output, output)
+	}
+}

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -43,6 +43,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/clustermanager"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/policy/envbinding"
+	"github.com/oam-dev/kubevela/pkg/utils"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	errors3 "github.com/oam-dev/kubevela/pkg/utils/errors"
 	"github.com/oam-dev/kubevela/references/a/preimport"
@@ -208,6 +209,11 @@ func NewClusterJoinCommand(c *common.Args) *cobra.Command {
 
 			switch clusterManagementType {
 			case ClusterGateWayClusterManagement:
+				if endpoint, err := utils.ParseAPIServerEndpoint(cluster.Server); err == nil {
+					cluster.Server = endpoint
+				} else {
+					_, _ = cmd.OutOrStdout().Write([]byte("failed to parse server endpoint: " + err.Error()))
+				}
 				if err = registerClusterManagedByVela(c.Client, cluster, authInfo, clusterName); err != nil {
 					return err
 				}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Using `vela cluster join` now only support kubeconfig with full apiserver url such as https://127.0.0.1:6443. It must include `scheme`, `host`, `port` three parts to work. This PR allows user only specify `host` and the added function will automatically add `scheme` and `port` to it.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->