### PR TITLE
Fix: velaQL miss query the resources created by the old application version

### DIFF
--- a/charts/vela-core/templates/velaql-views/component-pod-view.yaml
+++ b/charts/vela-core/templates/velaql-views/component-pod-view.yaml
@@ -14,16 +14,18 @@ data:
     parameter: {
       appName:    string
       appNs:      string
-      name:       string
+      name?:      string
       cluster?:   string
       clusterNs?: string
     }
 
-    appList: ql.#ListResourcesInApp & {
+    annotationDeployVersion:  "app.oam.dev/deployVersion"
+    annotationPublishVersion: "app.oam.dev/publishVersion"
+
+    resources: ql.#ListResourcesInApp & {
       app: {
         name:      parameter.appName
         namespace: parameter.appNs
-        components: [parameter.name]
         filter: {
           if parameter.cluster != _|_ {
             cluster: parameter.cluster
@@ -31,17 +33,16 @@ data:
           if parameter.clusterNs != _|_ {
             clusterNamespace: parameter.clusterNs
           }
+          if parameter.name != _|_ {
+            components: [parameter.name]
+          }
         }
       }
     }
 
-    if appList.err == _|_ {
-      appRev:            appList.list[0].revision
-      appPublishVersion: appList.list[0].publishVersion
-      appDeployVersion:  appList.list[0].deployVersion
-      resources:         appList.list[0].components[0].resources
-      collectedPods:     op.#Steps & {
-        for i, resource in resources {
+    if resources.err == _|_ {
+      collectedPods: op.#Steps & {
+        for i, resource in resources.list {
           "\(i)": ql.#CollectPods & {
             value:   resource.object
             cluster: resource.cluster
@@ -55,21 +56,30 @@ data:
           apiVersion: pods.value.apiVersion
           kind:       pods.value.kind
         }
+        if pods.value.metadata.annotations[annotationPublishVersion] != _|_ {
+          publishVersion: pods.value.metadata.annotations[annotationPublishVersion]
+        }
+        if pods.value.metadata.annotations[annotationDeployVersion] != _|_ {
+          deployVersion: pods.value.metadata.annotations[annotationDeployVersion]
+        }
       }]
       podsError: [ for pods in collectedPods if pods.err != _|_ {pods.err}]
       status: {
         if len(podsError) == 0 {
           podList: [ for pod in podsWithCluster {
-            cluster: pod.cluster
+            cluster:  pod.cluster
             workload: pod.workload
             metadata: {
               name:         pod.obj.metadata.name
               namespace:    pod.obj.metadata.namespace
               creationTime: pod.obj.metadata.creationTimestamp
               version: {
-                revision:       appRev
-                publishVersion: appPublishVersion
-                deployVersion:  appDeployVersion
+                if pod.publishVersion != _|_ {
+                  publishVersion: pod.publishVersion
+                }
+                if pod.deployVersion != _|_ {
+                  deployVersion: pod.deployVersion
+                }
               }
             }
             status: {
@@ -89,8 +99,8 @@ data:
       }
     }
 
-    if appList.err != _|_ {
+    if resources.err != _|_ {
       status: {
-        error: appList.err
+        error: resources.err
       }
     }

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -4,15 +4,18 @@
 	app: {
 		name:      string
 		namespace: string
-		components?: [...string]
 		filter?: {
 			cluster?:          string
 			clusterNamespace?: string
+			components?: [...string]
 		}
-		clusterNamespace?:   string
-		enableHistoryQuery?: bool
 	}
-	...
+	list?: [...{
+		cluster:   string
+		component: string
+		revision:  string
+		object: {...}
+	}]
 }
 
 #CollectPods: {

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -20,7 +20,6 @@ import (
 	stdctx "context"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,40 +44,26 @@ type provider struct {
 	cli client.Client
 }
 
-// AppResources represent resources created by app
-type AppResources struct {
-	Revision       int64             `json:"revision"`
-	PublishVersion string            `json:"publishVersion"`
-	DeployVersion  string            `json:"deployVersion"`
-	Metadata       metav1.ObjectMeta `json:"metadata"`
-	Components     []Component       `json:"components"`
-}
-
-// Component group resources rendered by ApplicationComponent
-type Component struct {
-	Name      string     `json:"name"`
-	Resources []Resource `json:"resources"`
-}
-
 // Resource refer to an object with cluster info
 type Resource struct {
-	Cluster string                     `json:"cluster"`
-	Object  *unstructured.Unstructured `json:"object"`
+	Cluster   string                     `json:"cluster"`
+	Component string                     `json:"component"`
+	Revision  string                     `json:"revision"`
+	Object    *unstructured.Unstructured `json:"object"`
 }
 
 // Option is the query option
 type Option struct {
-	Name               string        `json:"name"`
-	Namespace          string        `json:"namespace"`
-	Components         []string      `json:"components,omitempty"`
-	Filter             ClusterFilter `json:"filter,omitempty"`
-	EnableHistoryQuery bool          `json:"enableHistoryQuery,omitempty"`
+	Name      string       `json:"name"`
+	Namespace string       `json:"namespace"`
+	Filter    FilterOption `json:"filter,omitempty"`
 }
 
-// ClusterFilter filter resource created by component
-type ClusterFilter struct {
-	Cluster          string `json:"cluster,omitempty"`
-	ClusterNamespace string `json:"clusterNamespace,omitempty"`
+// FilterOption filter resource created by component
+type FilterOption struct {
+	Cluster          string   `json:"cluster,omitempty"`
+	ClusterNamespace string   `json:"clusterNamespace,omitempty"`
+	Components       []string `json:"components,omitempty"`
 }
 
 // ListResourcesInApp lists CRs created by Application

--- a/test/e2e-apiserver-test/testdata/component-pod-view.yaml
+++ b/test/e2e-apiserver-test/testdata/component-pod-view.yaml
@@ -1,91 +1,92 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: test-component-pod-view
-    namespace: vela-system
+  name: test-component-pod-view
+  namespace: vela-system
 data:
-    template: |
-        import (
-          "vela/ql"
-          "vela/op"
-        )
+  template: |
+    import (
+      "vela/ql"
+      "vela/op"
+    )
 
-        parameter: {
-          appName:    string
-          appNs:      string
-          name:       string
-          cluster?:   string
-          clusterNs?: string
-        }
+    parameter: {
+      appName:    string
+      appNs:      string
+      name?:      string
+      cluster?:   string
+      clusterNs?: string
+    }
 
-        application: ql.#ListResourcesInApp & {
-          app: {
-            name:      parameter.appName
-            namespace: parameter.appNs
+    application: ql.#ListResourcesInApp & {
+      app: {
+        name:      parameter.appName
+        namespace: parameter.appNs
+        filter: {
+          if parameter.cluster != _|_ {
+            cluster: parameter.cluster
+          }
+          if parameter.clusterNs != _|_ {
+            clusterNamespace: parameter.clusterNs
+          }
+          if parameter.name != _|_ {
             components: [parameter.name]
-            filter: {
-              if parameter.cluster != _|_ {
-                cluster: parameter.cluster
-              }
-              if parameter.clusterNs != _|_ {
-                clusterNamespace: parameter.clusterNs
+          }
+        }
+      }
+    }
+
+    resources: application.list
+
+    podsMap: op.#Steps & {
+      for i, resource in resources {
+        "\(i)": ql.#CollectPods & {
+          value:   resource.object
+          cluster: resource.cluster
+        }
+      }
+    }
+
+    podsWithCluster: [ for i, pods in podsMap for podObj in pods.list {
+      cluster: pods.cluster
+      obj:     podObj
+    }]
+
+    podStatus: op.#Steps & {
+      for i, pod in podsWithCluster {
+        "\(i)": op.#Steps & {
+          name: pod.obj.metadata.name
+          containers: {for container in pod.obj.status.containerStatuses {
+            "\(container.name)": {
+              image: container.image
+              state: container.state
+            }
+          }}
+          events: ql.#SearchEvents & {
+            value:   pod.obj
+            cluster: pod.cluster
+          }
+          metrics: ql.#Read & {
+            cluster: pod.cluster
+            value: {
+              apiVersion: "metrics.k8s.io/v1beta1"
+              kind:       "PodMetrics"
+              metadata: {
+                name:      pod.obj.metadata.name
+                namespace: pod.obj.metadata.namespace
               }
             }
           }
         }
+      }
+    }
 
-        app:       application.list[0]
-        resources: app.components[0].resources
-
-        podsMap: op.#Steps & {
-          for i, resource in resources {
-            "\(i)": ql.#CollectPods & {
-              value:   resource.object
-              cluster: resource.cluster
-            }
-          }
-        }
-
-        podsWithCluster: [ for i, pods in podsMap for podObj in pods.list {
-          cluster: pods.cluster
-          obj:     podObj
+    status: {
+      podList: [ for podInfo in podStatus {
+        name: podInfo.name
+        containers: [ for containerName, container in podInfo.containers {
+          containerName
         }]
-
-        podStatus: op.#Steps & {
-          for i, pod in podsWithCluster {
-            "\(i)": op.#Steps & {
-              name: pod.obj.metadata.name
-              containers: {for container in pod.obj.status.containerStatuses {
-                "\(container.name)": {
-                  image: container.image
-                  state: container.state
-                }
-              }}
-              events: ql.#SearchEvents & {
-                value:   pod.obj
-                cluster: pod.cluster
-              }
-              metrics: ql.#Read & {
-                cluster: pod.cluster
-                value: {
-                  apiVersion: "metrics.k8s.io/v1beta1"
-                  kind:       "PodMetrics"
-                  metadata: {
-                    name:      pod.obj.metadata.name
-                    namespace: pod.obj.metadata.namespace
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        status: {
-          podList: [ for podInfo in podStatus {
-            name: podInfo.name
-            containers: [ for containerName, container in podInfo.containers {
-              containerName
-            }]
-            events: podInfo.events.list
-          }]
-        }
+        events: podInfo.events.list
+      }]
+    }


### PR DESCRIPTION
Fix bug: velaql will miss query the resources created by the old application version


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->