### PR TITLE
Fix: query addon status api 500 because of secret

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -503,7 +503,7 @@ func renderNamespace(namespace string) *unstructured.Unstructured {
 func renderRawComponent(elem types.AddonElementFile) (*common2.ApplicationComponent, error) {
 	baseRawComponent := common2.ApplicationComponent{
 		Type: "raw",
-		Name: elem.Name,
+		Name: strings.ReplaceAll(elem.Name, ".", "-"),
 	}
 	obj, err := renderObject(elem)
 	if err != nil {
@@ -555,7 +555,7 @@ func renderCUETemplate(elem types.AddonElementFile, parameters string, args map[
 		return nil, err
 	}
 	comp := common2.ApplicationComponent{
-		Name: elem.Name,
+		Name: strings.ReplaceAll(elem.Name, ".", "-"),
 	}
 	err = yaml.Unmarshal(b, &comp)
 	if err != nil {

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -41,7 +41,7 @@ var paths = []string{
 var ossHandler http.HandlerFunc = func(rw http.ResponseWriter, req *http.Request) {
 	queryPath := strings.TrimPrefix(req.URL.Path, "/")
 
-	if strings.HasPrefix(req.URL.RawQuery, "prefix") {
+	if strings.Contains(req.URL.RawQuery, "prefix") {
 		prefix := req.URL.Query().Get("prefix")
 		res := ListBucketResult{
 			Files: []File{},

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -50,7 +50,7 @@ var ossHandler http.HandlerFunc = func(rw http.ResponseWriter, req *http.Request
 		for _, p := range paths {
 			if strings.HasPrefix(p, prefix) {
 				// Size 100 is for mock a file
-				res.Files = append(res.Files, File{Name: p,Size: 100})
+				res.Files = append(res.Files, File{Name: p, Size: 100})
 				res.Count += 1
 			}
 		}

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -44,12 +44,13 @@ var ossHandler http.HandlerFunc = func(rw http.ResponseWriter, req *http.Request
 	if strings.HasPrefix(req.URL.RawQuery, "prefix") {
 		prefix := req.URL.Query().Get("prefix")
 		res := ListBucketResult{
-			Files: []string{},
+			Files: []File{},
 			Count: 0,
 		}
 		for _, p := range paths {
 			if strings.HasPrefix(p, prefix) {
-				res.Files = append(res.Files, p)
+				// Size 100 is for mock a file
+				res.Files = append(res.Files, File{Name: p,Size: 100})
 				res.Count += 1
 			}
 		}

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -386,6 +386,7 @@ type ListBucketResult struct {
 	Count int    `xml:"KeyCount"`
 }
 
+// File is for oss xml parse
 type File struct {
 	Name string `xml:"Key"`
 	Size int    `xml:"Size"`

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -40,9 +40,9 @@ const (
 	// FileType means a file
 	FileType = "file"
 
-	bucketTmpl        = "%s//%s.%s"
+	bucketTmpl        = "%s://%s.%s"
 	singleOssFileTmpl = "%s/%s"
-	listOssFileTmpl   = "%s?prefix=%s"
+	listOssFileTmpl   = "%s?max-keys=1000&prefix=%s"
 )
 
 // Source is where to get addons
@@ -253,7 +253,15 @@ func (o *ossReader) Read(readPath string) (content string, subItem []Item, err e
 	if err != nil && err.Error() != EOFError {
 		return "", nil, err
 	}
-	if len(list.Files) == 1 && list.Files[0] == readPath {
+	var actualFiles []File
+	for _, f := range list.Files {
+		if f.Size > 0 {
+			actualFiles = append(actualFiles, f)
+		}
+	}
+	list.Files = actualFiles
+	list.Count = len(actualFiles)
+	if len(list.Files) == 1 && list.Files[0].Name == readPath {
 		resp, err = o.client.R().Get(fmt.Sprintf(singleOssFileTmpl, o.bucketEndPoint, readPath))
 		if err != nil {
 			return "", nil, err
@@ -270,13 +278,13 @@ func (o *ossReader) Read(readPath string) (content string, subItem []Item, err e
 	return "", nil, errors.Wrap(err, "read oss fail")
 }
 
-func convert2OssItem(files []string, nowPath string) []Item {
+func convert2OssItem(files []File, nowPath string) []Item {
 	const slash = "/"
 	var items []Item
 	ps := strings.Split(path.Clean(nowPath), slash)
 	pathExist := map[string]bool{}
 	for _, f := range files {
-		fPath := strings.Split(path.Clean(f), slash)
+		fPath := strings.Split(path.Clean(f.Name), slash)
 		if ps[0] != "." {
 			fPath = fPath[len(ps):]
 		}
@@ -286,7 +294,7 @@ func convert2OssItem(files []string, nowPath string) []Item {
 		}
 		pathExist[name] = true
 		item := OssItem{
-			path: f,
+			path: f.Name,
 			name: fPath[0],
 			tp:   FileType,
 		}
@@ -358,7 +366,10 @@ func NewAsyncReader(baseURL, dirOrBucket, token string, rdType ReaderType) (Asyn
 		if dirOrBucket == "" {
 			bucketEndPoint = ossURL.String()
 		} else {
-			bucketEndPoint = fmt.Sprintf(bucketTmpl, ossURL.Scheme, dirOrBucket, baseURL)
+			if ossURL.Scheme == "" {
+				ossURL.Scheme = "https"
+			}
+			bucketEndPoint = fmt.Sprintf(bucketTmpl, ossURL.Scheme, dirOrBucket, ossURL.Host)
 		}
 		return &ossReader{
 			baseReader:     bReader,
@@ -371,6 +382,11 @@ func NewAsyncReader(baseURL, dirOrBucket, token string, rdType ReaderType) (Asyn
 
 // ListBucketResult describe a file list from OSS
 type ListBucketResult struct {
-	Files []string `xml:"Contents>Key"`
-	Count int      `xml:"KeyCount"`
+	Files []File `xml:"Contents"`
+	Count int    `xml:"KeyCount"`
+}
+
+type File struct {
+	Name string `xml:"Key"`
+	Size int    `xml:"Size"`
 }

--- a/test/e2e-apiserver-test/addon_test.go
+++ b/test/e2e-apiserver-test/addon_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -52,10 +51,9 @@ func get(path string) *http.Response {
 var _ = Describe("Test addon rest api", func() {
 	createReq := apis.CreateAddonRegistryRequest{
 		Name: "test-addon-registry-1",
-		Git: &addon.GitAddonSource{
-			URL:   "https://github.com/oam-dev/catalog",
-			Path:  "addons/",
-			Token: os.Getenv("GITHUB_TOKEN"),
+		Oss: &addon.OSSAddonSource{
+			EndPoint: "https://oss-cn-hangzhou.aliyuncs.com",
+			Bucket:   "kubevela-addons",
 		},
 	}
 	It("should add a registry and list addons from it", func() {


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>

1. fix query addon status api 500 because of secret
2. fix read problems from oss

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->