### PR TITLE
Fix: enable addon with argument and without that

### DIFF
--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -137,7 +137,6 @@ func (s *addonWebService) detailAddon(req *restful.Request, res *restful.Respons
 
 func (s *addonWebService) enableAddon(req *restful.Request, res *restful.Response) {
 	var createReq apis.EnableAddonRequest
-	if req.Request.GetBody != nil {
 		err := req.ReadEntity(&createReq)
 		if err != nil {
 			bcode.ReturnError(req, res, err)
@@ -147,10 +146,9 @@ func (s *addonWebService) enableAddon(req *restful.Request, res *restful.Respons
 			bcode.ReturnError(req, res, err)
 			return
 		}
-	}
 
 	name := req.PathParameter("name")
-	err := s.addonUsecase.EnableAddon(req.Request.Context(), name, createReq)
+	err = s.addonUsecase.EnableAddon(req.Request.Context(), name, createReq)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Test addon rest api", func() {
 
 	})
 
-	PIt("should enable and disable an addon", func() {
+	It("should enable and disable an addon", func() {
 		defer GinkgoRecover()
 		req := apis.EnableAddonRequest{
 			Args: map[string]string{


### PR DESCRIPTION
### Description of your changes

Please hold this PR until things missed(https://github.com/oam-dev/kubevela/pull/2761) when merge apiserver to master in this commit are fixed. And this enable function will be fully tested.

**Enable a addon without argument**
![image](https://user-images.githubusercontent.com/47812250/142978159-b99b1842-8e03-4dc1-b834-a75d9b204715.png)

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->