### PR TITLE
Fix: lookupByScript don't support `import`

### DIFF
--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -354,17 +354,19 @@ func behindKey(file *ast.File, key string) {
 			decls = append(decls, file.Decls[i])
 		}
 	}
+
+	file.Decls = implDecls
 	if len(decls) == 1 {
 		target := decls[0]
 		if embed, ok := target.(*ast.EmbedDecl); ok {
-			file.Decls = append(implDecls, &ast.Field{
+			file.Decls = append(file.Decls, &ast.Field{
 				Label: ast.NewIdent(key),
 				Value: embed.Expr,
 			})
 			return
 		}
 	}
-	file.Decls = append(implDecls, &ast.Field{
+	file.Decls = append(file.Decls, &ast.Field{
 		Label: ast.NewIdent(key),
 		Value: &ast.StructLit{
 			Elts: decls,

--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -207,6 +207,27 @@ func (val *Value) MakeValue(s string) (*Value, error) {
 	return v, nil
 }
 
+func (val *Value) makeValueWithFile(files ...*ast.File) (*Value, error) {
+	builder := &build.Instance{}
+	for _, f := range files {
+		if err := builder.AddSyntax(f); err != nil {
+			return nil, err
+		}
+	}
+	if err := val.addImports(builder); err != nil {
+		return nil, err
+	}
+	inst, err := val.r.Build(builder)
+	if err != nil {
+		return nil, err
+	}
+	v := new(Value)
+	v.r = val.r
+	v.v = inst.Value()
+	v.addImports = val.addImports
+	return v, nil
+}
+
 // FillRaw unify the value with the cue format string x at the given path.
 func (val *Value) FillRaw(x string, paths ...string) error {
 	xInst, err := val.r.Compile("-", x)
@@ -296,16 +317,60 @@ func (val *Value) LookupValue(paths ...string) (*Value, error) {
 func (val *Value) LookupByScript(script string) (*Value, error) {
 	var outputKey = "zz_output__"
 	script = strings.TrimSpace(script)
+	scriptFile, err := parser.ParseFile("-", script)
+	if err != nil {
+		return nil, errors.WithMessage(err, "parse script")
+	}
+
 	raw, err := val.String()
 	if err != nil {
 		return nil, err
 	}
-	raw += fmt.Sprintf("\n%s: %s", outputKey, script)
-	newV, err := val.MakeValue(raw)
+
+	rawFile, err := parser.ParseFile("-", raw)
+	if err != nil {
+		return nil, errors.WithMessage(err, "parse script")
+	}
+
+	behindKey(scriptFile, outputKey)
+
+	newV, err := val.makeValueWithFile(rawFile, scriptFile)
 	if err != nil {
 		return nil, err
 	}
+
 	return newV.LookupValue(outputKey)
+}
+func behindKey(file *ast.File, key string) {
+	var (
+		implDecls []ast.Decl
+		decls     []ast.Decl
+	)
+
+	for i, decl := range file.Decls {
+		if _, ok := decl.(*ast.ImportDecl); ok {
+			implDecls = append(implDecls, file.Decls[i])
+		} else {
+			decls = append(decls, file.Decls[i])
+		}
+	}
+	if len(decls) == 1 {
+		target := decls[0]
+		if embed, ok := target.(*ast.EmbedDecl); ok {
+			file.Decls = append(implDecls, &ast.Field{
+				Label: ast.NewIdent(key),
+				Value: embed.Expr,
+			})
+			return
+		}
+	}
+	file.Decls = append(implDecls, &ast.Field{
+		Label: ast.NewIdent(key),
+		Value: &ast.StructLit{
+			Elts: decls,
+		},
+	})
+
 }
 
 type field struct {

--- a/pkg/cue/model/value/value_test.go
+++ b/pkg/cue/model/value/value_test.go
@@ -612,6 +612,16 @@ apply.workload.name`,
 			expect: `"main"
 `,
 		},
+		{
+			src: `
+apply: arr: ["abc","def"]
+`,
+			script: `
+import "strings"
+strings.Join(apply.arr,".")+"$"`,
+			expect: `"abc.def$"
+`,
+		},
 	}
 
 	for _, tCase := range testCases {
@@ -634,7 +644,7 @@ apply.workload.name`,
    op: 12
 `,
 			script: `op(1`,
-			err:    "expected ')', found 'EOF'",
+			err:    "parse script: expected ')', found 'EOF'",
 		},
 		{
 			src: `


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->