### PR TITLE
Fix: application status.services doesn't include Terraform typed components

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Run api e2e tests
         run: make e2e-api-test
 
+      - name: Run addons e2e tests
+        run: make e2e-addon-test
+
       - name: Run e2e tests
         run: make e2e-test
 

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,11 @@ e2e-test:
 	ginkgo -v  --skip="rollout related e2e-test." ./test/e2e-test
 	@$(OK) tests pass
 
+e2e-addon-test:
+	cp bin/vela /tmp/
+	ginkgo -v ./test/e2e-addon-test
+	@$(OK) tests pass
+
 e2e-rollout-test:
 	ginkgo -v  --focus="rollout related e2e-test." ./test/e2e-test
 	@$(OK) tests pass

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -36,7 +36,6 @@ import (
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/application/dispatch"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/applicationrollout"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
-	"github.com/oam-dev/kubevela/pkg/cue/process"
 	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
 )
 
@@ -174,24 +173,34 @@ func (h *AppHandler) collectHealthStatus(wl *appfile.Workload, appRev *v1beta1.A
 		}
 		appName  = appRev.Spec.Application.Name
 		isHealth = true
+		err      error
 	)
 
 	if wl.CapabilityCategory == types.TerraformCategory {
-		return nil, true, nil
+		ctx := context.Background()
+		var configuration terraformapi.Configuration
+		if err := h.r.Client.Get(ctx, client.ObjectKey{Name: wl.Name, Namespace: h.app.Namespace}, &configuration); err != nil {
+			return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, check health error", appName, wl.Name)
+		}
+		if configuration.Status.Apply.State != terraformtypes.Available {
+			status.Healthy = false
+		} else {
+			status.Healthy = true
+		}
+		status.Message = configuration.Status.Apply.Message
+	} else {
+		if ok, err := wl.EvalHealth(wl.Ctx, h.r.Client, h.app.Namespace); !ok || err != nil {
+			isHealth = false
+			status.Healthy = false
+		}
+
+		status.Message, err = wl.EvalStatus(wl.Ctx, h.r.Client, h.app.Namespace)
+		if err != nil {
+			return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, evaluate workload status message error", appName, wl.Name)
+		}
 	}
 
-	if ok, err := wl.EvalHealth(wl.Ctx, h.r.Client, h.app.Namespace); !ok || err != nil {
-		isHealth = false
-		status.Healthy = false
-	}
 	var traitStatusList []common.ApplicationTraitStatus
