### PR TITLE
Feat: automatically populate the provider and region configuration for cloud app

### DIFF
--- a/pkg/apiserver/rest/usecase/application.go
+++ b/pkg/apiserver/rest/usecase/application.go
@@ -112,6 +112,7 @@ func NewApplicationUsecase(ds datastore.DataStore, workflowUsecase WorkflowUseca
 		deliveryTargetUsecase: deliveryTargetUsecase,
 		kubeClient:            kubecli,
 		apply:                 apply.NewAPIApplicator(kubecli),
+		definitionUsecase:     definitionUsecase,
 	}
 }
 

--- a/pkg/apiserver/rest/usecase/application.go
+++ b/pkg/apiserver/rest/usecase/application.go
@@ -1261,8 +1261,9 @@ func (c *applicationUsecaseImpl) createTargetClusterEnv(ctx context.Context, app
 				}
 				log.Logger.Info(properties)
 				componentPatchs = append(componentPatchs, v1alpha1.EnvComponentPatch{
-					Name:       component.Name,
+					Name:       converComponentName(component.Name, envBind.Name),
 					Properties: properties.RawExtension(),
+					Type:       component.Type,
 				})
 			}
 		}

--- a/pkg/apiserver/rest/usecase/application_test.go
+++ b/pkg/apiserver/rest/usecase/application_test.go
@@ -510,7 +510,7 @@ var _ = Describe("Test application usecase function", func() {
 		} else {
 			Expect(err).Should(BeNil())
 		}
-		err = k8sClient.Create(context.TODO(), &v1beta1.ComponentDefinition{
+		definition := &v1beta1.ComponentDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aliyun-rds",
 				Namespace: types.DefaultKubeVelaNS,
@@ -520,7 +520,8 @@ var _ = Describe("Test application usecase function", func() {
 					Type: TerraformWorkfloadType,
 				},
 			},
-		})
+		}
+		err = k8sClient.Create(context.TODO(), definition)
 		Expect(err).Should(BeNil())
 		envConfig := appUsecase.createTargetClusterEnv(context.TODO(), &model.Application{
 			Namespace: "prod",
@@ -540,6 +541,8 @@ var _ = Describe("Test application usecase function", func() {
 		})
 		Expect(cmp.Diff(len(envConfig.Patch.Components), 1)).Should(BeEmpty())
 		Expect(cmp.Diff(strings.Contains(string(envConfig.Patch.Components[0].Properties.Raw), "aliyun"), true)).Should(BeEmpty())
+		err = k8sClient.Delete(context.TODO(), definition)
+		Expect(err).Should(BeNil())
 	})
 })
 

