### PR TITLE
Feat: rework resource tracker to solve bugs

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -479,6 +479,11 @@ type ClusterObjectReference struct {
 	corev1.ObjectReference `json:",inline"`
 }
 
+// Equal check if two references are equal
+func (in ClusterObjectReference) Equal(r ClusterObjectReference) bool {
+	return in.APIVersion == r.APIVersion && in.Kind == r.Kind && in.Name == r.Name && in.Namespace == r.Namespace && in.UID == r.UID && in.Creator == r.Creator && in.Cluster == r.Cluster
+}
+
 // RawExtensionPointer is the pointer of raw extension
 type RawExtensionPointer struct {
 	RawExtension *runtime.RawExtension

--- a/apis/core.oam.dev/v1beta1/core_types.go
+++ b/apis/core.oam.dev/v1beta1/core_types.go
@@ -17,7 +17,6 @@
 package v1beta1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -256,33 +255,4 @@ type ScopeDefinitionList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ScopeDefinition `json:"items"`
-}
-
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// An ResourceTracker represents a tracker for track cross namespace resources
-// +kubebuilder:resource:scope=Cluster,categories={oam},shortName=tracker
-type ResourceTracker struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Status ResourceTrackerStatus `json:"status,omitempty"`
-}
-
-// ResourceTrackerStatus define the status of resourceTracker
-type ResourceTrackerStatus struct {
-	TrackedResources []corev1.ObjectReference `json:"trackedResources,omitempty"`
-}
-
-// +kubebuilder:object:root=true
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// ResourceTrackerList contains a list of ResourceTracker
-type ResourceTrackerList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ResourceTracker `json:"items"`
 }

