### PR TITLE
Fix: the first addon should not be `example`

### DIFF
--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Test addon rest api", func() {
 		Expect(err).Should(BeNil())
 		Expect(lres.Addons).ShouldNot(BeZero())
 		firstAddon := lres.Addons[0]
-		Expect(firstAddon.Name).Should(Equal("example"))
+		Expect(firstAddon.Name).Should(Equal("fluxcd"))
 
 	})
 


### PR DESCRIPTION
As addon example has been removed, the first addon on should not
be `example`


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->