### PR TITLE
Fix: resourcetracker do not garbage collect legacyRTs correctly

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/dispatch.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/dispatch/dispatch.go
@@ -114,7 +114,7 @@ func (a *AppManifestsDispatcher) Dispatch(ctx context.Context, manifests []*unst
 	if err := a.applyAndRecordManifests(ctx, manifests); err != nil {
 		return nil, err
 	}
-	if !a.skipGC && a.previousRT != nil && a.previousRT.Name != a.currentRTName {
+	if !a.skipGC && ((a.previousRT != nil && a.previousRT.Name != a.currentRTName) || len(a.legacyRTs) > 0) {
 		if err := a.gcHandler.GarbageCollect(ctx, a.previousRT, a.currentRT, a.legacyRTs); err != nil {
 			return nil, errors.WithMessagef(err, "cannot do GC based on resource trackers %q and %q", a.previousRT.Name, a.currentRTName)
 		}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Current ResourceTracker mechanism does not garbage collect legacyRTs when previousRT is absent or equal to currentRT. However, in cases where latestRT is firstly updated but GC not executed due to the interruption of workflow, the recycle of outdated resources will be broken. This PR fixes it.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->