### PR TITLE
Fix: istio addon application namespace not in vela-system

### DIFF
--- a/charts/vela-core/templates/addons/istio.yaml
+++ b/charts/vela-core/templates/addons/istio.yaml
@@ -8,7 +8,7 @@ data:
         addons.oam.dev/description: istio Controller is a Kubernetes Controller for manage
           traffic.
       name: istio
-      namespace: istio-system
+      namespace: vela-system
     spec:
       components:
       - name: ns-istio-system

--- a/vela-templates/addons/auto-gen/istio.yaml
+++ b/vela-templates/addons/auto-gen/istio.yaml
@@ -5,7 +5,7 @@ metadata:
     addons.oam.dev/description: istio Controller is a Kubernetes Controller for manage
       traffic.
   name: istio
-  namespace: istio-system
+  namespace: vela-system
 spec:
   components:
   - name: ns-istio-system

--- a/vela-templates/addons/istio/template.yaml
+++ b/vela-templates/addons/istio/template.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     addons.oam.dev/description: "istio Controller is a Kubernetes Controller for manage traffic."
   name: istio
-  namespace: istio-system
+  namespace: vela-system
 spec:
   workflow:
     steps:


### PR DESCRIPTION
### Description of your changes

Addon's application should be in `vela-system` uniformly. `istio` addon isn't and fix this.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->