### PR TITLE
Fix: healthscope support envbinding (namespace)

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -173,7 +173,7 @@ func (h *AppHandler) addServiceStatus(cover bool, svcs ...common.ApplicationComp
 		found := false
 		for i := range h.services {
 			current := h.services[i]
-			if current.Name == svc.Name {
+			if current.Name == svc.Name && current.Env == svc.Env {
 				if cover {
 					h.services[i] = svc
 				}

--- a/pkg/controller/core.oam.dev/v1alpha2/core/scopes/healthscope/healthscope_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/scopes/healthscope/healthscope_controller.go
@@ -422,6 +422,12 @@ func (r *Reconciler) patchHealthStatusToApplications(ctx context.Context, appHea
 		if err := r.client.Get(ctx, client.ObjectKey{Name: appName, Namespace: hs.Namespace}, app); err != nil {
 			return err
 		}
+		if app.Status.Workflow == nil {
+			continue
+		}
+		if !app.Status.Workflow.Finished && !app.Status.Workflow.Suspend {
+			continue
+		}
 		copyApp := app.DeepCopy()
 		componentPosition := make(map[string]int)
 		for i, comp := range app.Spec.Components {


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fix HealthScope to support env-binding over namespace. Old HealthScope only support multi-cluster but not support multi-namespace across clusters. This PR fixes it. It also allows users to use `vela status` to check application status with env-binding and health-scope configured.

`vela status` effect
```bash
$ vela status example-app                                                                        
About:                                                                                    
                                                                                          
  Name:         example-app                                                               
  Namespace:    default                                                                   
  Created at:   2021-11-23 15:41:02 +0800 CST                                                                                                                                        
                                                                                                                                                                                     
Services:                                                                                                                                                                            

  - Name: data-worker  Env: test                                                          
    Type: worker                                                                          
    healthy Ready:1/1                                                                     
    Traits:                                                                                                                                                                          
                                                                                                                                                                                     
  - Name: hello-world-server  Env: staging                                                
    Type: webservice                                                                      
    healthy Ready:3/3                                                                     
    Traits:                                                                               
      - ✅ ingress: Visiting URL: stagesvc.example.com, IP: 47.88.84.192                                                                                                             
  - Name: data-worker  Env: staging                                                       
    Type: worker                                                                          
    healthy Ready:1/1                                                                     
    Traits:                                                                                                                                                                          
                                                                                          
  - Name: hello-world-server  Env: prod                                                   
    Type: webservice                                                                      
    healthy Ready:5/5                                                                                                                                                                
    Traits:                                                                                                                                                                          
      - ✅ ingress: Visiting URL: testsvc.example.com, IP: 47.88.84.192                                                                                                              
  - Name: data-worker  Env: prod                                                          
    Type: worker                                                                          
    healthy Ready:1/1                                                                     
    Traits:                                                                                                                                                                          
             
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->