### PR TITLE
Feat: support parse addon argument to optional field

### DIFF
--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -118,8 +118,8 @@ type Parameter struct {
 type NestedParameter struct {
 	Parameter
 	SubParam []NestedParameter
-
 }
+
 // SetFlagBy set cli flag from Parameter
 func SetFlagBy(flags *pflag.FlagSet, v Parameter) {
 	name := v.Name

--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -112,6 +112,14 @@ type Parameter struct {
 	JSONType string      `json:"jsonType,omitempty"`
 }
 
+// NestedParameter is more real Parameter. It can contains name and a list
+// of sub-parameter. If subParam is set. other filed in Parameter will be ignored
+// except for Parameter.Name and Parameter.Required
+type NestedParameter struct {
+	Parameter
+	SubParam []NestedParameter
+
+}
 // SetFlagBy set cli flag from Parameter
 func SetFlagBy(flags *pflag.FlagSet, v Parameter) {
 	name := v.Name

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -20,8 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	cue2 "github.com/oam-dev/kubevela/pkg/cue"
-	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/pkg/apiserver/log"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -45,11 +44,13 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/apis/types"
 	utils2 "github.com/oam-dev/kubevela/pkg/controller/utils"
+	cue2 "github.com/oam-dev/kubevela/pkg/cue"
 	cuemodel "github.com/oam-dev/kubevela/pkg/cue/model"
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
 )
 
 const (
@@ -436,7 +437,7 @@ func genAddonAPISchema(addonRes *types.Addon) error {
 	}
 	schema, err := common.GenOpenAPIFromParameters(nestedParams)
 	if err != nil {
-		return errors.Wrap(err,"generate OpenAPI schema fail")
+		return errors.Wrap(err, "generate OpenAPI schema fail")
 	}
 	addonRes.APISchema = schema
 	return nil
@@ -493,6 +494,7 @@ func RenderApplication(addon *types.Addon, args map[string]interface{}) (*v1beta
 	for _, tmpl := range addon.CUETemplates {
 		comp, err := renderCUETemplate(tmpl, addon.Parameters, args)
 		if err != nil {
+			log.Logger.Errorf("fail to render cue template, %v",err)
 			return nil, nil, ErrRenderCueTmpl
 		}
 		app.Spec.Components = append(app.Spec.Components, *comp)

--- a/pkg/apiserver/rest/rest_server.go
+++ b/pkg/apiserver/rest/rest_server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
@@ -136,7 +137,7 @@ func (s *restServer) setupLeaderElection() (*leaderelection.LeaderElectionConfig
 			},
 			OnStoppedLeading: func() {
 				klog.Infof("leader lost: %s", s.cfg.LeaderConfig.ID)
-				//os.Exit(0)
+				os.Exit(0)
 			},
 			OnNewLeader: func(identity string) {
 				if identity == s.cfg.LeaderConfig.ID {

--- a/pkg/apiserver/rest/rest_server.go
+++ b/pkg/apiserver/rest/rest_server.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
@@ -137,7 +136,7 @@ func (s *restServer) setupLeaderElection() (*leaderelection.LeaderElectionConfig
 			},
 			OnStoppedLeading: func() {
 				klog.Infof("leader lost: %s", s.cfg.LeaderConfig.ID)
-				os.Exit(0)
+				//os.Exit(0)
 			},
 			OnNewLeader: func(identity string) {
 				if identity == s.cfg.LeaderConfig.ID {

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -359,6 +359,7 @@ func (u *addonUsecaseImpl) EnableAddon(ctx context.Context, name string, args ap
 		}
 
 		app, defs, err := pkgaddon.RenderApplication(addon, args.Args)
+		log.Logger.Errorf("render application fail: %v",err)
 		if err != nil {
 			return bcode.ErrAddonRender
 		}

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -535,6 +535,28 @@ func GenerateOpenAPISchemaFromDefinition(definitionName, cueTemplate string) ([]
 	return generateOpenAPISchemaFromCapabilityParameter(capability, nil)
 }
 
+// PrepareParam is a copy of PrepareParameterCue, for ast parse
+func PrepareParam(capabilityName, capabilityTemplate string)(string,error){
+	var template string
+	var withParameterFlag bool
+	r := regexp.MustCompile(`[[:space:]]*parameter:[[:space:]]*`)
+	trimRe := regexp.MustCompile(`\s+`)
+
+	for _, text := range strings.Split(capabilityTemplate, "\n") {
+		if r.MatchString(text) {
+			// a variable has to be refined as a definition which starts with "#"
+			// text may be start with space or tab, we should clean up text
+			text = fmt.Sprintf("%s", trimRe.ReplaceAllString(text, ""))
+			withParameterFlag = true
+		}
+		template += fmt.Sprintf("%s\n", text)
+	}
+
+	if !withParameterFlag {
+		return "", ErrNoSectionParameterInCue{capName: capabilityName}
+	}
+	return template, nil
+}
 // PrepareParameterCue cuts `parameter` section form definition .cue file
 func PrepareParameterCue(capabilityName, capabilityTemplate string) (string, error) {
 	var template string

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -536,7 +536,7 @@ func GenerateOpenAPISchemaFromDefinition(definitionName, cueTemplate string) ([]
 }
 
 // PrepareParam is a copy of PrepareParameterCue, for ast parse
-func PrepareParam(capabilityName, capabilityTemplate string)(string,error){
+func PrepareParam(capabilityName, capabilityTemplate string) (string, error) {
 	var template string
 	var withParameterFlag bool
 	r := regexp.MustCompile(`[[:space:]]*parameter:[[:space:]]*`)
@@ -546,7 +546,7 @@ func PrepareParam(capabilityName, capabilityTemplate string)(string,error){
 		if r.MatchString(text) {
 			// a variable has to be refined as a definition which starts with "#"
 			// text may be start with space or tab, we should clean up text
-			text = fmt.Sprintf("%s", trimRe.ReplaceAllString(text, ""))
+			text = trimRe.ReplaceAllString(text, "")
 			withParameterFlag = true
 		}
 		template += fmt.Sprintf("%s\n", text)
@@ -557,6 +557,7 @@ func PrepareParam(capabilityName, capabilityTemplate string)(string,error){
 	}
 	return template, nil
 }
+
 // PrepareParameterCue cuts `parameter` section form definition .cue file
 func PrepareParameterCue(capabilityName, capabilityTemplate string) (string, error) {
 	var template string

--- a/pkg/cue/convert.go
+++ b/pkg/cue/convert.go
@@ -19,9 +19,11 @@ package cue
 import (
 	"errors"
 	"fmt"
-	"github.com/oam-dev/kubevela/pkg/cue/model/sets"
-	errors2 "github.com/pkg/errors"
 	"strings"
+
+	errors2 "github.com/pkg/errors"
+
+	"github.com/oam-dev/kubevela/pkg/cue/model/sets"
 
 	"cuelang.org/go/cue"
 

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -22,13 +22,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/oam-dev/kubevela/apis/types"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/oam-dev/kubevela/apis/types"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/ast"

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -166,27 +166,17 @@ func GetCUEParameterValue(cueStr string) (cue.Value, error) {
 }
 
 func genSchemaFromParameter(title string, p types.NestedParameter) (*openapi3.Schema, error) {
+	if p.SubParam != nil {
+		return genSchemaFromParameters(p.Name, p.SubParam)
+	}
 	paramSchema := openapi3.NewSchema()
 	paramSchema.Title = title
-	if p.SubParam != nil {
-		paramSchema.Type = "object"
-		props := map[string]*openapi3.Schema{}
-		for _, sub := range p.SubParam {
-			subSchema, err := genSchemaFromParameter(sub.Name, sub)
-			if err != nil {
-				return nil, err
-			}
-			props[sub.Name] = subSchema
-		}
-		paramSchema.WithProperties(props)
-	} else {
-		paramSchema.Type = p.JSONType
-		paramSchema.Default = p.Default
-	}
+	paramSchema.Type = p.JSONType
+	paramSchema.Default = p.Default
 	return paramSchema, nil
 }
 
-func genOpenAPIFromParameters(title string, parameters []types.NestedParameter) (*openapi3.Schema, error) {
+func genSchemaFromParameters(title string, parameters []types.NestedParameter) (*openapi3.Schema, error) {
 	paramSchema := openapi3.NewObjectSchema()
 	paramSchema.Title = title
 	requiredProps := make([]string, 0)
@@ -202,14 +192,13 @@ func genOpenAPIFromParameters(title string, parameters []types.NestedParameter) 
 		}
 	}
 	paramSchema.Required = requiredProps
-	fmt.Println(requiredProps)
 	paramSchema.WithProperties(props)
 	return paramSchema, nil
 }
 
 // GenOpenAPIFromParameters will help generate openAPI schema from types.NestedParameter array
 func GenOpenAPIFromParameters(parameters []types.NestedParameter) (*openapi3.Schema, error) {
-	paramSchema, err := genOpenAPIFromParameters("", parameters)
+	paramSchema, err := genSchemaFromParameters("", parameters)
 	if err != nil {
 		return nil, err
 	}

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -562,7 +562,7 @@ func (ref *ParseReference) parseParameters(paraValue cue.Value, paramKey string,
 			if def, ok := val.Default(); ok && def.IsConcrete() {
 				param.Default = velacue.GetDefault(def)
 			}
-			param.Short, param.Usage, param.Alias, param.Ignore = velacue.RetrieveComments(val)
+			param.Short, param.Usage, param.Alias, param.Ignore, param.Required = velacue.RetrieveComments(val)
 			param.Type = val.IncompleteKind()
 			switch val.IncompleteKind() {
 			case cue.StructKind:


### PR DESCRIPTION
### Description of your changes

**Problem**
Now, our parameters in cue file is parsed to openAPI schema by "cuelang.org/go/encoding/openapi". The problem is this package parse all parameter to required field value. And it's hard to be extended.

Also, X-definitions' schema (stored in ConfigMap now) are generated in that way.
 
**How this is solved**
Introduce struct `NestedParameter` to simulate cue struct and convert a group of `NestedParameter` to `openapi.schema`
Now we can easily extend the `NestedParameter` and its conversion to `openapi.schema`

This PR show how to introduce a `+optional` to parameter field in CUE.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.


### How has this code been tested

- [ ] Add test for parse process.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->