### PR TITLE
Fix: reset record status when a new one is created

### DIFF
--- a/pkg/apiserver/rest/usecase/workflow.go
+++ b/pkg/apiserver/rest/usecase/workflow.go
@@ -539,6 +539,9 @@ func (w *workflowUsecaseImpl) CreateWorkflowRecord(ctx context.Context, appModel
 	for _, raw := range records {
 		record, ok := raw.(*model.WorkflowRecord)
 		if ok {
+			if record.Name == app.Annotations[oam.AnnotationPublishVersion] {
+				continue
+			}
 			record.Status = model.RevisionStatusTerminated
 			record.Finished = "true"
 			if err := w.ds.Put(ctx, record); err != nil {


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

 reset record status when a new one is created

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->