### PR TITLE
Fix: remove .cue suffix from the component name of observability

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -501,6 +501,9 @@ func RenderApplication(addon *types.Addon, args map[string]interface{}) (*v1beta
 		if err != nil {
 			return nil, nil, ErrRenderCueTmpl
 		}
+		if addon.Name == "observability" && strings.HasSuffix(comp.Name, ".cue") {
+			comp.Name = strings.Split(comp.Name, ".cue")[0]
+		}
 		app.Spec.Components = append(app.Spec.Components, *comp)
 	}
 


### PR DESCRIPTION
If the component name has a suffix `.cue`, it will hit issue of not
matching a DNS name


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->