### PR TITLE
Fix: addon with arguments could not be installed

### DIFF
--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -137,7 +137,9 @@ func (s *addonWebService) detailAddon(req *restful.Request, res *restful.Respons
 
 func (s *addonWebService) enableAddon(req *restful.Request, res *restful.Response) {
 	var createReq apis.EnableAddonRequest
-	if req.Request.GetBody != nil {
+	var args []byte
+	_, err := req.Request.Body.Read(args)
+	if err == nil {
 		err := req.ReadEntity(&createReq)
 		if err != nil {
 			bcode.ReturnError(req, res, err)
@@ -150,7 +152,7 @@ func (s *addonWebService) enableAddon(req *restful.Request, res *restful.Respons
 	}
 
 	name := req.PathParameter("name")
-	err := s.addonUsecase.EnableAddon(req.Request.Context(), name, createReq)
+	err = s.addonUsecase.EnableAddon(req.Request.Context(), name, createReq)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return


### PR DESCRIPTION
With the fix #2766 to install addon without arguments, fix the issue of
installing addons with arguments.


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->