### PR TITLE
Feat: support addon definition in cue format

### DIFF
--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -196,13 +196,14 @@ type Addon struct {
 	UISchema  []*utils.UIParameter `json:"uiSchema"`
 
 	// More details about the addon, e.g. README
-	Detail        string               `json:"detail,omitempty"`
-	Definitions   []AddonElementFile   `json:"definitions"`
-	Parameters    string               `json:"parameters"`
-	CUETemplates  []AddonElementFile   `json:"cue_templates"`
-	YAMLTemplates []AddonElementFile   `json:"yaml_templates,omitempty"`
-	DefSchemas    []AddonElementFile   `json:"def_schemas,omitempty"`
-	AppTemplate   *v1beta1.Application `json:"app_template"`
+	Detail         string               `json:"detail,omitempty"`
+	Definitions    []AddonElementFile   `json:"definitions"`
+	CUEDefinitions []AddonElementFile   `json:"cue_definitions"`
+	Parameters     string               `json:"parameters"`
+	CUETemplates   []AddonElementFile   `json:"cue_templates"`
+	YAMLTemplates  []AddonElementFile   `json:"yaml_templates,omitempty"`
+	DefSchemas     []AddonElementFile   `json:"def_schemas,omitempty"`
+	AppTemplate    *v1beta1.Application `json:"app_template"`
 }
 
 // AddonMeta defines the format for a single addon

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/oam-dev/kubevela/pkg/definition"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -216,6 +217,13 @@ forLoop:
 	return r.Addon(), nil
 }
 
+// appendFile will add AddonElementFile to a slice, lock to avoid goroutine race
+func appendFile(reader AsyncReader, slice []types.AddonElementFile, file types.AddonElementFile) {
+	reader.Mutex().Lock()
+	slice = append(slice, file)
+	reader.Mutex().Unlock()
+}
+
 func readTemplate(wg *sync.WaitGroup, reader AsyncReader, readPath string) {
 	defer wg.Done()
 	data, _, err := reader.Read(readPath)
@@ -285,15 +293,12 @@ func readResFile(wg *sync.WaitGroup, reader AsyncReader, readPath string) {
 		reader.Addon().Parameters = b
 		return
 	}
+	file := types.AddonElementFile{Data: b, Name: path.Base(readPath)}
 	switch filepath.Ext(filename) {
 	case ".cue":
-		reader.Mutex().Lock()
-		reader.Addon().CUETemplates = append(reader.Addon().CUETemplates, types.AddonElementFile{Data: b, Name: path.Base(readPath)})
-		reader.Mutex().Unlock()
+		appendFile(reader, reader.Addon().CUETemplates, file)
 	default:
-		reader.Mutex().Lock()
-		reader.Addon().YAMLTemplates = append(reader.Addon().YAMLTemplates, types.AddonElementFile{Data: b, Name: path.Base(readPath)})
-		reader.Mutex().Unlock()
+		appendFile(reader, reader.Addon().YAMLTemplates, file)
 	}
 }
 
@@ -335,9 +340,14 @@ func readDefFile(wg *sync.WaitGroup, reader AsyncReader, readPath string) {
 		reader.SendErr(err)
 		return
 	}
