### PR TITLE
Feat: add ui container and api/ui options in helm chart

### DIFF
--- a/charts/vela-core/templates/_helpers.tpl
+++ b/charts/vela-core/templates/_helpers.tpl
@@ -51,9 +51,9 @@ app.kubernetes.io/name: {{ include "kubevela.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-{{- define "kubevela-apiserver.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "kubevela.name" . }}-apiserver
-app.kubernetes.io/instance: {{ .Release.Name }}-apiserver
+{{- define "kubevela-ux.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubevela.name" . }}-ux
+app.kubernetes.io/instance: {{ .Release.Name }}-ux
 {{- end -}}
 
 {{- define "kubevela-cluster-gateway.selectorLabels" -}}

--- a/charts/vela-core/templates/kubevela-apiserver.yaml
+++ b/charts/vela-core/templates/kubevela-apiserver.yaml
@@ -33,7 +33,7 @@ spec:
             - containerPort: 8000
         {{- end }}
         {{- if .Values.velaux.uiServer }}
-        - name: {{ include "kubevela.fullname" . }}-api
+        - name: {{ include "kubevela.fullname" . }}-ui
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.imageRegistry }}{{ .Values.velaux.uiServer.image }}

--- a/charts/vela-core/templates/kubevela-apiserver.yaml
+++ b/charts/vela-core/templates/kubevela-apiserver.yaml
@@ -1,53 +1,57 @@
-{{- if .Values.apiServer.enabled -}}
+{{- if .Values.velaux -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kubevela.fullname" . }}-apiserver
+  name: {{ include "kubevela.fullname" . }}-ux
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "kubevela.labels" . | nindent 4 }}
+    {{- include "kubevela.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.apiServer.replicaCount }}
+  replicas: {{ .replicaCount }}
   selector:
     matchLabels:
-  {{- include "kubevela-apiserver.selectorLabels" . | nindent 6 }}
+      {{- include "kubevela-ux.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-    {{- include "kubevela-apiserver.selectorLabels" . | nindent 8 }}
+        {{- include "kubevela-ux.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kubevela.serviceAccountName" . }}
       securityContext:
-      {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "kubevela.fullname" . }}-apiserver
+        {{- if .Values.velaux.apiServer }}
+        - name: {{ include "kubevela.fullname" . }}-api
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-          args:
-            - "apiserver"
-            - "--port={{ .Values.apiServer.port }}"
-          image: {{ .Values.imageRegistry }}{{ .Values.apiserverImage.repository }}:{{ .Values.apiserverImage.tag }}
-          imagePullPolicy: {{ quote .Values.apiserverImage.pullPolicy }}
-          resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          image: {{ .Values.imageRegistry }}{{ .Values.velaux.apiServer.image }}
           ports:
-            - containerPort: {{ .Values.apiServer.port }}
+            - containerPort: 8000
+        {{- end }}
+        {{- if .Values.velaux.uiServer }}
+        - name: {{ include "kubevela.fullname" . }}-api
+          securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ .Values.imageRegistry }}{{ .Values.velaux.uiServer.image }}
+          ports:
+            - containerPort: 80
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-  {{- toYaml . | nindent 8 }}
-  {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -55,14 +59,16 @@ metadata:
   name: {{ include "kubevela.fullname" . }}-apiserver
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "kubevela.labels" . | nindent 4 }}
+    {{- include "kubevela.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.apiServer.Service.type }}
+  type: {{ .Values.velaux.service.type }}
   ports:
     - port: 80
-      targetPort: {{ .Values.apiServer.port }}
+      {{- with .Values.velaux.service.nodePort }}
+      nodePort: {{- . }}
+      {{- end}}
+      targetPort: 80
       protocol: TCP
-      name: http
   selector:
-  {{- include "kubevela-apiserver.selectorLabels" . | nindent 6 }}
+    {{- include "kubevela-ux.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/vela-core/templates/kubevela-apiserver.yaml
+++ b/charts/vela-core/templates/kubevela-apiserver.yaml
@@ -65,7 +65,7 @@ spec:
   ports:
     - port: 80
       {{- with .Values.velaux.service.nodePort }}
-      nodePort: {{- . }}
+      nodePort: {{ . }}
       {{- end}}
       targetPort: 80
       protocol: TCP

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -13,10 +13,6 @@ image:
   repository: oamdev/vela-core
   tag: latest
   pullPolicy: Always
-apiserverImage:
-  repository: oamdev/vela-apiserver
-  tag: v1.1.2
-  pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: ""
@@ -110,12 +106,18 @@ dependCheckWait: 30s
 # OAMSpecVer is the oam spec version controller want to setup
 OAMSpecVer: "v0.3"
 
-apiServer:
-  enabled: true
-  port: 8000
+
+velaux:
   replicaCount: 1
-  Service:
-    type: ClusterIP
+  apiServer:
+    image: oamdev/vela-apiserver:v1.1.2
+    Service:
+      type: ClusterIP
+  uiServer:
+    image: barnett/kubevela:velaux.11241
+  service:
+    type: NodePort
+    nodePort: 32465
 
 multicluster:
   enabled: false

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -115,7 +115,7 @@ velaux:
     Service:
       type: ClusterIP
   uiServer:
-    image: barnett/kubevela:velaux.11241
+    image: oamdev/velaux
   service:
     type: NodePort
     nodePort: 32465

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -110,7 +110,8 @@ OAMSpecVer: "v0.3"
 velaux:
   replicaCount: 1
   apiServer:
-    image: oamdev/vela-apiserver:v1.1.2
+    image: oamdev/vela-apiserver 
+
     Service:
       type: ClusterIP
   uiServer:

--- a/charts/vela-minimal/templates/_helpers.tpl
+++ b/charts/vela-minimal/templates/_helpers.tpl
@@ -51,9 +51,9 @@ app.kubernetes.io/name: {{ include "kubevela.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-{{- define "kubevela-apiserver.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "kubevela.name" . }}-apiserver
-app.kubernetes.io/instance: {{ .Release.Name }}-apiserver
+{{- define "kubevela-ux.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubevela.name" . }}-ux
+app.kubernetes.io/instance: {{ .Release.Name }}-ux
 {{- end -}}
 
 {{- define "kubevela-cluster-gateway.selectorLabels" -}}

--- a/charts/vela-minimal/templates/kubevela-apiserver.yaml
+++ b/charts/vela-minimal/templates/kubevela-apiserver.yaml
@@ -10,11 +10,11 @@ spec:
   replicas: {{ .Values.apiServer.replicaCount }}
   selector:
     matchLabels:
-  {{- include "kubevela-apiserver.selectorLabels" . | nindent 6 }}
+  {{- include "kubevela-ux.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-    {{- include "kubevela-apiserver.selectorLabels" . | nindent 8 }}
+    {{- include "kubevela-ux.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -64,5 +64,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-  {{- include "kubevela-apiserver.selectorLabels" . | nindent 6 }}
+  {{- include "kubevela-ux.selectorLabels" . | nindent 6 }}
 {{- end -}}

--- a/charts/vela-minimal/templates/kubevela-apiserver.yaml
+++ b/charts/vela-minimal/templates/kubevela-apiserver.yaml
@@ -33,7 +33,7 @@ spec:
             - containerPort: 8000
         {{- end }}
         {{- if .Values.velaux.uiServer }}
-        - name: {{ include "kubevela.fullname" . }}-api
+        - name: {{ include "kubevela.fullname" . }}-ui
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.imageRegistry }}{{ .Values.velaux.uiServer.image }}

--- a/charts/vela-minimal/templates/kubevela-apiserver.yaml
+++ b/charts/vela-minimal/templates/kubevela-apiserver.yaml
@@ -1,53 +1,57 @@
-{{- if .Values.apiServer.enabled -}}
+{{- if .Values.velaux -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kubevela.fullname" . }}-apiserver
+  name: {{ include "kubevela.fullname" . }}-ux
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "kubevela.labels" . | nindent 4 }}
+    {{- include "kubevela.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.apiServer.replicaCount }}
+  replicas: {{ .replicaCount }}
   selector:
     matchLabels:
-  {{- include "kubevela-ux.selectorLabels" . | nindent 6 }}
+      {{- include "kubevela-ux.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-    {{- include "kubevela-ux.selectorLabels" . | nindent 8 }}
+        {{- include "kubevela-ux.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kubevela.serviceAccountName" . }}
       securityContext:
-      {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "kubevela.fullname" . }}-apiserver
+        {{- if .Values.velaux.apiServer }}
+        - name: {{ include "kubevela.fullname" . }}-api
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-          args:
-            - "apiserver"
-            - "--bind-addr=0.0.0.0:{{ .Values.apiServer.port }}"
-          image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
-          imagePullPolicy: {{ quote .Values.image.pullPolicy }}
-          resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          image: {{ .Values.imageRegistry }}{{ .Values.velaux.apiServer.image }}
           ports:
-            - containerPort: {{ .Values.apiServer.port }}
+            - containerPort: 8000
+        {{- end }}
+        {{- if .Values.velaux.uiServer }}
+        - name: {{ include "kubevela.fullname" . }}-api
+          securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ .Values.imageRegistry }}{{ .Values.velaux.uiServer.image }}
+          ports:
+            - containerPort: 80
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-  {{- toYaml . | nindent 8 }}
-  {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -55,14 +59,16 @@ metadata:
   name: {{ include "kubevela.fullname" . }}-apiserver
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "kubevela.labels" . | nindent 4 }}
+    {{- include "kubevela.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.apiServer.Service.type }}
+  type: {{ .Values.velaux.service.type }}
   ports:
     - port: 80
-      targetPort: {{ .Values.apiServer.port }}
+      {{- with .Values.velaux.service.nodePort }}
+      nodePort: {{- . }}
+      {{- end}}
+      targetPort: 80
       protocol: TCP
-      name: http
   selector:
-  {{- include "kubevela-ux.selectorLabels" . | nindent 6 }}
+    {{- include "kubevela-ux.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/vela-minimal/templates/kubevela-apiserver.yaml
+++ b/charts/vela-minimal/templates/kubevela-apiserver.yaml
@@ -65,7 +65,7 @@ spec:
   ports:
     - port: 80
       {{- with .Values.velaux.service.nodePort }}
-      nodePort: {{- . }}
+      nodePort: {{ . }}
       {{- end}}
       targetPort: 80
       protocol: TCP

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 # Valid applyOnceOnly values: true/false/on/off/force
 applyOnceOnly: "off"
 
-disableCaps: "manualscalertrait,containerizedwokrload,envbinding"
+disableCaps: ""
 
 imageRegistry: ""
 image:
@@ -77,6 +77,7 @@ admissionWebhooks:
     tolerations: []
   certManager:
     enabled: false
+    revisionHistoryLimit: 3
   # If autoGenWorkloadDefinition is true, webhook will auto generated workloadDefinition which componentDefinition refers to
   autoGenWorkloadDefinition: true
 
@@ -103,14 +104,20 @@ concurrentReconciles: 4
 dependCheckWait: 30s
 
 # OAMSpecVer is the oam spec version controller want to setup
-OAMSpecVer: "minimal"
+OAMSpecVer: "v0.3"
 
-apiServer:
-  enabled: false
-  port: 8000
+
+velaux:
   replicaCount: 1
-  Service:
-    type: ClusterIP
+  apiServer:
+    image: oamdev/vela-apiserver:v1.1.2
+    Service:
+      type: ClusterIP
+  uiServer:
+    image: barnett/kubevela:velaux.11241
+  service:
+    type: NodePort
+    nodePort: 32465
 
 multicluster:
   enabled: false
@@ -119,7 +126,7 @@ multicluster:
     port: 9443
     image:
       repository: oamdev/cluster-gateway
-      tag: v1.1.3
+      tag: v1.1.6
       pullPolicy: Always
     resources:
       limits:
@@ -133,3 +140,6 @@ test:
   app:
     repository: oamdev/hello-world
     tag: latest
+  k8s:
+    repository: oamdev/alpine-k8s
+    tag: 1.18.2


### PR DESCRIPTION
ref: https://github.com/oam-dev/kubevela/issues/2801

- [x] api+ui 处于同一个deployment.
- [x] api+ui 默认部署，但可以配置disable。
- [x] api 默认使用kubeapi数据库