### PR TITLE
Fix: cloud resource type applications could not be identified

### DIFF
--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -558,7 +558,7 @@ type CreateWorkflowRequest struct {
 	Alias       string         `json:"alias"  validate:"checkalias" optional:"true"`
 	Description string         `json:"description" optional:"true"`
 	Steps       []WorkflowStep `json:"steps,omitempty"`
-	Default     bool           `json:"default"`
+	Default     *bool          `json:"default"`
 	EnvName     string         `json:"envName"`
 }
 

--- a/pkg/apiserver/rest/usecase/application.go
+++ b/pkg/apiserver/rest/usecase/application.go
@@ -1238,7 +1238,8 @@ func (c *applicationUsecaseImpl) createTargetClusterEnv(ctx context.Context, app
 			continue
 		}
 		if definition != nil {
-			if definition.Spec.Workload.Type == TerraformWorkfloadType {
+			if definition.Spec.Workload.Type == TerraformWorkfloadType ||
+				definition.Spec.Workload.Definition.Kind == TerraformWorkfloadKind {
 				properties := model.JSONStruct{
 					"providerRef": map[string]interface{}{
 						"name":      "",

--- a/pkg/apiserver/rest/usecase/application.go
+++ b/pkg/apiserver/rest/usecase/application.go
@@ -1242,10 +1242,8 @@ func (c *applicationUsecaseImpl) createTargetClusterEnv(ctx context.Context, app
 				definition.Spec.Workload.Definition.Kind == TerraformWorkfloadKind {
 				properties := model.JSONStruct{
 					"providerRef": map[string]interface{}{
-						"name":      "",
-						"namespace": "default",
+						"name": "default",
 					},
-					"region": "",
 					"writeConnectionSecretToRef": map[string]interface{}{
 						"name":      fmt.Sprintf("%s-%s", component.Name, envBind.Name),
 						"namespace": app.Namespace,
@@ -1260,7 +1258,6 @@ func (c *applicationUsecaseImpl) createTargetClusterEnv(ctx context.Context, app
 				if providerNamespace, ok := target.Variable["providerNamespace"]; ok {
 					properties["providerRef"].(map[string]interface{})["namespace"] = providerNamespace
 				}
-				log.Logger.Info(properties)
 				componentPatchs = append(componentPatchs, v1alpha1.EnvComponentPatch{
 					Name:       converComponentName(component.Name, envBind.Name),
 					Properties: properties.RawExtension(),

--- a/pkg/apiserver/rest/usecase/envbinding.go
+++ b/pkg/apiserver/rest/usecase/envbinding.go
@@ -43,6 +43,8 @@ const (
 	DeployCloudResource string = "deploy-cloud-resource"
 	// TerraformWorkfloadType cloud application
 	TerraformWorkfloadType string = "configurations.terraform.core.oam.dev"
+	// TerraformWorkfloadKind terraform workload kind
+	TerraformWorkfloadKind string = "Configuration"
 )
 
 // EnvBindingUsecase envbinding usecase
@@ -246,7 +248,7 @@ func (e *envBindingUsecaseImpl) createEnvWorkflow(ctx context.Context, app *mode
 		Description: "Created automatically by envbinding.",
 		EnvName:     env.Name,
 		Steps:       steps,
-		Default:     isDefault,
+		Default:     &isDefault,
 	})
 	if err != nil {
 		return err
@@ -405,6 +407,9 @@ func (e *envBindingUsecaseImpl) GetSuitableType(ctx context.Context, app *model.
 		}
 		if definition != nil {
 			if definition.Spec.Workload.Type == TerraformWorkfloadType {
+				return DeployCloudResource
+			}
+			if definition.Spec.Workload.Definition.Kind == TerraformWorkfloadKind {
 				return DeployCloudResource
 			}
 		}

--- a/pkg/apiserver/rest/usecase/workflow.go
+++ b/pkg/apiserver/rest/usecase/workflow.go
@@ -174,7 +174,7 @@ func (w *workflowUsecaseImpl) CreateOrUpdateWorkflow(ctx context.Context, app *m
 		workflow.Steps = steps
 		workflow.Alias = req.Alias
 		workflow.Description = req.Description
-		workflow.Default = &req.Default
+		workflow.Default = req.Default
 		if err := w.ds.Put(ctx, workflow); err != nil {
 			return nil, err
 		}
@@ -185,7 +185,7 @@ func (w *workflowUsecaseImpl) CreateOrUpdateWorkflow(ctx context.Context, app *m
 			Name:          req.Name,
 			Alias:         req.Alias,
 			Description:   req.Description,
-			Default:       &req.Default,
+			Default:       req.Default,
 			EnvName:       req.EnvName,
 			AppPrimaryKey: app.PrimaryKey(),
 		}

--- a/pkg/apiserver/rest/usecase/workflow_test.go
+++ b/pkg/apiserver/rest/usecase/workflow_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Test workflow usecase functions", func() {
 		Expect(err).Should(BeNil())
 		Expect(cmp.Diff(base.Description, req2.Description)).Should(BeEmpty())
 		Expect(cmp.Diff(base.EnvName, req2.EnvName)).ShouldNot(BeEmpty())
-
+		var defaultW = true
 		req = apisv1.CreateWorkflowRequest{
 			Name:        "test-workflow-2",
 			Description: "this is test workflow",
@@ -106,7 +106,7 @@ var _ = Describe("Test workflow usecase functions", func() {
 					Alias: "step-alias-2",
 				},
 			},
-			Default: true,
+			Default: &defaultW,
 		}
 		base, err = workflowUsecase.CreateOrUpdateWorkflow(context.TODO(), &model.Application{
 			Name:      appName,


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

Cloud resource applications do not fully define Workload Type, so we also judge Kind.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.