### PR TITLE
Fix: don't invoke docker command if not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,9 +220,11 @@ e2e-cleanup:
 	rm -rf ~/.vela
 
 image-cleanup:
+ifneq (, $(shell which docker))
 # Delete Docker image
 ifneq ($(shell docker images -q $(VELA_CORE_TEST_IMAGE)),)
 	docker rmi -f $(VELA_CORE_TEST_IMAGE)
+endif
 endif
 
 end-e2e-core:


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

Fix the `make vela-cli` can't work as docker command not exist in the build env. Add a condition check in the command.

Fixes #2812

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->