### PR TITLE
Fix: addon name should not add prefix `resources`

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -606,7 +606,7 @@ func renderCUETemplate(elem types.AddonElementFile, parameters string, args map[
 		return nil, err
 	}
 	comp := common2.ApplicationComponent{
-		Name: strings.Join(append(elem.Path, elem.Name), "-"),
+		Name: elem.Name,
 	}
 	err = yaml.Unmarshal(b, &comp)
 	if err != nil {

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -568,7 +568,7 @@ func renderNamespace(namespace string) *unstructured.Unstructured {
 func renderRawComponent(elem types.AddonElementFile) (*common2.ApplicationComponent, error) {
 	baseRawComponent := common2.ApplicationComponent{
 		Type: "raw",
-		Name: strings.Join(append(elem.Path, elem.Name), "-"),
+		Name: elem.Name,
 	}
 	obj, err := renderObject(elem)
 	if err != nil {


### PR DESCRIPTION
- Adding prefix `resources will hit issues as:
'unable to parse requirement: invalid label value:
"resources-prometheus-server-register-grafana-datasource-5576f7f6b4":
      at key: "controller.oam.dev/component": must be no more than 63 characters'
- This won't avoid the name confliction with other components


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->