### PR TITLE
Fix: health check appRev label bug

### DIFF
--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -78,6 +78,9 @@ func (p *Parser) GenerateAppFile(ctx context.Context, app *v1beta1.Application) 
 	appName := app.Name
 
 	appfile := p.newAppfile(appName, ns, app)
+	if app.Status.LatestRevision != nil {
+		appfile.AppRevisionName = app.Status.LatestRevision.Name
+	}
 
 	var wds []*Workload
 	for _, comp := range app.Spec.Components {

--- a/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler.go
+++ b/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler.go
@@ -221,13 +221,24 @@ func (h *handler) setWorkloadBaseInfo() {
 		h.sourceWorkload.SetNamespace(h.rollout.Namespace)
 	}
 
+	var appRev string
+	if len(h.rollout.GetLabels()) > 0 {
+		appRev = h.rollout.GetLabels()[oam.LabelAppRevision]
+	}
+
 	h.targetWorkload.SetName(h.compName)
-	util.AddLabels(h.targetWorkload, map[string]string{oam.LabelAppComponentRevision: h.targetRevName})
+	util.AddLabels(h.targetWorkload, map[string]string{
+		oam.LabelAppComponentRevision: h.targetRevName,
+		oam.LabelAppRevision:          appRev,
+	})
 	util.AddAnnotations(h.targetWorkload, map[string]string{oam.AnnotationSkipGC: "true"})
 
 	if h.sourceWorkload != nil {
 		h.sourceWorkload.SetName(h.compName)
-		util.AddLabels(h.sourceWorkload, map[string]string{oam.LabelAppComponentRevision: h.sourceRevName})
+		util.AddLabels(h.sourceWorkload, map[string]string{
+			oam.LabelAppComponentRevision: h.sourceRevName,
+			oam.LabelAppRevision:          appRev,
+		})
 	}
 }
 

--- a/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler_suit_test.go
+++ b/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler_suit_test.go
@@ -60,6 +60,7 @@ var _ = Describe("Test rollout related handler func", func() {
 		srcWorkload.SetAPIVersion("apps/v1")
 		srcWorkload.SetKind("Deployment")
 		compName := "comp-test"
+		appRevName := "app-revision-v2"
 		h := handler{
 			reconciler: &reconciler{
 				Client: k8sClient,
@@ -67,6 +68,9 @@ var _ = Describe("Test rollout related handler func", func() {
 			rollout: &v1alpha1.Rollout{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
+					Labels: map[string]string{
+						oam.LabelAppRevision: appRevName,
+					},
 				}},
 			targetWorkload: tarWorkload,
 			sourceWorkload: srcWorkload,
@@ -82,10 +86,10 @@ var _ = Describe("Test rollout related handler func", func() {
 		Expect(h.targetWorkload.GetNamespace()).Should(BeEquivalentTo(namespace))
 		Expect(h.sourceWorkload.GetNamespace()).Should(BeEquivalentTo(namespace))
 		tarLabel := h.targetWorkload.GetLabels()
-		Expect(len(tarLabel)).Should(BeEquivalentTo(2))
+		Expect(tarLabel[oam.LabelAppRevision]).Should(BeEquivalentTo(appRevName))
 		Expect(tarLabel[oam.LabelAppComponentRevision]).Should(BeEquivalentTo("comp-test-v2"))
 		srcLabel := h.sourceWorkload.GetLabels()
-		Expect(len(srcLabel)).Should(BeEquivalentTo(2))
+		Expect(srcLabel[oam.LabelAppRevision]).Should(BeEquivalentTo(appRevName))
 		Expect(srcLabel[oam.LabelAppComponentRevision]).Should(BeEquivalentTo("comp-test-v1"))
 
 		Expect(h.assembleWorkload(ctx)).Should(BeNil())


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Health Check select target workloads by labels. One of the label is appRevision.
1. Workloads created by rollout inherits the labels from component revision which does not have appRevision. Amend it.
2. HealthScope controller label selector does not fill appRevision. Amend it.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->