### PR TITLE
Fix: add more fields for Terraform types definitions in api schema

### DIFF
--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -44,7 +44,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
-	"github.com/oam-dev/kubevela/references/plugins"
+	"github.com/oam-dev/kubevela/pkg/utils/terraform"
 )
 
 // data types of parameter value
@@ -189,22 +189,22 @@ func parseOtherProperties4TerraformDefinition() map[string]*openapi3.Schema {
 	// 1. writeConnectionSecretToRef
 	secretName := openapi3.NewStringSchema()
 	secretName.Title = "name"
-	secretName.Description = plugins.TerraformSecretNameDescription
+	secretName.Description = terraform.TerraformSecretNameDescription
 
 	secretNamespace := openapi3.NewStringSchema()
 	secretNamespace.Title = "namespace"
-	secretNamespace.Description = plugins.TerraformSecretNamespaceDescription
+	secretNamespace.Description = terraform.TerraformSecretNamespaceDescription
 
 	secret := openapi3.NewObjectSchema()
-	secret.Title = plugins.TerraformWriteConnectionSecretToRefName
-	secret.Description = plugins.TerraformWriteConnectionSecretToRefDescription
+	secret.Title = terraform.TerraformWriteConnectionSecretToRefName
+	secret.Description = terraform.TerraformWriteConnectionSecretToRefDescription
 	secret.Properties = openapi3.Schemas{
 		"name":      &openapi3.SchemaRef{Value: secretName},
 		"namespace": &openapi3.SchemaRef{Value: secretNamespace},
 	}
 	secret.Required = []string{"name"}
 
-	otherProperties[plugins.TerraformWriteConnectionSecretToRefName] = secret
+	otherProperties[terraform.TerraformWriteConnectionSecretToRefName] = secret
 
 	// 2. providerRef
 	providerName := openapi3.NewStringSchema()

--- a/pkg/utils/terraform/properties.go
+++ b/pkg/utils/terraform/properties.go
@@ -1,0 +1,14 @@
+package terraform
+
+const (
+	// TerraformWriteConnectionSecretToRefName is the name for Terraform WriteConnectionSecretToRef
+	TerraformWriteConnectionSecretToRefName = "writeConnectionSecretToRef"
+	// TerraformWriteConnectionSecretToRefType is the type for Terraform WriteConnectionSecretToRef
+	TerraformWriteConnectionSecretToRefType = "[writeConnectionSecretToRef](#writeConnectionSecretToRef)"
+	// TerraformWriteConnectionSecretToRefDescription is the description for Terraform WriteConnectionSecretToRef
+	TerraformWriteConnectionSecretToRefDescription = "The secret which the cloud resource connection will be written to"
+	// TerraformSecretNameDescription is the description for the name for Terraform Secret
+	TerraformSecretNameDescription = "The secret name which the cloud resource connection will be written to"
+	// TerraformSecretNamespaceDescription is the description for the namespace for Terraform Secret
+	TerraformSecretNamespaceDescription = "The secret namespace which the cloud resource connection will be written to"
+)

--- a/pkg/utils/terraform/properties.go
+++ b/pkg/utils/terraform/properties.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package terraform
 
 const (

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -56,6 +56,12 @@ const (
 	TerraformWriteConnectionSecretToRefName = "writeConnectionSecretToRef"
 	// TerraformWriteConnectionSecretToRefType is the type for Terraform WriteConnectionSecretToRef
 	TerraformWriteConnectionSecretToRefType = "[writeConnectionSecretToRef](#writeConnectionSecretToRef)"
+	// TerraformWriteConnectionSecretToRefDescription is the description for Terraform WriteConnectionSecretToRef
+	TerraformWriteConnectionSecretToRefDescription = "The secret which the cloud resource connection will be written to"
+	// TerraformSecretNameDescription is the description for the name for Terraform Secret
+	TerraformSecretNameDescription = "The secret name which the cloud resource connection will be written to"
+	// TerraformSecretNamespaceDescription is the description for the namespace for Terraform Secret
+	TerraformSecretNamespaceDescription = "The secret namespace which the cloud resource connection will be written to"
 )
 
 // Int64Type is int64 type
@@ -750,7 +756,7 @@ func (ref *ParseReference) parseTerraformCapabilityParameters(capability types.C
 	writeConnectionSecretToRefReferenceParameter.Name = TerraformWriteConnectionSecretToRefName
 	writeConnectionSecretToRefReferenceParameter.PrintableType = TerraformWriteConnectionSecretToRefType
 	writeConnectionSecretToRefReferenceParameter.Required = false
-	writeConnectionSecretToRefReferenceParameter.Usage = "The secret which the cloud resource connection will be written to"
+	writeConnectionSecretToRefReferenceParameter.Usage = TerraformWriteConnectionSecretToRefDescription
 
 	variables, err := common.ParseTerraformVariables(capability.TerraformConfiguration)
 	if err != nil {
@@ -781,12 +787,12 @@ func (ref *ParseReference) parseTerraformCapabilityParameters(capability types.C
 	writeSecretRefNameParam.Name = "name"
 	writeSecretRefNameParam.PrintableType = "string"
 	writeSecretRefNameParam.Required = true
-	writeSecretRefNameParam.Usage = "The secret name which the cloud resource connection will be written to"
+	writeSecretRefNameParam.Usage = TerraformSecretNameDescription
 
 	writeSecretRefNameSpaceParam.Name = "namespace"
 	writeSecretRefNameSpaceParam.PrintableType = "string"
 	writeSecretRefNameSpaceParam.Required = false
-	writeSecretRefNameSpaceParam.Usage = "The secret namespace which the cloud resource connection will be written to"
+	writeSecretRefNameSpaceParam.Usage = TerraformSecretNamespaceDescription
 
 	writeSecretRefParameterList := []ReferenceParameter{writeSecretRefNameParam, writeSecretRefNameSpaceParam}
 	writeSecretTableName := fmt.Sprintf("%s %s", strings.Repeat("#", 4), TerraformWriteConnectionSecretToRefName)

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -36,6 +36,7 @@ import (
 	velacue "github.com/oam-dev/kubevela/pkg/cue"
 	"github.com/oam-dev/kubevela/pkg/cue/model"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/pkg/utils/terraform"
 )
 
 const (
@@ -49,19 +50,6 @@ const (
 	WorkloadTypePath = "workload-types"
 	// TraitPath is the URL path for trait typed capability
 	TraitPath = "traits"
-)
-
-const (
-	// TerraformWriteConnectionSecretToRefName is the name for Terraform WriteConnectionSecretToRef
-	TerraformWriteConnectionSecretToRefName = "writeConnectionSecretToRef"
-	// TerraformWriteConnectionSecretToRefType is the type for Terraform WriteConnectionSecretToRef
-	TerraformWriteConnectionSecretToRefType = "[writeConnectionSecretToRef](#writeConnectionSecretToRef)"
-	// TerraformWriteConnectionSecretToRefDescription is the description for Terraform WriteConnectionSecretToRef
-	TerraformWriteConnectionSecretToRefDescription = "The secret which the cloud resource connection will be written to"
-	// TerraformSecretNameDescription is the description for the name for Terraform Secret
-	TerraformSecretNameDescription = "The secret name which the cloud resource connection will be written to"
-	// TerraformSecretNamespaceDescription is the description for the namespace for Terraform Secret
-	TerraformSecretNamespaceDescription = "The secret namespace which the cloud resource connection will be written to"
 )
 
 // Int64Type is int64 type
@@ -753,10 +741,10 @@ func (ref *ParseReference) parseTerraformCapabilityParameters(capability types.C
 		writeConnectionSecretToRefReferenceParameter ReferenceParameter
 	)
 
-	writeConnectionSecretToRefReferenceParameter.Name = TerraformWriteConnectionSecretToRefName
-	writeConnectionSecretToRefReferenceParameter.PrintableType = TerraformWriteConnectionSecretToRefType
+	writeConnectionSecretToRefReferenceParameter.Name = terraform.TerraformWriteConnectionSecretToRefName
+	writeConnectionSecretToRefReferenceParameter.PrintableType = terraform.TerraformWriteConnectionSecretToRefType
 	writeConnectionSecretToRefReferenceParameter.Required = false
-	writeConnectionSecretToRefReferenceParameter.Usage = TerraformWriteConnectionSecretToRefDescription
+	writeConnectionSecretToRefReferenceParameter.Usage = terraform.TerraformWriteConnectionSecretToRefDescription
 
 	variables, err := common.ParseTerraformVariables(capability.TerraformConfiguration)
 	if err != nil {
@@ -787,15 +775,15 @@ func (ref *ParseReference) parseTerraformCapabilityParameters(capability types.C
 	writeSecretRefNameParam.Name = "name"
 	writeSecretRefNameParam.PrintableType = "string"
 	writeSecretRefNameParam.Required = true
-	writeSecretRefNameParam.Usage = TerraformSecretNameDescription
+	writeSecretRefNameParam.Usage = terraform.TerraformSecretNameDescription
 
 	writeSecretRefNameSpaceParam.Name = "namespace"
 	writeSecretRefNameSpaceParam.PrintableType = "string"
 	writeSecretRefNameSpaceParam.Required = false
-	writeSecretRefNameSpaceParam.Usage = TerraformSecretNamespaceDescription
+	writeSecretRefNameSpaceParam.Usage = terraform.TerraformSecretNamespaceDescription
 
 	writeSecretRefParameterList := []ReferenceParameter{writeSecretRefNameParam, writeSecretRefNameSpaceParam}
-	writeSecretTableName := fmt.Sprintf("%s %s", strings.Repeat("#", 4), TerraformWriteConnectionSecretToRefName)
+	writeSecretTableName := fmt.Sprintf("%s %s", strings.Repeat("#", 4), terraform.TerraformWriteConnectionSecretToRefName)
 
 	tables = append(tables, ReferenceParameterTable{
 		Name:       writeSecretTableName,


### PR DESCRIPTION
Added `writeConnectionStringSecrecto`, `region` and `deleteResoruce`
fields for Terraform types definitions in OpenAPI schema


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->