### PR TITLE
Fix: mark test chart image in a fixed tag to avoid changed by release

### DIFF
--- a/charts/oam-runtime/values.yaml
+++ b/charts/oam-runtime/values.yaml
@@ -105,4 +105,4 @@ OAMSpecVer: "v0.2"
 test:
   app:
     repository: oamdev/busybox
-    tag: latest
+    tag: v1

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -126,7 +126,7 @@ multicluster:
 test:
   app:
     repository: oamdev/hello-world
-    tag: latest
+    tag: v1
   k8s:
     repository: oamdev/alpine-k8s
     tag: 1.18.2

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -125,4 +125,4 @@ multicluster:
 test:
   app:
     repository: oamdev/hello-world
-    tag: latest
+    tag: v1


### PR DESCRIPTION
### Description of your changes

We changed the test image tag in this PR #2623
while the image tag will be automatically changed in the release pipeline: https://github.com/oam-dev/kubevela/blob/release-1.1/.github/workflows/registry.yml#L117-L141

In this PR, I mark the tag as a fixed one.

Fixes #2869 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Already pushed to docker hub

![image](https://user-images.githubusercontent.com/2173670/144543230-3fe99afb-05e3-411d-ae79-3698abaed453.png)


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->