-
-	var err error
-	status.Message, err = wl.EvalStatus(wl.Ctx, h.r.Client, h.app.Namespace)
-	if err != nil {
-		return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, evaluate workload status message error", appName, wl.Name)
-	}
-
 	for _, tr := range wl.Traits {
 		var traitStatus = common.ApplicationTraitStatus{
 			Type:    tr.Name,
@@ -212,95 +221,6 @@ func (h *AppHandler) collectHealthStatus(wl *appfile.Workload, appRev *v1beta1.A
 	status.Scopes = generateScopeReference(wl.Scopes)
 	h.addServiceStatus(true, status)
 	return &status, isHealth, nil
-}
-
-func (h *AppHandler) aggregateHealthStatus(appFile *appfile.Appfile) ([]common.ApplicationComponentStatus, bool, error) {
-	var appStatus []common.ApplicationComponentStatus
-	var healthy = true
-	for _, wl := range appFile.Workloads {
-		var status = common.ApplicationComponentStatus{
-			Name:               wl.Name,
-			WorkloadDefinition: wl.FullTemplate.Reference.Definition,
-			Healthy:            true,
-		}
-
-		var pCtx process.Context
-
-		switch wl.CapabilityCategory {
-		case types.TerraformCategory:
-			pCtx = appfile.NewBasicContext(wl, appFile.Name, appFile.AppRevisionName, appFile.Namespace)
-			ctx := context.Background()
-			var configuration terraformapi.Configuration
-			if err := h.r.Client.Get(ctx, client.ObjectKey{Name: wl.Name, Namespace: h.app.Namespace}, &configuration); err != nil {
-				return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, check health error", appFile.Name, wl.Name)
-			}
-			if configuration.Status.Apply.State != terraformtypes.Available {
-				healthy = false
-				status.Healthy = false
-			} else {
-				status.Healthy = true
-			}
-			status.Message = configuration.Status.Apply.Message
-		default:
-			pCtx = process.NewContext(h.app.Namespace, wl.Name, appFile.Name, appFile.AppRevisionName)
-			if !h.isNewRevision && wl.CapabilityCategory != types.CUECategory {
-				templateStr, err := appfile.GenerateCUETemplate(wl)
-				if err != nil {
-					return nil, false, err
-				}
-				wl.FullTemplate.TemplateStr = templateStr
-			}
-
-			if err := wl.EvalContext(pCtx); err != nil {
-				return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, evaluate context error", appFile.Name, wl.Name)
-			}
-			workloadHealth, err := wl.EvalHealth(pCtx, h.r.Client, h.app.Namespace)
-			if err != nil {
-				return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, check health error", appFile.Name, wl.Name)
-			}
-			if !workloadHealth {
-				// TODO(wonderflow): we should add a custom way to let the template say why it's unhealthy, only a bool flag is not enough
-				status.Healthy = false
-				healthy = false
-			}
-
-			status.Message, err = wl.EvalStatus(pCtx, h.r.Client, h.app.Namespace)
-			if err != nil {
-				return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, evaluate workload status message error", appFile.Name, wl.Name)
-			}
-		}
-
-		var traitStatusList []common.ApplicationTraitStatus
-		for _, tr := range wl.Traits {
-			if err := tr.EvalContext(pCtx); err != nil {
-				return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, trait=%s, evaluate context error", appFile.Name, wl.Name, tr.Name)
-			}
-
-			var traitStatus = common.ApplicationTraitStatus{
-				Type:    tr.Name,
-				Healthy: true,
-			}
-			traitHealth, err := tr.EvalHealth(pCtx, h.r.Client, h.app.Namespace)
-			if err != nil {
-				return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, trait=%s, check health error", appFile.Name, wl.Name, tr.Name)
-			}
-			if !traitHealth {
-				// TODO(wonderflow): we should add a custom way to let the template say why it's unhealthy, only a bool flag is not enough
-				traitStatus.Healthy = false
-				healthy = false
-			}
-			traitStatus.Message, err = tr.EvalStatus(pCtx, h.r.Client, h.app.Namespace)
-			if err != nil {
-				return nil, false, errors.WithMessagef(err, "app=%s, comp=%s, trait=%s, evaluate status message error", appFile.Name, wl.Name, tr.Name)
-			}
-			traitStatusList = append(traitStatusList, traitStatus)
-		}
-
-		status.Traits = traitStatusList
-		status.Scopes = generateScopeReference(wl.Scopes)
-		appStatus = append(appStatus, status)
-	}
-	return appStatus, healthy, nil
 }
 
 func generateScopeReference(scopes []appfile.Scope) []corev1.ObjectReference {

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply_test.go
@@ -24,22 +24,17 @@ import (
 
 	"github.com/oam-dev/kubevela/pkg/oam/testutil"
 
-	terraformtypes "github.com/oam-dev/terraform-controller/api/types"
-	terraformapi "github.com/oam-dev/terraform-controller/api/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	velatypes "github.com/oam-dev/kubevela/apis/types"
-	"github.com/oam-dev/kubevela/pkg/appfile"
 )
 
 const workloadDefinition = `
@@ -155,63 +150,5 @@ var _ = Describe("Test Application apply", func() {
 		applabel, exist := apprev.Labels["app.oam.dev/name"]
 		Expect(exist).Should(BeTrue())
 		Expect(strings.Compare(applabel, app.Name) == 0).Should(BeTrue())
-	})
-})
-
-var _ = Describe("Test statusAggregate", func() {
-	It("the component is Terraform type", func() {
-		var (
-			ctx           = context.TODO()
-			componentName = "sample-oss"
-			ns            = "default"
-			h             = &AppHandler{r: reconciler, app: &v1beta1.Application{
-				TypeMeta:   metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{Namespace: ns},
-			}}
-			appFile = &appfile.Appfile{
-				Workloads: []*appfile.Workload{
-					{
-						Name: componentName,
-						FullTemplate: &appfile.Template{
-							Reference: common.WorkloadTypeDescriptor{
-								Definition: common.WorkloadGVK{APIVersion: "v1", Kind: "A1"},
-							},
-						},
-						CapabilityCategory: velatypes.TerraformCategory,
-					},
-				},
-			}
-		)
-
-		By("aggregate status")
-		statuses, healthy, err := h.aggregateHealthStatus(appFile)
-		Expect(statuses).Should(BeNil())
-		Expect(healthy).Should(Equal(false))
-		Expect(err).Should(HaveOccurred())
-
-		By("create Terraform configuration")
-		configuration := terraformapi.Configuration{
-			TypeMeta:   metav1.TypeMeta{APIVersion: "terraform.core.oam.dev/v1beta1", Kind: "Configuration"},
-			ObjectMeta: metav1.ObjectMeta{Name: componentName, Namespace: ns},
-		}
-		k8sClient.Create(ctx, &configuration)
-
-		By("aggregate status again")
-		statuses, healthy, err = h.aggregateHealthStatus(appFile)
-		Expect(len(statuses)).Should(Equal(1))
-		Expect(healthy).Should(Equal(false))
-		Expect(err).Should(BeNil())
-
-		By("set status for Terraform configuration")
-		var gotConfiguration terraformapi.Configuration
-		k8sClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: componentName}, &gotConfiguration)
-		gotConfiguration.Status.Apply.State = terraformtypes.Available
-		k8sClient.Status().Update(ctx, &gotConfiguration)
-
-		By("aggregate status one more time")
-		statuses, healthy, err = h.aggregateHealthStatus(appFile)
-		Expect(len(statuses)).Should(Equal(1))
-		Expect(healthy).Should(Equal(true))
-		Expect(err).Should(BeNil())
 	})
 })

--- a/test/e2e-addon-test/addon_test.go
+++ b/test/e2e-addon-test/addon_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os/exec"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+)
+
+var _ = Describe("Addon tests", func() {
+	ctx := context.Background()
+	var namespaceName string
+	var ns corev1.Namespace
+	var app v1beta1.Application
+
+	createNamespace := func() {
+		ns = corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+			},
+		}
+		// delete the namespaceName with all its resources
+		Eventually(
+			func() error {
+				return k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))
+			},
+			time.Second*120, time.Millisecond*500).Should(SatisfyAny(BeNil(), &util.NotFoundMatcher{}))
+		By("make sure all the resources are removed")
+		objectKey := client.ObjectKey{
+			Name: namespaceName,
+		}
+		res := &corev1.Namespace{}
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, objectKey, res)
+			},
+			time.Second*120, time.Millisecond*500).Should(&util.NotFoundMatcher{})
+		Eventually(
+			func() error {
+				return k8sClient.Create(ctx, &ns)
+			},
+			time.Second*3, time.Millisecond*300).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+	}
+
+	BeforeEach(func() {
+		By("Start to run a test, clean up previous resources")
+		namespaceName = "app-terraform" + "-" + strconv.FormatInt(rand.Int63(), 16)
+		createNamespace()
+	})
+
+	AfterEach(func() {
+		By("Clean up resources after a test")
+		k8sClient.Delete(ctx, &app)
+		By(fmt.Sprintf("Delete the entire namespaceName %s", ns.Name))
+		// delete the namespaceName with all its resources
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationBackground))).Should(BeNil())
+	})
+
+	It("Addons Terraform is successfully enables and Terraform application works", func() {
+		By("Install Addon Terraform")
+		output, err := exec.Command("bash", "-c", "/tmp/vela addon enable terraform").Output()
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			fmt.Println("exit code error:", string(ee.Stderr))
+		}
+		Expect(err).Should(BeNil())
+		Expect(string(output)).Should(ContainSubstring("Successfully enable addon:"))
+
+		By("Apply an application with Terraform Component")
+		var terraformApp v1beta1.Application
+		Expect(common.ReadYamlToObject("testdata/app/app_terraform_oss.yaml", &terraformApp)).Should(BeNil())
+		terraformApp.Namespace = namespaceName
+		Eventually(func() error {
+			return k8sClient.Create(ctx, terraformApp.DeepCopy())
+		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+		By("Check status.services of the application")
+		Eventually(
+			func() error {
+				k8sClient.Get(ctx, client.ObjectKey{Namespace: terraformApp.Namespace, Name: terraformApp.Name}, &app)
+				if len(app.Status.Services) == 1 {
+					return nil
+				}
+				return errors.New("expect 1 service")
+			},
+			time.Second*30, time.Millisecond*500).ShouldNot(BeNil())
+	})
+})

--- a/test/e2e-addon-test/suite_test.go
+++ b/test/e2e-addon-test/suite_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/oam-dev/kubevela/apis/standard.oam.dev/v1alpha1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	core "github.com/oam-dev/kubevela/apis/core.oam.dev"
+	// +kubebuilder:scaffold:imports
+)
+
+var k8sClient client.Client
+var scheme = runtime.NewScheme()
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Addons Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	By("Bootstrapping test environment")
+	rand.Seed(time.Now().UnixNano())
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+	err := clientgoscheme.AddToScheme(scheme)
+	Expect(err).Should(BeNil())
+	err = core.AddToScheme(scheme)
+	Expect(err).Should(BeNil())
+	err = crdv1.AddToScheme(scheme)
+	Expect(err).Should(BeNil())
+	err = v1alpha1.AddToScheme(scheme)
+	Expect(err).Should(BeNil())
+	By("Setting up kubernetes client")
+	k8sClient, err = client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		logf.Log.Error(err, "failed to create k8sClient")
+		Fail("setup failed")
+	}
+	By("Finished setting up test environment")
+	close(done)
+}, 300)
+
+var _ = AfterSuite(func() {
+	By("Tearing down test environment")
+	// TearDownSuite()
+	By("Finished tearing down test environment")
+})

--- a/test/e2e-addon-test/testdata/app/app_terraform_oss.yaml
+++ b/test/e2e-addon-test/testdata/app/app_terraform_oss.yaml
@@ -1,0 +1,13 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: provision-cloud-resource-sample
+spec:
+  components:
+    - name: sample-oss
+      type: alibaba-oss
+      properties:
+        bucket: vela-website-0911
+        acl: private
+        writeConnectionSecretToRef:
+          name: oss-conn


### PR DESCRIPTION
Function aggregateHealthStatus() in pkg/controller/core.oam.dev/v1alpha2/application/apply.go which is used to retrieve components status, was
abandoned. All unit-tests of it was abandoned too. Fixed it and restore all the unit
tests.


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->