--- a/pkg/apiserver/rest/usecase/application_test.go
+++ b/pkg/apiserver/rest/usecase/application_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
@@ -495,7 +498,19 @@ var _ = Describe("Test application usecase function", func() {
 	})
 
 	It("Test createTargetClusterEnv function", func() {
-		err := k8sClient.Create(context.TODO(), &v1beta1.ComponentDefinition{
+		var namespace corev1.Namespace
+		err := k8sClient.Get(context.TODO(), k8stypes.NamespacedName{Name: types.DefaultKubeVelaNS}, &namespace)
+		if apierrors.IsNotFound(err) {
+			err := k8sClient.Create(context.TODO(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: types.DefaultKubeVelaNS,
+				},
+			})
+			Expect(err).Should(BeNil())
+		} else {
+			Expect(err).Should(BeNil())
+		}
+		err = k8sClient.Create(context.TODO(), &v1beta1.ComponentDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aliyun-rds",
 				Namespace: types.DefaultKubeVelaNS,

--- a/pkg/apiserver/rest/usecase/definition_test.go
+++ b/pkg/apiserver/rest/usecase/definition_test.go
@@ -60,11 +60,17 @@ var _ = Describe("Test namespace usecase functions", func() {
 		Expect(err).Should(Succeed())
 		err = k8sClient.Create(context.Background(), &cd)
 		Expect(err).Should(Succeed())
-		components, err := definitionUsecase.ListDefinitions(context.TODO(), "", "component", "")
+		definitions, err := definitionUsecase.ListDefinitions(context.TODO(), "", "component", "")
 		Expect(err).Should(BeNil())
-		Expect(cmp.Diff(len(components), 1)).Should(BeEmpty())
-		Expect(cmp.Diff(components[0].Name, "webservice-test")).Should(BeEmpty())
-		Expect(components[0].Description).ShouldNot(BeEmpty())
+		var selectDefinition *v1.DefinitionBase
+		for i, definition := range definitions {
+			if definition.WorkloadType == "deployments.apps" {
+				selectDefinition = definitions[i]
+			}
+		}
+		Expect(selectDefinition).ShouldNot(BeNil())
+		Expect(cmp.Diff(selectDefinition.Name, "webservice-test")).Should(BeEmpty())
+		Expect(selectDefinition.Description).ShouldNot(BeEmpty())
 
 		By("List trait definitions")
 		myingress, err := ioutil.ReadFile("./testdata/myingress-td.yaml")

--- a/pkg/apiserver/rest/usecase/testdata/ui-schema.yaml
+++ b/pkg/apiserver/rest/usecase/testdata/ui-schema.yaml
@@ -51,19 +51,6 @@
     - valueFrom
     label: Add By Secret
   subParameters:
-  - description: Environment variable name
-    jsonKey: name
-    label: Name
-    sort: 100
-    uiType: Input
-    validate:
-      required: true
-  - description: The value of the environment variable
-    jsonKey: value
-    label: Value
-    sort: 100
-    uiType: Input
-    validate: {}
   - description: Specifies a source the value of this var should come from
     jsonKey: valueFrom
     label: Secret Selector
@@ -93,6 +80,19 @@
       validate:
         required: true
     uiType: InnerGroup
+    validate: {}
+  - description: Environment variable name
+    jsonKey: name
+    label: Name
+    sort: 100
+    uiType: Input
+    validate:
+      required: true
+  - description: The value of the environment variable
+    jsonKey: value
+    label: Value
+    sort: 100
+    uiType: Input
     validate: {}
   uiType: Structs
   validate: {}
@@ -182,6 +182,14 @@
     label: HttpGet
     sort: 100
     subParameters:
+    - description: The endpoint, relative to the port, to which the HTTP GET request
+        should be directed.
+      jsonKey: path
+      label: Path
+      sort: 100
+      uiType: Input
+      validate:
+        required: true
     - description: The TCP socket within the container to which the HTTP GET request
         should be directed.
       jsonKey: port
@@ -211,14 +219,6 @@
           required: true
       uiType: Structs
       validate: {}
-    - description: The endpoint, relative to the port, to which the HTTP GET request
-        should be directed.
-      jsonKey: path
-      label: Path
-      sort: 100
-      uiType: Input
-      validate:
-        required: true
     uiType: Group
     validate: {}
   - description: Number of seconds after the container is started before the first
@@ -237,53 +237,6 @@
   label: LivenessProbe
   sort: 15
   subParameters:
-  - description: Instructions for assessing container health by executing an HTTP
-      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
-      MUST be specified. This attribute is mutually exclusive with both the exec attribute
-      and the tcpSocket attribute.
-    jsonKey: httpGet
-    label: HttpGet
-    sort: 100
-    subParameters:
-    - description: ""
-      jsonKey: httpHeaders
-      label: HttpHeaders
-      sort: 100
-      subParameters:
-      - description: ""
-        jsonKey: name
-        label: Name
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      - description: ""
-        jsonKey: value
-        label: Value
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      uiType: Structs
-      validate: {}
-    - description: The endpoint, relative to the port, to which the HTTP GET request
-        should be directed.
-      jsonKey: path
-      label: Path
-      sort: 100
-      uiType: Input
-      validate:
-        required: true
-    - description: The TCP socket within the container to which the HTTP GET request
-        should be directed.
-      jsonKey: port
-      label: Port
-      sort: 100
-      uiType: Number
-      validate:
-        required: true
-    uiType: Group
-    validate: {}
   - description: Number of seconds after the container is started before the first
       probe is initiated.
     jsonKey: initialDelaySeconds
@@ -365,7 +318,60 @@
     validate:
       defaultValue: 3
       required: true
+  - description: Instructions for assessing container health by executing an HTTP
+      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
+      MUST be specified. This attribute is mutually exclusive with both the exec attribute
+      and the tcpSocket attribute.
+    jsonKey: httpGet
+    label: HttpGet
+    sort: 100
+    subParameters:
+    - description: ""
+      jsonKey: httpHeaders
+      label: HttpHeaders
+      sort: 100
+      subParameters:
+      - description: ""
+        jsonKey: name
+        label: Name
+        sort: 100
+        uiType: Input
+        validate:
+          required: true
+      - description: ""
+        jsonKey: value
+        label: Value
+        sort: 100
+        uiType: Input
+        validate:
+          required: true
+      uiType: Structs
+      validate: {}
+    - description: The endpoint, relative to the port, to which the HTTP GET request
+        should be directed.
+      jsonKey: path
+      label: Path
+      sort: 100
+      uiType: Input
+      validate:
+        required: true
+    - description: The TCP socket within the container to which the HTTP GET request
+        should be directed.
+      jsonKey: port
+      label: Port
+      sort: 100
+      uiType: Number
+      validate:
+        required: true
+    uiType: Group
+    validate: {}
   uiType: Group
+  validate: {}
+- description: Specify image pull secrets for your service
+  jsonKey: imagePullSecrets
+  label: ImagePullSecrets
+  sort: 100
+  uiType: Strings
   validate: {}
 - description: Which port do you want customer traffic sent to
   disable: true
@@ -375,22 +381,6 @@
   uiType: Number
   validate:
     defaultValue: 80
-    required: true
-- description: Specify image pull secrets for your service
-  jsonKey: imagePullSecrets
-  label: ImagePullSecrets
-  sort: 100
-  uiType: Strings
-  validate: {}
-- description: If addRevisionLabel is true, the appRevision label will be added to
-    the underlying pods
-  disable: true
-  jsonKey: addRevisionLabel
-  label: AddRevisionLabel
-  sort: 100
-  uiType: Switch
-  validate:
-    defaultValue: false
     required: true
 - description: Declare volumes and volumeMounts
   disable: true
@@ -430,3 +420,13 @@
       required: true
   uiType: Structs
   validate: {}
+- description: If addRevisionLabel is true, the appRevision label will be added to
+    the underlying pods
+  disable: true
+  jsonKey: addRevisionLabel
+  label: AddRevisionLabel
+  sort: 100
+  uiType: Switch
+  validate:
+    defaultValue: false
+    required: true

--- a/pkg/apiserver/rest/usecase/testdata/webserver-cd.yaml
+++ b/pkg/apiserver/rest/usecase/testdata/webserver-cd.yaml
@@ -249,6 +249,7 @@ spec:
         	failureThreshold: *3 | int
         }
   workload:
+    type: deployments.apps
     definition:
       apiVersion: apps/v1
       kind: Deployment

--- a/pkg/apiserver/rest/webservice/webservice.go
+++ b/pkg/apiserver/rest/webservice/webservice.go
@@ -67,7 +67,7 @@ func Init(ds datastore.DataStore) {
 	definitionUsecase := usecase.NewDefinitionUsecase()
 	addonUsecase := usecase.NewAddonUsecase(ds)
 	envBindingUsecase := usecase.NewEnvBindingUsecase(ds, workflowUsecase, definitionUsecase)
-	applicationUsecase := usecase.NewApplicationUsecase(ds, workflowUsecase, envBindingUsecase, deliveryTargetUsecase)
+	applicationUsecase := usecase.NewApplicationUsecase(ds, workflowUsecase, envBindingUsecase, deliveryTargetUsecase, definitionUsecase)
 	RegistWebService(NewClusterWebService(clusterUsecase))
 	RegistWebService(NewApplicationWebService(applicationUsecase, envBindingUsecase, workflowUsecase))
 	RegistWebService(NewNamespaceWebService(namespaceUsecase))


### PR DESCRIPTION
### Description of your changes

Users can configure differentiated variable data in the Target, including provider、region, and others, to automatically populate differentiated cluster data for cloud applications.

Here, the secret name is automatically populated with the name of the component.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.