### PR TITLE
Fix: arguments map[string]string doesn't support observability's args

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -634,7 +634,7 @@ func Convert2AddonName(name string) string {
 func RenderArgsSecret(addon *types.Addon, args map[string]interface{}) *v1.Secret {
 	data := make(map[string]string)
 	for k, v := range args {
-		switch v:= v.(type) {
+		switch v := v.(type) {
 		case bool:
 			data[k] = strconv.FormatBool(v)
 		default:

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -457,10 +458,7 @@ func cutPathUntil(path []string, end string) ([]string, error) {
 }
 
 // RenderApplication render a K8s application
-func RenderApplication(addon *types.Addon, args map[string]string) (*v1beta1.Application, []*unstructured.Unstructured, error) {
-	if args == nil {
-		args = map[string]string{}
-	}
+func RenderApplication(addon *types.Addon, args map[string]interface{}) (*v1beta1.Application, []*unstructured.Unstructured, error) {
 	app := addon.AppTemplate
 	if app == nil {
 		app = &v1beta1.Application{
@@ -582,7 +580,7 @@ func renderRawComponent(elem types.AddonElementFile) (*common2.ApplicationCompon
 }
 
 // renderCUETemplate will return a component from cue template
-func renderCUETemplate(elem types.AddonElementFile, parameters string, args map[string]string) (*common2.ApplicationComponent, error) {
+func renderCUETemplate(elem types.AddonElementFile, parameters string, args map[string]interface{}) (*common2.ApplicationComponent, error) {
 	bt, err := json.Marshal(args)
 	if err != nil {
 		return nil, err
@@ -633,14 +631,23 @@ func Convert2AddonName(name string) string {
 }
 
 // RenderArgsSecret TODO add desc
-func RenderArgsSecret(addon *types.Addon, args map[string]string) *v1.Secret {
+func RenderArgsSecret(addon *types.Addon, args map[string]interface{}) *v1.Secret {
+	data := make(map[string]string)
+	for k, v := range args {
+		switch v:= v.(type) {
+		case bool:
+			data[k] = strconv.FormatBool(v)
+		default:
+			data[k] = fmt.Sprintf("%v", v)
+		}
+	}
 	sec := v1.Secret{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      Convert2SecName(addon.Name),
 			Namespace: types.DefaultKubeVelaNS,
 		},
-		StringData: args,
+		StringData: data,
 		Type:       v1.SecretTypeOpaque,
 	}
 	return &sec

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -83,7 +83,7 @@ type ListAddonRegistryResponse struct {
 // EnableAddonRequest defines the format for enable addon request
 type EnableAddonRequest struct {
 	// Args is the key-value environment variables, e.g. AK/SK credentials.
-	Args map[string]string `json:"args,omitempty"`
+	Args map[string]interface{} `json:"args,omitempty"`
 }
 
 // ListAddonResponse defines the format for addon list response

--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -137,7 +137,9 @@ func (s *addonWebService) detailAddon(req *restful.Request, res *restful.Respons
 
 func (s *addonWebService) enableAddon(req *restful.Request, res *restful.Response) {
 	var createReq apis.EnableAddonRequest
-	if req.Request.GetBody != nil {
+	var args []byte
+	_, err := req.Request.Body.Read(args)
+	if err == nil {
 		err := req.ReadEntity(&createReq)
 		if err != nil {
 			bcode.ReturnError(req, res, err)
@@ -150,7 +152,7 @@ func (s *addonWebService) enableAddon(req *restful.Request, res *restful.Respons
 	}
 
 	name := req.PathParameter("name")
-	err := s.addonUsecase.EnableAddon(req.Request.Context(), name, createReq)
+	err = s.addonUsecase.EnableAddon(req.Request.Context(), name, createReq)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Test addon rest api", func() {
 	PIt("should enable and disable an addon", func() {
 		defer GinkgoRecover()
 		req := apis.EnableAddonRequest{
-			Args: map[string]string{
+			Args: map[string]interface{}{
 				"example": "test-args",
 			},
 		}


### PR DESCRIPTION
As there are bool typed arguments, the current arguments' type doesn't support them.


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->