### PR TITLE
Fix: add lock to avoid addon concurrency read error

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -112,7 +112,7 @@ type asyncReader struct {
 	h       *gitHelper
 	item    *github.RepositoryContent
 	errChan chan error
-	//mutex is needed when append to addon's Definitions/CUETemplate/YAMLTemplate slices
+	// mutex is needed when append to addon's Definitions/CUETemplate/YAMLTemplate slices
 	mutex *sync.Mutex
 }
 


### PR DESCRIPTION
### Description of your changes

Now addon's async read may cause concurrent error because slice in go is not safe in concurrency.
Fix this.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->