### PR TITLE
Fix: support exposing cloud resource identifier and console url

### DIFF
--- a/charts/vela-core/templates/addons/terraform.yaml
+++ b/charts/vela-core/templates/addons/terraform.yaml
@@ -114,6 +114,8 @@ data:
           kind: ComponentDefinition
           metadata:
             annotations:
+              cloud-resource/console-url: https://oss.console.aliyun.com/bucket/oss-{ALICLOUD_REGION}/{BUCKET_NAME}/overview
+              cloud-resource/identifier: BUCKET_NAME
               definition.oam.dev/description: Terraform configuration for Alibaba Cloud
                 OSS object
             labels:
@@ -141,6 +143,9 @@ data:
           kind: ComponentDefinition
           metadata:
             annotations:
+              cloud-resource/console-url: https://rdsnext.console.aliyun.com/detail/{DB_ID}/basicInfo?&region={ALICLOUD_REGION}
+              cloud-resource/identifier: DB_ID
+              cloud-resource/sensitive-outputs: DB_PASSWORD
               definition.oam.dev/description: Terraform configuration for Alibaba Cloud
                 RDS object
             labels:
@@ -162,6 +167,10 @@ data:
                     password = var.password
                     allocate_public_connection = var.allocate_public_connection
                     security_ips = ["0.0.0.0/0",]
+                  }
+
+                  output "DB_ID" {
+                    value = module.rds.db_instance_id
                   }
 
                   output "DB_NAME" {

--- a/docs/examples/terraform/cloud-resource-provision-and-consume/application-rds.yaml
+++ b/docs/examples/terraform/cloud-resource-provision-and-consume/application-rds.yaml
@@ -1,0 +1,14 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-rds-sample
+spec:
+  components:
+    - name: sample-db
+      type: alibaba-rds
+      properties:
+        instance_name: sample-db
+        account_name: oamtest
+        password: U34rfwefwefffaked
+        writeConnectionSecretToRef:
+          name: db-conn

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -666,8 +666,8 @@ func generateTerraformConfigurationWorkload(wl *Workload, ns string) (*unstructu
 	configuration := terraformapi.Configuration{
 		TypeMeta: metav1.TypeMeta{APIVersion: "terraform.core.oam.dev/v1beta1", Kind: "Configuration"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: wl.Name,
-			Namespace: ns,
+			Name:        wl.Name,
+			Namespace:   ns,
 			Annotations: wl.FullTemplate.ComponentDefinition.Annotations,
 		},
 	}

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -664,8 +664,12 @@ func generateTerraformConfigurationWorkload(wl *Workload, ns string) (*unstructu
 	}
 
 	configuration := terraformapi.Configuration{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "terraform.core.oam.dev/v1beta1", Kind: "Configuration"},
-		ObjectMeta: metav1.ObjectMeta{Name: wl.Name, Namespace: ns},
+		TypeMeta: metav1.TypeMeta{APIVersion: "terraform.core.oam.dev/v1beta1", Kind: "Configuration"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: wl.Name,
+			Namespace: ns,
+			Annotations: wl.FullTemplate.ComponentDefinition.Annotations,
+		},
 	}
 
 	switch wl.FullTemplate.Terraform.Type {

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -666,10 +666,12 @@ func generateTerraformConfigurationWorkload(wl *Workload, ns string) (*unstructu
 	configuration := terraformapi.Configuration{
 		TypeMeta: metav1.TypeMeta{APIVersion: "terraform.core.oam.dev/v1beta1", Kind: "Configuration"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        wl.Name,
-			Namespace:   ns,
-			Annotations: wl.FullTemplate.ComponentDefinition.Annotations,
+			Name:      wl.Name,
+			Namespace: ns,
 		},
+	}
+	if wl.FullTemplate.ComponentDefinition != nil {
+		configuration.ObjectMeta.Annotations = wl.FullTemplate.ComponentDefinition.Annotations
 	}
 
 	switch wl.FullTemplate.Terraform.Type {

--- a/vela-templates/addons/auto-gen/terraform.yaml
+++ b/vela-templates/addons/auto-gen/terraform.yaml
@@ -111,6 +111,8 @@ spec:
       kind: ComponentDefinition
       metadata:
         annotations:
+          cloud-resource/console-url: https://oss.console.aliyun.com/bucket/oss-{ALICLOUD_REGION}/{BUCKET_NAME}/overview
+          cloud-resource/identifier: BUCKET_NAME
           definition.oam.dev/description: Terraform configuration for Alibaba Cloud
             OSS object
         labels:
@@ -138,6 +140,9 @@ spec:
       kind: ComponentDefinition
       metadata:
         annotations:
+          cloud-resource/console-url: https://rdsnext.console.aliyun.com/detail/{DB_ID}/basicInfo?&region={ALICLOUD_REGION}
+          cloud-resource/identifier: DB_ID
+          cloud-resource/sensitive-outputs: DB_PASSWORD
           definition.oam.dev/description: Terraform configuration for Alibaba Cloud
             RDS object
         labels:
@@ -159,6 +164,10 @@ spec:
                 password = var.password
                 allocate_public_connection = var.allocate_public_connection
                 security_ips = ["0.0.0.0/0",]
+              }
+
+              output "DB_ID" {
+                value = module.rds.db_instance_id
               }
 
               output "DB_NAME" {

--- a/vela-templates/addons/terraform/definitions/terraform-alibaba-oss.yaml
+++ b/vela-templates/addons/terraform/definitions/terraform-alibaba-oss.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: vela-system
   annotations:
     definition.oam.dev/description: Terraform configuration for Alibaba Cloud OSS object
+    # identifier of this cloud resource
+    cloud-resource/identifier: BUCKET_NAME
+    # the console url of this cloud resource
+    cloud-resource/console-url: "https://oss.console.aliyun.com/bucket/oss-{ALICLOUD_REGION}/{BUCKET_NAME}/overview"
+    # the outputs which are sensitive. Separate them by a comma if there are more than one
   labels:
     type: terraform
 spec:

--- a/vela-templates/addons/terraform/definitions/terraform-alibaba-rds.yaml
+++ b/vela-templates/addons/terraform/definitions/terraform-alibaba-rds.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: vela-system
   annotations:
     definition.oam.dev/description: Terraform configuration for Alibaba Cloud RDS object
+    # identifier of this cloud resource
+    cloud-resource/identifier: DB_ID
+    # the console url of this cloud resource
+    cloud-resource/console-url: "https://rdsnext.console.aliyun.com/detail/{DB_ID}/basicInfo?&region={ALICLOUD_REGION}"
+    # the outputs which are sensitive. Separate them by a comma if there are more than one
+    cloud-resource/sensitive-outputs: "DB_PASSWORD"
   labels:
     type: terraform
 spec:
@@ -26,6 +32,10 @@ spec:
           password = var.password
           allocate_public_connection = var.allocate_public_connection
           security_ips = ["0.0.0.0/0",]
+        }
+
+        output "DB_ID" {
+          value = module.rds.db_instance_id
         }
 
         output "DB_NAME" {


### PR DESCRIPTION
To help users quickly navigate to the instance in the web console, exposing
necessary information in ComponentDefinition and convert them to Configuration


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->