### PR TITLE
Fix: use specific cli release download folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           path: ./_bin/sha256-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.txt
           retention-days: 1
 
-  upload-sha256sums-plugin-homebrew:
+  upload-plugin-homebrew:
     needs: build
     runs-on: ubuntu-latest
     name: upload-sha256sums
@@ -119,7 +119,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: sha256sums
+          path: cli-artifacts
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: cli-artifacts
       - shell: bash
+        working-directory: cli-artifacts
         run: |
           for file in *
           do
@@ -129,7 +134,7 @@ jobs:
         uses: actions/upload-release-asset@v1.0.2
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: sha256sums.txt
+          asset_path: cli-artifacts/sha256sums.txt
           asset_name: sha256sums.txt
           asset_content_type: text/plain
       - name: Update kubectl plugin version in krew-index


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

Fix the failed release pipeline: 

https://github.com/oam-dev/kubevela/runs/4441258128?check_suite_focus=true

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested in my repo https://github.com/wonderflow/kubevela/releases/tag/v0.1.20

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->