-	reader.Mutex().Lock()
-	reader.Addon().Definitions = append(reader.Addon().Definitions, types.AddonElementFile{Data: b, Name: path.Base(readPath)})
-	reader.Mutex().Unlock()
+	filename := path.Base(readPath)
+	file := types.AddonElementFile{Data: b, Name: path.Base(readPath)}
+	switch filepath.Ext(filename) {
+	case ".cue":
+		appendFile(reader, reader.Addon().CUEDefinitions, file)
+	default:
+		appendFile(reader, reader.Addon().Definitions, file)
+	}
 }
 
 func readMetadata(wg *sync.WaitGroup, reader AsyncReader, readPath string) {
@@ -411,7 +421,7 @@ func genAddonAPISchema(addonRes *types.Addon) error {
 }
 
 // RenderAppAndResources render a K8s application
-func RenderAppAndResources(addon *types.Addon, args map[string]interface{}) (*v1beta1.Application, []*unstructured.Unstructured, []*unstructured.Unstructured, error) {
+func RenderAppAndResources(addon *types.Addon, args map[string]interface{}) (*v1beta1.Application, error) {
 	if args == nil {
 		args = map[string]interface{}{}
 	}
@@ -448,14 +458,14 @@ func RenderAppAndResources(addon *types.Addon, args map[string]interface{}) (*v1
 	for _, tmpl := range addon.YAMLTemplates {
 		comp, err := renderRawComponent(tmpl)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		app.Spec.Components = append(app.Spec.Components, *comp)
 	}
 	for _, tmpl := range addon.CUETemplates {
 		comp, err := renderCUETemplate(tmpl, addon.Parameters, args)
 		if err != nil {
-			return nil, nil, nil, ErrRenderCueTmpl
+			return nil, nil, ErrRenderCueTmpl
 		}
 		if addon.Name == "observability" && strings.HasSuffix(comp.Name, ".cue") {
 			comp.Name = strings.Split(comp.Name, ".cue")[0]
@@ -463,26 +473,7 @@ func RenderAppAndResources(addon *types.Addon, args map[string]interface{}) (*v1
 		app.Spec.Components = append(app.Spec.Components, *comp)
 	}
 
-	var schemaConfigmaps []*unstructured.Unstructured
-
-	var defObjs []*unstructured.Unstructured
-
 	if isDeployToRuntimeOnly(addon) {
-		// Runtime cluster mode needs to deploy definitions to control plane k8s.
-		for _, def := range addon.Definitions {
-			obj, err := renderObject(def)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			defObjs = append(defObjs, obj)
-		}
-		for _, teml := range addon.DefSchemas {
-			u, err := renderSchemaConfigmap(teml)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			schemaConfigmaps = append(schemaConfigmaps, u)
-		}
 		if app.Spec.Workflow == nil {
 			app.Spec.Workflow = &v1beta1.Workflow{Steps: make([]v1beta1.WorkflowStep, 0)}
 		}
@@ -499,14 +490,14 @@ func RenderAppAndResources(addon *types.Addon, args map[string]interface{}) (*v1
 		for _, def := range addon.Definitions {
 			comp, err := renderRawComponent(def)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, nil, err
 			}
 			app.Spec.Components = append(app.Spec.Components, *comp)
 		}
 		for _, teml := range addon.DefSchemas {
 			u, err := renderSchemaConfigmap(teml)
 			if err != nil {
-				return nil, nil, nil, err
+				return nil, nil, err
 			}
 			app.Spec.Components = append(app.Spec.Components, common2.ApplicationComponent{
 				Name:       teml.Name,
@@ -514,14 +505,51 @@ func RenderAppAndResources(addon *types.Addon, args map[string]interface{}) (*v1
 				Properties: util.Object2RawExtension(u),
 			})
 		}
+		// set to nil so workflow mode will be set to "DAG" automatically
 		if app.Spec.Workflow != nil && len(app.Spec.Workflow.Steps) == 0 {
 			app.Spec.Workflow = nil
 		}
 	}
 
-	return app, defObjs, schemaConfigmaps, nil
+	return app, nil
 }
 
+// RenderDefinitions render definition objects if needed
+func RenderDefinitions(addon *types.Addon) ([]*unstructured.Unstructured, error) {
+	defObjs := make([]*unstructured.Unstructured, 0)
+
+	if isDeployToRuntimeOnly(addon) {
+		// Runtime cluster mode needs to deploy definitions to control plane k8s.
+		for _, def := range addon.Definitions {
+			obj, err := renderObject(def)
+			if err != nil {
+				return nil, err
+			}
+			defObjs = append(defObjs, obj)
+		}
+
+		for _,cueDef:=range addon.CUEDefinitions{
+			def:=definition.Definition{Unstructured:unstructured.Unstructured{}}
+			def.FromCUEString(cueDef.Data,)
+		}
+	}
+	return nil, nil
+}
+
+func RenderDefinitionSchema(addon *types.Addon) ([]*unstructured.Unstructured, error) {
+	schemaConfigmaps := make([]*unstructured.Unstructured, 0)
+
+	if isDeployToRuntimeOnly(addon) {
+		for _, teml := range addon.DefSchemas {
+			u, err := renderSchemaConfigmap(teml)
+			if err != nil {
+				return nil, err
+			}
+			schemaConfigmaps = append(schemaConfigmaps, u)
+		}
+	}
+	return schemaConfigmaps, nil
+}
 func isDeployToRuntimeOnly(addon *types.Addon) bool {
 	if addon.DeployTo == nil {
 		return false
@@ -720,9 +748,19 @@ func (h *Handler) checkDependencies() error {
 }
 
 func (h *Handler) dispatchAddonResource() error {
-	app, defs, schemas, err := RenderAppAndResources(h.addon, h.args)
+	app, err := RenderAppAndResources(h.addon, h.args)
 	if err != nil {
 		return errors.Wrap(err, "render addon application fail")
+	}
+
+	defs, err := RenderDefinitions(h.addon)
+	if err != nil {
+		return errors.Wrap(err, "render addon definitions fail")
+	}
+
+	schemas, err := RenderDefinitionSchema(h.addon)
+	if err != nil {
+		return errors.Wrap(err, "render addon definitions' schema fail")
 	}
 
 	err = h.apply.Apply(h.ctx, app)

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -117,7 +117,7 @@ func TestRenderApp(t *testing.T) {
 	addon := baseAddon
 	app, err := RenderApp(&addon, nil, map[string]interface{}{})
 	assert.NilError(t, err, "render app fail")
-	assert.Equal(t, len(app.Spec.Components), 1)
+	assert.Equal(t, len(app.Spec.Components), 2)
 }
 
 func TestRenderDeploy2RuntimeAddon(t *testing.T) {
@@ -143,7 +143,7 @@ func TestRenderDeploy2RuntimeAddon(t *testing.T) {
 
 var baseAddon = types.Addon{
 	AddonMeta: types.AddonMeta{
-		Name: "test-render-cue-definition-addon",
+		Name:          "test-render-cue-definition-addon",
 		NeedNamespace: []string{"test-ns"},
 	},
 	CUEDefinitions: []types.AddonElementFile{

--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
@@ -28,8 +29,8 @@ import (
 )
 
 // EnableAddon will enable addon with dependency check, source is where addon from.
-func EnableAddon(ctx context.Context, addon *types.Addon, cli client.Client, apply apply.Applicator, source Source, args map[string]interface{}) error {
-	h := newAddonHandler(ctx, addon, cli, apply, source, args)
+func EnableAddon(ctx context.Context, addon *types.Addon, cli client.Client, apply apply.Applicator, config *rest.Config, source Source, args map[string]interface{}) error {
+	h := newAddonHandler(ctx, addon, cli, apply, config, source, args)
 	err := h.enableAddon()
 	if err != nil {
 		return err

--- a/pkg/definition/definition.go
+++ b/pkg/definition/definition.go
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+// Package definition contains some helper functions used in vela CLI
+// and vela addon mechanism
+package definition
 
 import (
 	"context"
@@ -41,10 +43,10 @@ import (
 )
 
 const (
-	// DefinitionDescriptionKey the key for accessing definition description
-	DefinitionDescriptionKey = "definition.oam.dev/description"
-	// DefinitionUserPrefix defines the prefix of user customized label or annotation
-	DefinitionUserPrefix = "custom.definition.oam.dev/"
+	// DescriptionKey the key for accessing definition description
+	DescriptionKey = "definition.oam.dev/description"
+	// UserPrefix defines the prefix of user customized label or annotation
+	UserPrefix = "custom.definition.oam.dev/"
 )
 
 var (
@@ -100,15 +102,15 @@ func (def *Definition) SetType(t string) error {
 func (def *Definition) ToCUE() (*cue.Value, string, error) {
 	annotations := map[string]string{}
 	for key, val := range def.GetAnnotations() {
-		if strings.HasPrefix(key, DefinitionUserPrefix) {
-			annotations[strings.TrimPrefix(key, DefinitionUserPrefix)] = val
+		if strings.HasPrefix(key, UserPrefix) {
+			annotations[strings.TrimPrefix(key, UserPrefix)] = val
 		}
 	}
-	desc := def.GetAnnotations()[DefinitionDescriptionKey]
+	desc := def.GetAnnotations()[DescriptionKey]
 	labels := map[string]string{}
 	for key, val := range def.GetLabels() {
-		if strings.HasPrefix(key, DefinitionUserPrefix) {
-			labels[strings.TrimPrefix(key, DefinitionUserPrefix)] = val
+		if strings.HasPrefix(key, UserPrefix) {
+			labels[strings.TrimPrefix(key, UserPrefix)] = val
 		}
 	}
 	spec := map[string]interface{}{}
@@ -193,13 +195,13 @@ func (def *Definition) FromCUE(val *cue.Value, templateString string) error {
 	}
 	annotations := map[string]string{}
 	for k, v := range def.GetAnnotations() {
-		if !strings.HasPrefix(k, DefinitionUserPrefix) && k != DefinitionDescriptionKey {
+		if !strings.HasPrefix(k, UserPrefix) && k != DescriptionKey {
 			annotations[k] = v
 		}
 	}
 	labels := map[string]string{}
 	for k, v := range def.GetLabels() {
-		if !strings.HasPrefix(k, DefinitionUserPrefix) {
+		if !strings.HasPrefix(k, UserPrefix) {
 			annotations[k] = v
 		}
 	}
@@ -242,14 +244,14 @@ func (def *Definition) FromCUE(val *cue.Value, templateString string) error {
 				if err != nil {
 					return err
 				}
-				annotations[DefinitionDescriptionKey] = desc
+				annotations[DescriptionKey] = desc
 			case "annotations":
 				var _annotations map[string]string
 				if err := codec.Encode(_value, &_annotations); err != nil {
 					return err
 				}
 				for _k, _v := range _annotations {
-					annotations[DefinitionUserPrefix+_k] = _v
+					annotations[UserPrefix+_k] = _v
 				}
 			case "labels":
 				var _labels map[string]string
@@ -257,7 +259,7 @@ func (def *Definition) FromCUE(val *cue.Value, templateString string) error {
 					return err
 				}
 				for _k, _v := range _labels {
-					labels[DefinitionUserPrefix+_k] = _v
+					labels[UserPrefix+_k] = _v
 				}
 			case "attributes":
 				if err := codec.Encode(_value, &spec); err != nil {

--- a/pkg/definition/definition_test.go
+++ b/pkg/definition/definition_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+package definition
 
 import (
 	"context"
@@ -33,12 +33,12 @@ func TestDefinitionBasicFunctions(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
 	def := &Definition{Unstructured: unstructured.Unstructured{}}
 	def.SetAnnotations(map[string]string{
-		DefinitionUserPrefix + "annotation": "annotation",
-		"other":                             "other",
+		UserPrefix + "annotation": "annotation",
+		"other":                   "other",
 	})
 	def.SetLabels(map[string]string{
-		DefinitionUserPrefix + "label": "label",
-		"other":                        "other",
+		UserPrefix + "label": "label",
+		"other":              "other",
 	})
 	def.SetName("test-trait")
 	def.SetGVK("TraitDefinition")

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/client-go/rest"
+
 	"github.com/gosuri/uitable"
 
 	"github.com/pkg/errors"
@@ -140,7 +142,7 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 			if err != nil {
 				return err
 			}
-			err = enableAddon(ctx, k8sClient, name, addonArgs)
+			err = enableAddon(ctx, k8sClient, c.Config, name, addonArgs)
 			if err != nil {
 				return err
 			}
@@ -212,7 +214,7 @@ func NewAddonStatusCommand(ioStream cmdutil.IOStreams) *cobra.Command {
 	}
 }
 
-func enableAddon(ctx context.Context, k8sClient client.Client, name string, args map[string]interface{}) error {
+func enableAddon(ctx context.Context, k8sClient client.Client, config *rest.Config, name string, args map[string]interface{}) error {
 	var addon *types.Addon
 	var err error
 	registryDS := pkgaddon.NewRegistryDataStore(k8sClient)
@@ -235,7 +237,7 @@ func enableAddon(ctx context.Context, k8sClient client.Client, name string, args
 		if addon == nil {
 			continue
 		}
-		err = pkgaddon.EnableAddon(ctx, addon, k8sClient, apply.NewAPIApplicator(k8sClient), source, args)
+		err = pkgaddon.EnableAddon(ctx, addon, k8sClient, apply.NewAPIApplicator(k8sClient), config, source, args)
 		if err != nil {
 			return err
 		}

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	pkgdef "github.com/oam-dev/kubevela/pkg/definition"
+
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +37,6 @@ import (
 	common3 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	common2 "github.com/oam-dev/kubevela/pkg/utils/common"
-	"github.com/oam-dev/kubevela/references/common"
 )
 
 const (
@@ -70,7 +71,7 @@ func createNamespacedTrait(c common2.Args, name string, ns string, t *testing.T)
 			Name:      name,
 			Namespace: ns,
 			Annotations: map[string]string{
-				common.DefinitionDescriptionKey: "My test-trait " + traitName,
+				pkgdef.DescriptionKey: "My test-trait " + traitName,
 			},
 		},
 		Spec: v1beta1.TraitDefinitionSpec{


### PR DESCRIPTION
### Description of your changes

Now our definition in addons are all YAML, This PR support definition's CUE format.

This makes it possible to develop addon definition with `vela def`

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

1. Add one test.: render an addon with a cue format definition.
2. test by hand
  - test cue definition
  ![image](https://user-images.githubusercontent.com/47812250/145148919-be2ec768-fc77-4240-8f8c-c98e04fcf1bc.png)
  - enable addon    
    ![image](https://user-images.githubusercontent.com/47812250/145149390-8ced8163-9a3b-4a52-945e-46bb1983e9ff.png)
  - check addon
    ![image](https://user-images.githubusercontent.com/47812250/145149464-4b4faed1-7a88-4e8f-8551-7b04bd58956a.png)
 

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->