--- a/apis/core.oam.dev/v1beta1/resourcetracker.go
+++ b/apis/core.oam.dev/v1beta1/resourcetracker.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/interfaces"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// An ResourceTracker represents a tracker for track cross namespace resources
+// +kubebuilder:resource:scope=Cluster,categories={oam},shortName=tracker
+type ResourceTracker struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Status ResourceTrackerStatus `json:"status,omitempty"`
+}
+
+// ResourceTrackerStatus define the status of resourceTracker
+type ResourceTrackerStatus struct {
+	TrackedResources []common.ClusterObjectReference `json:"trackedResources,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ResourceTrackerList contains a list of ResourceTracker
+type ResourceTrackerList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ResourceTracker `json:"items"`
+}
+
+// ToOwnerReference convert ResourceTracker into owner reference for other resource to refer
+func (in *ResourceTracker) ToOwnerReference() *metav1.OwnerReference {
+	return &metav1.OwnerReference{
+		APIVersion:         SchemeGroupVersion.String(),
+		Kind:               ResourceTrackerKind,
+		Name:               in.Name,
+		UID:                in.UID,
+		Controller:         pointer.BoolPtr(true),
+		BlockOwnerDeletion: pointer.BoolPtr(true),
+	}
+}
+
+// AddOwnerReferenceToTrackerResource add resourcetracker as owner reference to target object, return true if already exists (outdated)
+func (in *ResourceTracker) AddOwnerReferenceToTrackerResource(rsc interfaces.ObjectOwner) bool {
+	ownerRefs := []metav1.OwnerReference{*in.ToOwnerReference()}
+	exists := false
+	for _, owner := range rsc.GetOwnerReferences() {
+		// delete the old resourceTracker owner
+		if owner.Kind == ResourceTrackerKind && owner.APIVersion == SchemeGroupVersion.String() {
+			exists = true
+			continue
+		}
+		if owner.Controller != nil && *owner.Controller && owner.UID != in.UID {
+			owner.Controller = pointer.BoolPtr(false)
+		}
+		ownerRefs = append(ownerRefs, owner)
+	}
+	rsc.SetOwnerReferences(ownerRefs)
+	return exists
+}
+
+func (in *ResourceTracker) addClusterObjectReference(ref common.ClusterObjectReference) bool {
+	for _, _rsc := range in.Status.TrackedResources {
+		if _rsc.Equal(ref) {
+			return true
+		}
+	}
+	in.Status.TrackedResources = append(in.Status.TrackedResources, ref)
+	return false
+}
+
+// AddTrackedResource add new object reference into tracked resources, return if already exists
+func (in *ResourceTracker) AddTrackedResource(rsc interfaces.TrackableResource) bool {
+	return in.addClusterObjectReference(common.ClusterObjectReference{
+		ObjectReference: v1.ObjectReference{
+			APIVersion: rsc.GetAPIVersion(),
+			Kind:       rsc.GetKind(),
+			Name:       rsc.GetName(),
+			Namespace:  rsc.GetNamespace(),
+			UID:        rsc.GetUID(),
+		},
+	})
+}
+
+// AddTrackedCluster add resourcetracker in remote cluster into tracked resources, return if already exists
+func (in *ResourceTracker) AddTrackedCluster(clusterName string) bool {
+	if clusterName == "" {
+		return true
+	}
+	return in.addClusterObjectReference(common.ClusterObjectReference{
+		Cluster: clusterName,
+		ObjectReference: v1.ObjectReference{
+			APIVersion: SchemeGroupVersion.String(),
+			Kind:       ResourceTrackerKind,
+			Name:       in.GetName(),
+		},
+	})
+}
+
+// GetTrackedClusters return remote clusters recorded in the resource tracker
+func (in *ResourceTracker) GetTrackedClusters() (clusters []string) {
+	for _, ref := range in.Status.TrackedResources {
+		if ref.APIVersion == SchemeGroupVersion.String() && ref.Kind == ResourceTrackerKind && ref.Name == in.Name && ref.Cluster != "" {
+			clusters = append(clusters, ref.Cluster)
+		}
+	}
+	return
+}
+
+// IsLifeLong check if resourcetracker shares the same whole life with the entire application
+func (in *ResourceTracker) IsLifeLong() bool {
+	_, ok := in.GetAnnotations()[oam.AnnotationResourceTrackerLifeLong]
+	return ok
+}
+
+// SetLifeLong set life long to resource tracker
+func (in *ResourceTracker) SetLifeLong() {
+	in.SetAnnotations(map[string]string{oam.AnnotationResourceTrackerLifeLong: "true"})
+}

--- a/apis/core.oam.dev/v1beta1/zz_generated.deepcopy.go
+++ b/apis/core.oam.dev/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -1040,7 +1039,7 @@ func (in *ResourceTrackerStatus) DeepCopyInto(out *ResourceTrackerStatus) {
 	*out = *in
 	if in.TrackedResources != nil {
 		in, out := &in.TrackedResources, &out.TrackedResources
-		*out = make([]corev1.ObjectReference, len(*in))
+		*out = make([]common.ClusterObjectReference, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/apis/interfaces/resourcetracker.go
+++ b/apis/interfaces/resourcetracker.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interfaces
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ObjectOwner is the interface for get and set ownerReference
+type ObjectOwner interface {
+	GetOwnerReferences() []metav1.OwnerReference
+	SetOwnerReferences([]metav1.OwnerReference)
+}
+
+// TrackableResource is the interface for resources to be tracked by resourcetracker
+type TrackableResource interface {
+	client.Object
+	metav1.Type
+	ObjectOwner
+}

--- a/charts/vela-core/crds/core.oam.dev_resourcetrackers.yaml
+++ b/charts/vela-core/crds/core.oam.dev_resourcetrackers.yaml
@@ -42,34 +42,16 @@ spec:
             properties:
               trackedResources:
                 items:
-                  description: 'ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs.  1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage.  2.
-                    Invalid usage help.  It is impossible to add specific help for
-                    individual usage.  In most embedded usages, there are particular     restrictions
-                    like, "must refer only to types A and B" or "UID not honored"
-                    or "name must be restricted".     Those cannot be well described
-                    when embedded.  3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen.  4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity     during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple     and the version of the actual
-                    struct is irrelevant.  5. We cannot easily change it.  Because
-                    this type is embedded in many locations, updates to this type     will
-                    affect numerous schemas.  Don''t make new APIs embed an underspecified
-                    API type they do not control. Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    .'
+                  description: ClusterObjectReference defines the object reference
+                    with cluster.
                   properties:
                     apiVersion:
                       description: API version of the referent.
+                      type: string
+                    cluster:
+                      type: string
+                    creator:
+                      description: ResourceCreatorRole defines the resource creator.
                       type: string
                     fieldPath:
                       description: 'If referring to a piece of an object instead of

--- a/charts/vela-minimal/crds/core.oam.dev_resourcetrackers.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_resourcetrackers.yaml
@@ -42,34 +42,16 @@ spec:
             properties:
               trackedResources:
                 items:
-                  description: 'ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs.  1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage.  2.
-                    Invalid usage help.  It is impossible to add specific help for
-                    individual usage.  In most embedded usages, there are particular     restrictions
-                    like, "must refer only to types A and B" or "UID not honored"
-                    or "name must be restricted".     Those cannot be well described
-                    when embedded.  3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen.  4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity     during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple     and the version of the actual
-                    struct is irrelevant.  5. We cannot easily change it.  Because
-                    this type is embedded in many locations, updates to this type     will
-                    affect numerous schemas.  Don''t make new APIs embed an underspecified
-                    API type they do not control. Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    .'
+                  description: ClusterObjectReference defines the object reference
+                    with cluster.
                   properties:
                     apiVersion:
                       description: API version of the referent.
+                      type: string
+                    cluster:
+                      type: string
+                    creator:
+                      description: ResourceCreatorRole defines the resource creator.
                       type: string
                     fieldPath:
                       description: 'If referring to a piece of an object instead of

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_resourcetrackers.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_resourcetrackers.yaml
@@ -42,34 +42,16 @@ spec:
             properties:
               trackedResources:
                 items:
-                  description: 'ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs.  1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage.  2.
-                    Invalid usage help.  It is impossible to add specific help for
-                    individual usage.  In most embedded usages, there are particular     restrictions
-                    like, "must refer only to types A and B" or "UID not honored"
-                    or "name must be restricted".     Those cannot be well described
-                    when embedded.  3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen.  4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity     during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple     and the version of the actual
-                    struct is irrelevant.  5. We cannot easily change it.  Because
-                    this type is embedded in many locations, updates to this type     will
-                    affect numerous schemas.  Don''t make new APIs embed an underspecified
-                    API type they do not control. Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    .'
+                  description: ClusterObjectReference defines the object reference
+                    with cluster.
                   properties:
                     apiVersion:
                       description: API version of the referent.
+                      type: string
+                    cluster:
+                      type: string
+                    creator:
+                      description: ResourceCreatorRole defines the resource creator.
                       type: string
                     fieldPath:
                       description: 'If referring to a piece of an object instead of

--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/gc_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/gc_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 )
 
@@ -33,31 +34,39 @@ func TestIsTrackedResources(t *testing.T) {
 	}{{
 		oldRT: &v1beta1.ResourceTracker{
 			Status: v1beta1.ResourceTrackerStatus{
-				TrackedResources: []corev1.ObjectReference{{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
-					Name:       "test",
-					Namespace:  "default",
+				TrackedResources: []common.ClusterObjectReference{{
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}, {
-					Kind:       "Pod",
-					APIVersion: "v1",
-					Name:       "test",
-					Namespace:  "default",
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Pod",
+						APIVersion: "v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}},
 			},
 		},
 		newRT: &v1beta1.ResourceTracker{
 			Status: v1beta1.ResourceTrackerStatus{
-				TrackedResources: []corev1.ObjectReference{{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
-					Name:       "test",
-					Namespace:  "default",
+				TrackedResources: []common.ClusterObjectReference{{
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}, {
-					Kind:       "Pod",
-					APIVersion: "v1",
-					Name:       "test",
-					Namespace:  "default",
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Pod",
+						APIVersion: "v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}},
 			},
 		},
@@ -65,31 +74,39 @@ func TestIsTrackedResources(t *testing.T) {
 	}, {
 		oldRT: &v1beta1.ResourceTracker{
 			Status: v1beta1.ResourceTrackerStatus{
-				TrackedResources: []corev1.ObjectReference{{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
-					Name:       "test",
-					Namespace:  "default",
+				TrackedResources: []common.ClusterObjectReference{{
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}, {
-					Kind:       "Pod",
-					APIVersion: "v1",
-					Name:       "hello",
-					Namespace:  "default",
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Pod",
+						APIVersion: "v1",
+						Name:       "hello",
+						Namespace:  "default",
+					},
 				}},
 			},
 		},
 		newRT: &v1beta1.ResourceTracker{
 			Status: v1beta1.ResourceTrackerStatus{
-				TrackedResources: []corev1.ObjectReference{{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
-					Name:       "test",
-					Namespace:  "default",
+				TrackedResources: []common.ClusterObjectReference{{
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}, {
-					Kind:       "Pod",
-					APIVersion: "v1",
-					Name:       "test",
-					Namespace:  "default",
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Pod",
+						APIVersion: "v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}},
 			},
 		},
@@ -98,16 +115,20 @@ func TestIsTrackedResources(t *testing.T) {
 		oldRT: &v1beta1.ResourceTracker{},
 		newRT: &v1beta1.ResourceTracker{
 			Status: v1beta1.ResourceTrackerStatus{
-				TrackedResources: []corev1.ObjectReference{{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
-					Name:       "test",
-					Namespace:  "default",
+				TrackedResources: []common.ClusterObjectReference{{
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}, {
-					Kind:       "Pod",
-					APIVersion: "v1",
-					Name:       "test",
-					Namespace:  "default",
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Pod",
+						APIVersion: "v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}},
 			},
 		},
@@ -115,16 +136,20 @@ func TestIsTrackedResources(t *testing.T) {
 	}, {
 		oldRT: &v1beta1.ResourceTracker{
 			Status: v1beta1.ResourceTrackerStatus{
-				TrackedResources: []corev1.ObjectReference{{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
-					Name:       "test",
-					Namespace:  "default",
+				TrackedResources: []common.ClusterObjectReference{{
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}, {
-					Kind:       "Pod",
-					APIVersion: "v1",
-					Name:       "test",
-					Namespace:  "default",
+					ObjectReference: corev1.ObjectReference{
+						Kind:       "Pod",
+						APIVersion: "v1",
+						Name:       "test",
+						Namespace:  "default",
+					},
 				}},
 			},
 		},

--- a/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler.go
+++ b/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -317,14 +316,7 @@ func (h *handler) recordWorkloadInResourceTracker(ctx context.Context, workload 
 		klog.Errorf("fail to get resourceTracker to record workload rollout: namespace:%s, name: %s", h.rollout.Namespace, h.rollout.Name)
 		return err
 	}
-	recordedWorkload := corev1.ObjectReference{
-		APIVersion: workload.GetAPIVersion(),
-		Kind:       workload.GetKind(),
-		UID:        workload.GetUID(),
-		Namespace:  workload.GetNamespace(),
-		Name:       workload.GetName(),
-	}
-	rt.Status.TrackedResources = append(rt.Status.TrackedResources, recordedWorkload)
+	rt.AddTrackedResource(workload)
 	if err := h.Status().Update(ctx, &rt); err != nil {
 		klog.Errorf("fail to update resourceTracker for rollout record workload namespace:%s, name: %s", h.rollout.Namespace, h.rollout.Name)
 		return err

--- a/pkg/resourcetracker/resourcetracker.go
+++ b/pkg/resourcetracker/resourcetracker.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcetracker
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+// GetApplicationRootResourceTracker get root resourcetracker for application
+// root resourcetracker if a life-long resourcetracker which shares the life-cycle with the application instead of one revision
+func GetApplicationRootResourceTracker(ctx context.Context, c client.Client, app *v1beta1.Application) (*v1beta1.ResourceTracker, error) {
+	rt := &v1beta1.ResourceTracker{}
+	rtName := app.Name + "-" + app.Namespace
+	if err := c.Get(ctx, types.NamespacedName{Name: rtName}, rt); err != nil {
+		return nil, err
+	}
+	return rt, nil
+}
+
+// CreateOrGetApplicationRootResourceTracker create or get root resourcetracker for application
+// root resourcetracker if a life-long resourcetracker which shares the life-cycle with the application instead of one revision
+func CreateOrGetApplicationRootResourceTracker(ctx context.Context, c client.Client, app *v1beta1.Application) (*v1beta1.ResourceTracker, error) {
+	rt, err := GetApplicationRootResourceTracker(ctx, c, app)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
+		rt = &v1beta1.ResourceTracker{}
+		rtName := app.Name + "-" + app.Namespace
+		rt.SetName(rtName)
+		rt.SetLabels(map[string]string{
+			oam.LabelAppName:      app.Name,
+			oam.LabelAppNamespace: app.Namespace,
+		})
+		rt.SetLifeLong()
+		if err = c.Create(ctx, rt); err != nil {
+			return nil, err
+		}
+	}
+	return rt, nil
+}

--- a/pkg/utils/apply/apply.go
+++ b/pkg/utils/apply/apply.go
@@ -18,7 +18,10 @@ package apply
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/controller/utils"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 
@@ -270,6 +273,37 @@ func MustBeControllableByAny(ctrlUIDs []types.UID) ApplyOption {
 			}
 		}
 		return errors.Errorf("existing object is not controlled by any of UID %q", ctrlUIDs)
+	}
+}
+
+// MustBeControlledByApp requires that the new object is controllable by versioned resourcetracker
+func MustBeControlledByApp(app *v1beta1.Application) ApplyOption {
+	pattern := "^" + app.GetName() + "-v[0-9]+-" + app.GetNamespace() + "$"
+	return func(_ *applyAction, existing, _ client.Object) error {
+		if existing == nil {
+			return nil
+		}
+		existingObjMeta, _ := existing.(metav1.Object)
+		c := metav1.GetControllerOf(existingObjMeta)
+		if c == nil {
+			return nil
+		}
+
+		// NOTE This is for backward compatibility after ApplicationContext is deprecated.
+		// In legacy clusters, existing resources are ctrl-owned by ApplicationContext or ResourceTracker (only for
+		// cx-namespace and cluster-scope resources).  We use a particular annotation to identify legacy resources.
+		if len(existingObjMeta.GetAnnotations()[oam.AnnotationKubeVelaVersion]) == 0 {
+			// just skip checking UIDs, '3-way-merge' will remove the legacy ctrl-owner automatically
+			return nil
+		}
+
+		if !(c.APIVersion == v1beta1.SchemeGroupVersion.String()) || !(c.Kind == v1beta1.ResourceTrackerKind) {
+			return fmt.Errorf("existing object is not controlled by resourcetracker, currently controlled by %s[%s]", c.Kind, c.APIVersion)
+		}
+		if !regexp.MustCompile(pattern).MatchString(c.Name) {
+			return fmt.Errorf("existing object is controlled by resourcetracker %s which does not conform to pattern %s", c.Name, pattern)
+		}
+		return nil
 	}
 }
 

--- a/pkg/workflow/providers/multicluster/multicluster.go
+++ b/pkg/workflow/providers/multicluster/multicluster.go
@@ -115,6 +115,9 @@ func (p *provider) MakePlacementDecisions(ctx wfContext.Context, v *value.Value,
 	if err = envbinding.WritePlacementDecisions(p.app, policy, env, decisions); err != nil {
 		return err
 	}
+	if err = envbinding.WriteClustersToResourceTracker(context.Background(), p.Client, p.app, clusterName); err != nil {
+		return err
+	}
 	return v.FillObject(map[string]interface{}{"decisions": decisions}, "outputs")
 }
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fix two problems:
1. Runtime Cluster Root ResourceTracker recorded in Management Cluster Root ResourceTracker, so that runtime-cluster GC can work without application status.
2. OwnerReference not must be controlled by UID, but filter by label name. So that outdated resource can be correctly recycled even when its outdated Resourcetracker has gone. #2767

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

This PR will help rework RT to support life-long/versioned resource & customized GC policy in the future.