### PR TITLE
Feat: add test for registry name in addon response

### DIFF
--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -122,9 +122,11 @@ func testReaderFunc(t *testing.T, reader AsyncReader) {
 	assert.True(t, len(uiData.Definitions) > 0)
 
 	// test get ui data
-	uiDataList, err := ListAddonUIDataFromReader(reader, registryMeta, "KubeVela", UIMetaOptions)
+	rName := "KubeVela"
+	uiDataList, err := ListAddonUIDataFromReader(reader, registryMeta, rName, UIMetaOptions)
 	assert.True(t, strings.Contains(err.Error(), "#parameter.example: preference mark not allowed at this position"))
 	assert.Equal(t, len(uiDataList), 3)
+	assert.Equal(t, uiDataList[0].RegistryName, rName)
 
 	// test get install package
 	installPkg, err := GetInstallPackageFromReader(reader, &testAddonMeta, uiData)

--- a/pkg/addon/error.go
+++ b/pkg/addon/error.go
@@ -17,8 +17,6 @@ limitations under the License.
 package addon
 
 import (
-	"net/http"
-
 	"github.com/google/go-github/v32/github"
 	"github.com/pkg/errors"
 )
@@ -38,15 +36,6 @@ var (
 	// ErrNotExist  means addon not exists
 	ErrNotExist = NewAddonError("addon not exist")
 )
-
-// WrapErrNotExist returns ErrNotExist if is the situation, or original error
-func WrapErrNotExist(err error) error {
-	errMsg := &github.ErrorResponse{}
-	if ok := errors.As(err, &errMsg); ok && errMsg.Response.StatusCode == http.StatusNotFound {
-		return ErrNotExist
-	}
-	return err
-}
 
 // WrapErrRateLimit return ErrRateLimit if is the situation, or return error directly
 func WrapErrRateLimit(err error) error {

--- a/pkg/addon/error.go
+++ b/pkg/addon/error.go
@@ -17,6 +17,8 @@ limitations under the License.
 package addon
 
 import (
+	"net/http"
+
 	"github.com/google/go-github/v32/github"
 	"github.com/pkg/errors"
 )
@@ -36,6 +38,15 @@ var (
 	// ErrNotExist  means addon not exists
 	ErrNotExist = NewAddonError("addon not exist")
 )
+
+// WrapErrNotExist returns ErrNotExist if is the situation, or original error
+func WrapErrNotExist(err error) error {
+	errMsg := &github.ErrorResponse{}
+	if ok := errors.As(err, &errMsg); ok && errMsg.Response.StatusCode == http.StatusNotFound {
+		return ErrNotExist
+	}
+	return err
+}
 
 // WrapErrRateLimit return ErrRateLimit if is the situation, or return error directly
 func WrapErrRateLimit(err error) error {

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Test addon rest api", func() {
 		Expect(deleteRes.StatusCode).Should(Equal(200))
 	})
 
-	Context("list addons", func() {
+	It("list addons", func() {
 		DefaultRegistry := "KubeVela"
 		listRes := get("/api/v1/addons/")
 		defer listRes.Body.Close()

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -49,14 +49,15 @@ func get(path string) *http.Response {
 }
 
 var _ = Describe("Test addon rest api", func() {
+	registryName := "test-addon-registry"
 	createReq := apis.CreateAddonRegistryRequest{
-		Name: "test-addon-registry-1",
+		Name: registryName,
 		Oss: &addon.OSSAddonSource{
 			Endpoint: "https://oss-cn-hangzhou.aliyuncs.com",
-			Bucket:   "kubevela-addons",
+			Bucket:   "fake-kubevela-addons",
 		},
 	}
-	It("should add a registry and list addons from it", func() {
+	It("should add and delete a registry, list addons from default registry", func() {
 		defer GinkgoRecover()
 
 		By("add registry")
@@ -72,15 +73,26 @@ var _ = Describe("Test addon rest api", func() {
 		Expect(err).Should(BeNil())
 		Expect(rmeta.Name).Should(Equal(createReq.Name))
 		Expect(rmeta.Git).Should(Equal(createReq.Git))
+		Expect(rmeta.OSS).Should(Equal(createReq.Oss))
 
-		By("list addons")
+		deleteReq, err := http.NewRequest(http.MethodDelete, baseURL+"/api/v1/addon_registries/"+createReq.Name, nil)
+		Expect(err).Should(BeNil())
+		deleteRes, err := http.DefaultClient.Do(deleteReq)
+		Expect(err).Should(BeNil())
+		Expect(deleteRes).ShouldNot(BeNil())
+		Expect(deleteRes.StatusCode).Should(Equal(200))
+	})
+
+	Context("list addons", func() {
+		DefaultRegistry := "KubeVela"
 		listRes := get("/api/v1/addons/")
 		defer listRes.Body.Close()
 
 		var lres apis.ListAddonResponse
-		err = json.NewDecoder(listRes.Body).Decode(&lres)
+		err := json.NewDecoder(listRes.Body).Decode(&lres)
 		Expect(err).Should(BeNil())
 		Expect(lres.Addons).ShouldNot(BeZero())
+		Expect(lres.Addons[0]).To(Equal(DefaultRegistry))
 
 		By("get addon detail")
 		detailRes := get("/api/v1/addons/terraform-alibaba")
@@ -92,6 +104,7 @@ var _ = Describe("Test addon rest api", func() {
 		Expect(dres.Meta).ShouldNot(BeNil())
 		Expect(dres.UISchema).ShouldNot(BeNil())
 		Expect(dres.APISchema).ShouldNot(BeNil())
+		Expect(dres.RegistryName).Should(Equal(DefaultRegistry))
 	})
 
 	PIt("should enable and disable an addon", func() {
@@ -141,11 +154,5 @@ var _ = Describe("Test addon rest api", func() {
 
 	It("should delete test registry", func() {
 		defer GinkgoRecover()
-		deleteReq, err := http.NewRequest(http.MethodDelete, baseURL+"/api/v1/addon_registries/"+createReq.Name, nil)
-		Expect(err).Should(BeNil())
-		deleteRes, err := http.DefaultClient.Do(deleteReq)
-		Expect(err).Should(BeNil())
-		Expect(deleteRes).ShouldNot(BeNil())
-		Expect(deleteRes.StatusCode).Should(Equal(200))
 	})
 })

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Test addon rest api", func() {
 		err := json.NewDecoder(listRes.Body).Decode(&lres)
 		Expect(err).Should(BeNil())
 		Expect(lres.Addons).ShouldNot(BeZero())
-		Expect(lres.Addons[0]).To(Equal(DefaultRegistry))
+		Expect(lres.Addons[0].RegistryName).To(Equal(DefaultRegistry))
 
 		By("get addon detail")
 		detailRes := get("/api/v1/addons/terraform-alibaba")


### PR DESCRIPTION
### Description of your changes

duplicate here https://github.com/oam-dev/kubevela/pull/2993

Add test for this feature

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->