### PR TITLE
Fix: enable addon failed because the file name of the cue template is used as the component name

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -555,7 +555,7 @@ func renderCUETemplate(elem types.AddonElementFile, parameters string, args map[
 		return nil, err
 	}
 	comp := common2.ApplicationComponent{
-		Name: elem.Name,
+		Name: strings.ReplaceAll(elem.Name, ".", "-"),
 	}
 	err = yaml.Unmarshal(b, &comp)
 	if err != nil {


### PR DESCRIPTION
Fix bug: enable addon failed because the file name of the cue template is used as the component name


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->