### PR TITLE
Fix: OSS read data race

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -102,12 +102,12 @@ func GetAddonsFromReader(r AsyncReader, opt ListOptions) ([]*types.Addon, error)
 	if err != nil {
 		return nil, err
 	}
+	var l sync.Mutex
 	for _, subItem := range items {
 		if subItem.GetType() != "dir" {
 			continue
 		}
 		wg.Add(1)
-		var l sync.Mutex
 		go func(item Item) {
 			defer wg.Done()
 			ar := r.WithNewAddonAndMutex()

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -96,7 +96,9 @@ func GetAddonsFromReader(r AsyncReader, opt ListOptions) ([]*types.Addon, error)
 	var addons []*types.Addon
 	var err error
 	var wg sync.WaitGroup
-	errChan := make(chan error, 1)
+	var errs []error
+	errCh := make(chan error)
+	waitCh := make(chan struct{})
 
 	_, items, err := r.Read(".")
 	if err != nil {
@@ -113,7 +115,7 @@ func GetAddonsFromReader(r AsyncReader, opt ListOptions) ([]*types.Addon, error)
 			ar := r.WithNewAddonAndMutex()
 			addonRes, err := GetSingleAddonFromReader(ar, ar.RelativePath(item), opt)
 			if err != nil {
-				errChan <- err
+				errCh <- err
 				return
 			}
 			l.Lock()
@@ -121,16 +123,41 @@ func GetAddonsFromReader(r AsyncReader, opt ListOptions) ([]*types.Addon, error)
 			l.Unlock()
 		}(subItem)
 	}
-	wg.Wait()
-	if len(errChan) != 0 {
-		return nil, <-errChan
+	// in another goroutine for wait group to finish
+	go func() {
+		wg.Wait()
+		close(waitCh)
+	}()
+forLoop:
+	for {
+		select {
+		case <-waitCh:
+			break forLoop
+		case err = <-errCh:
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) != 0 {
+		return addons, compactErrors("error(s) happen when reading from registry: ", errs)
 	}
 	return addons, nil
+}
+
+func compactErrors(message string, errs []error) error {
+	errForPrint := make([]string, 0)
+	for _, e := range errs {
+		errForPrint = append(errForPrint, e.Error())
+	}
+
+	return errors.New(message + strings.Join(errForPrint, ","))
+
 }
 
 // GetSingleAddonFromReader read single addon from Reader
 func GetSingleAddonFromReader(r AsyncReader, addonName string, opt ListOptions) (*types.Addon, error) {
 	var wg sync.WaitGroup
+	var errs []error
+	waitCh := make(chan struct{})
 	readOption := map[string]struct {
 		jumpConds bool
 		read      func(wg *sync.WaitGroup, reader AsyncReader, path string)
@@ -160,14 +187,32 @@ func GetSingleAddonFromReader(r AsyncReader, addonName string, opt ListOptions) 
 			go readMethod.read(&wg, r, r.RelativePath(item))
 		}
 	}
-	wg.Wait()
+	go func() {
+		wg.Wait()
+		close(waitCh)
+	}()
+
+forLoop:
+	for {
+		select {
+		case <-waitCh:
+			break forLoop
+		case err = <-r.ErrCh():
+			errs = append(errs, err)
+		}
+	}
 
 	if opt.GetParameter && r.Addon().Parameters != "" {
 		err = genAddonAPISchema(r.Addon())
 		if err != nil {
-			return nil, err
+			errs = append(errs, err)
 		}
 	}
+
+	if len(errs) != 0 {
+		return r.Addon(), compactErrors(fmt.Sprintf("error(s) happen when reading addon %s: ", addonName), errs)
+	}
+
 	return r.Addon(), nil
 }
 

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -39,6 +39,9 @@ var paths = []string{
 
 	"terraform/metadata.yaml",
 	"terraform-alibaba/metadata.yaml",
+
+	"test-error-addon/metadata.yaml",
+	"test-error-addon/resources/parameter.cue",
 }
 
 var ossHandler http.HandlerFunc = func(rw http.ResponseWriter, req *http.Request) {
@@ -98,7 +101,7 @@ func TestGetAddon(t *testing.T) {
 	assert.Assert(t, len(addon.Definitions) > 0)
 
 	addons, err := GetAddonsFromReader(reader, EnableLevelOptions)
-	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(err.Error(), "#parameter.example: preference mark not allowed at this position"))
 	assert.Equal(t, len(addons), 3)
 
 	// test listing from OSS will act like listing from directory

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -36,6 +36,9 @@ var paths = []string{
 	"example/resources/configmap.cue",
 	"example/resources/parameter.cue",
 	"example/resources/service/source-controller.yaml",
+
+	"terraform/metadata.yaml",
+	"terraform-alibaba/metadata.yaml",
 }
 
 var ossHandler http.HandlerFunc = func(rw http.ResponseWriter, req *http.Request) {
@@ -96,5 +99,11 @@ func TestGetAddon(t *testing.T) {
 
 	addons, err := GetAddonsFromReader(reader, EnableLevelOptions)
 	assert.NilError(t, err)
-	assert.Assert(t, len(addons) == 1)
+	assert.Equal(t, len(addons), 3)
+
+	// test listing from OSS will act like listing from directory
+	_, items, err := reader.Read("terraform")
+	assert.NilError(t, err)
+	assert.Equal(t, len(items), 1, "should list items only from terraform/ without terraform-alibaba/")
+	assert.Equal(t, items[0].GetPath(), "terraform/metadata.yaml")
 }

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -133,6 +133,8 @@ type AsyncReader interface {
 	Addon() *types.Addon
 	// SendErr to outside and quit
 	SendErr(err error)
+	// ErrCh will get the reader's channel to send error
+	ErrCh() chan error
 	// Mutex return an mutex for slice insert
 	Mutex() *sync.Mutex
 	// RelativePath return a relative path to GitHub repo/path or OSS bucket
@@ -159,6 +161,10 @@ func (b *baseReader) SendErr(err error) {
 	b.errChan <- err
 }
 
+func (b *baseReader) ErrCh() chan error {
+	return b.errChan
+}
+
 // Mutex to lock baseReader addon's slice
 func (b *baseReader) Mutex() *sync.Mutex {
 	return b.mutex
@@ -179,7 +185,7 @@ func (g *gitReader) WithNewAddonAndMutex() AsyncReader {
 	return &gitReader{
 		baseReader: baseReader{
 			a:       &types.Addon{},
-			errChan: make(chan error, 1),
+			errChan: make(chan error),
 			mutex:   &sync.Mutex{},
 		},
 		h: g.h,
@@ -318,7 +324,7 @@ func (o *ossReader) WithNewAddonAndMutex() AsyncReader {
 	return &ossReader{
 		baseReader: baseReader{
 			a:       &types.Addon{},
-			errChan: make(chan error, 1),
+			errChan: make(chan error),
 			mutex:   &sync.Mutex{},
 		},
 		bucketEndPoint: o.bucketEndPoint,
@@ -340,7 +346,7 @@ const (
 func NewAsyncReader(baseURL, dirOrBucket, token string, rdType ReaderType) (AsyncReader, error) {
 	bReader := baseReader{
 		a:       &types.Addon{},
-		errChan: make(chan error, 1),
+		errChan: make(chan error),
 		mutex:   &sync.Mutex{},
 	}
 	switch rdType {

--- a/pkg/addon/testdata/terraform-alibaba/metadata.yaml
+++ b/pkg/addon/testdata/terraform-alibaba/metadata.yaml
@@ -1,0 +1,15 @@
+name: terraform-alibaba
+version: 1.0.0
+description: Kubernetes Terraform Controller for Alibaba Cloud
+icon: https://avatars3.githubusercontent.com/aliyun
+url: https://registry.terraform.io/providers/aliyun/alicloud/latest
+
+tags:
+  - terraform provider
+
+deployTo:
+  control_plane: true
+  runtime_cluster: false
+
+dependencies:
+  - name: terraform

--- a/pkg/addon/testdata/terraform/metadata.yaml
+++ b/pkg/addon/testdata/terraform/metadata.yaml
@@ -1,0 +1,18 @@
+name: terraform
+version: 1.0.0
+description: Terraform Controller is a Kubernetes Controller for Terraform.
+icon: https://www.terraform.io/assets/images/logo-text-8c3ba8a6.svg
+url: https://terraform.io/
+
+tags:
+  - IaC
+  - cloud resource
+
+deployTo:
+  control_plane: true
+  runtime_cluster: false
+
+dependencies:
+  - name: fluxcd
+
+invisible: true

--- a/pkg/addon/testdata/test-error-addon/metadata.yaml
+++ b/pkg/addon/testdata/test-error-addon/metadata.yaml
@@ -1,0 +1,15 @@
+name: test-error-addon
+version: 1.0.0
+description: This is a addon for test when some error are in addon files
+icon: https://www.terraform.io/assets/images/logo-text-8c3ba8a6.svg
+url: https://terraform.io/
+
+tags: []
+
+deployTo:
+  control_plane: true
+  runtime_cluster: false
+
+dependencies: []
+
+invisible: false

--- a/pkg/addon/testdata/test-error-addon/resources/parameter.cue
+++ b/pkg/addon/testdata/test-error-addon/resources/parameter.cue
@@ -1,0 +1,4 @@
+parameter: {
+	// test wrong parameter
+	example: *"default"
+}

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -35,7 +35,6 @@ import (
 	"github.com/oam-dev/kubevela/apis/types"
 	pkgaddon "github.com/oam-dev/kubevela/pkg/addon"
 	"github.com/oam-dev/kubevela/pkg/apiserver/clients"
-	"github.com/oam-dev/kubevela/pkg/apiserver/datastore"
 	"github.com/oam-dev/kubevela/pkg/apiserver/log"
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	restutils "github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"

--- a/pkg/apiserver/rest/webservice/addon_registry.go
+++ b/pkg/apiserver/rest/webservice/addon_registry.go
@@ -127,12 +127,12 @@ func (s *addonRegistryWebService) deleteAddonRegistry(req *restful.Request, res 
 }
 
 func (s *addonRegistryWebService) listAddonRegistry(req *restful.Request, res *restful.Response) {
-	registrys, err := s.addonUsecase.ListAddonRegistries(req.Request.Context())
+	registries, err := s.addonUsecase.ListAddonRegistries(req.Request.Context())
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return
 	}
-	if err := res.WriteEntity(apis.ListAddonRegistryResponse{Registrys: registrys}); err != nil {
+	if err := res.WriteEntity(apis.ListAddonRegistryResponse{Registrys: registries}); err != nil {
 		bcode.ReturnError(req, res, err)
 		return
 	}

--- a/pkg/apiserver/rest/webservice/webservice.go
+++ b/pkg/apiserver/rest/webservice/webservice.go
@@ -65,7 +65,7 @@ func Init(ds datastore.DataStore) {
 	oamApplicationUsecase := usecase.NewOAMApplicationUsecase()
 	velaQLUsecase := usecase.NewVelaQLUsecase()
 	definitionUsecase := usecase.NewDefinitionUsecase()
-	addonUsecase := usecase.NewAddonUsecase(ds)
+	addonUsecase := usecase.NewAddonUsecase()
 	envBindingUsecase := usecase.NewEnvBindingUsecase(ds, workflowUsecase, definitionUsecase)
 	applicationUsecase := usecase.NewApplicationUsecase(ds, workflowUsecase, envBindingUsecase, deliveryTargetUsecase, definitionUsecase)
 	RegistWebService(NewClusterWebService(clusterUsecase))


### PR DESCRIPTION
### Description of your changes

Fix several problem.
1. When get `bucket.endpoint?prefix=terraform`, files in `terraform-alibaba` will be listed.(They all have "terraform" prefix) This will cause race. 
2. AddonRegistryMeta's Git or OSS can be set and should be access by SourceOf function.
3. Unify the interface

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->