### PR TITLE
Fix: stop installing golangci-lint each time in a CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,16 +284,20 @@ HOSTARCH := amd64
 endif
 
 golangci:
-ifeq (, $(shell which golangci-lint))
+ifneq ($(shell which golangci-lint),)
+	@$(OK) golangci-lint is already installed
+GOLANGCILINT=$(shell which golangci-lint)
+else ifeq (, $(shell which $(GOBIN)/golangci-lint))
 	@{ \
 	set -e ;\
 	echo 'installing golangci-lint-$(GOLANGCILINT_VERSION)' ;\
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) $(GOLANGCILINT_VERSION) ;\
-	echo 'Install succeed' ;\
+	echo 'Successfully installed' ;\
 	}
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
-GOLANGCILINT=$(shell which golangci-lint)
+	@$(OK) golangci-lint is already installed
+GOLANGCILINT=$(GOBIN)/golangci-lint
 endif
 
 .PHONY: staticchecktool


### PR DESCRIPTION
When golangci-lint doesn't locate in $PATH, it will be installed in
$GOBIN every single time.


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->