### PR TITLE
Fix: addon timeout is not acturally tracked

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -432,7 +432,7 @@ func waitApplicationRunning(obj *v1beta1.Application) error {
 		applySpinnerNewSuffix(spinner, fmt.Sprintf("Waiting addon application running. It is now in phase: %s (timeout %d/%d seconds)...",
 			phase, timeConsumed, int(timeout.Seconds())))
 		if timeConsumed > int(timeout.Seconds()) {
-			return errors.Errorf("Enable timeout, please run \"vela status %s\" to check addon application status", obj.Name)
+			return errors.Errorf("Enable timeout, please run \"vela status %s -n vela-system\" to check addon application status", obj.Name)
 		}
 		time.Sleep(trackInterval)
 	}

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -432,7 +432,7 @@ func waitApplicationRunning(obj *v1beta1.Application) error {
 		applySpinnerNewSuffix(spinner, fmt.Sprintf("Waiting addon application running. It is now in phase: %s (timeout %d/%d seconds)...",
 			phase, timeConsumed, int(timeout.Seconds())))
 		if timeConsumed > int(timeout.Seconds()) {
-			return errors.Errorf("Enable timeout, please run \"vela status %s -n vela-system\" to check addon application status", obj.Name)
+			return errors.Errorf("Enabling timeout, please run \"vela status %s -n vela-system\" to check the status of the addon", obj.Name)
 		}
 		time.Sleep(trackInterval)
 	}

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -404,14 +404,14 @@ func (a *Addon) enable(ctx context.Context, k8sClient client.Client, name string
 	}
 	err = waitApplicationRunning(a.application)
 	if err != nil {
-		return errors.Wrap(err, "Error occurs when waiting addon applicatoin running")
+		return err
 	}
 	return nil
 }
 
 func waitApplicationRunning(obj *v1beta1.Application) error {
 	trackInterval := 5 * time.Second
-	timeout := 10 * time.Minute
+	timeout := 600 * time.Second
 	start := time.Now()
 	ctx := context.Background()
 	var app v1beta1.Application
@@ -431,6 +431,9 @@ func waitApplicationRunning(obj *v1beta1.Application) error {
 		timeConsumed := int(time.Since(start).Seconds())
 		applySpinnerNewSuffix(spinner, fmt.Sprintf("Waiting addon application running. It is now in phase: %s (timeout %d/%d seconds)...",
 			phase, timeConsumed, int(timeout.Seconds())))
+		if timeConsumed > int(timeout.Seconds()) {
+			return errors.Errorf("Enable timeout, please run \"vela status %s\" to check addon application status", obj.Name)
+		}
 		time.Sleep(trackInterval)
 	}
 }


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Now there is a bug: addon enable timeout won't quit the enable process.

![image](https://user-images.githubusercontent.com/47812250/144378954-fbf8c915-c892-4a9b-a3e3-4a50f5c6f727.png)

This PR:
1. fix addon enable timeout is not used
2. better addon enable fail message 


Signed-off-by: qiaozp <chivalry.pp@gmail.com>

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Test by build a binary with very short timeout, timeout fail like this:
![image](https://user-images.githubusercontent.com/47812250/144378581-a07cfe5c-587d-489b-a266-a7427ed08544.png)

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->