### PR TITLE
Fix: move addon api to pkg/addon

### DIFF
--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -184,4 +184,3 @@ type Capability struct {
 	KubeTemplate  runtime.RawExtension   `json:"kubetemplate,omitempty"`
 	KubeParameter []common.KubeParameter `json:"kubeparameter,omitempty"`
 }
-

--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -20,13 +20,10 @@ import (
 	"encoding/json"
 
 	"cuelang.org/go/cue"
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"
 )
 
 // Source record the source of Capability
@@ -188,51 +185,3 @@ type Capability struct {
 	KubeParameter []common.KubeParameter `json:"kubeparameter,omitempty"`
 }
 
-// Addon contains all information represent an addon
-type Addon struct {
-	AddonMeta
-
-	APISchema *openapi3.Schema     `json:"schema"`
-	UISchema  []*utils.UIParameter `json:"uiSchema"`
-
-	// More details about the addon, e.g. README
-	Detail         string               `json:"detail,omitempty"`
-	Definitions    []AddonElementFile   `json:"definitions"`
-	CUEDefinitions []AddonElementFile   `json:"cue_definitions"`
-	Parameters     string               `json:"parameters"`
-	CUETemplates   []AddonElementFile   `json:"cue_templates"`
-	YAMLTemplates  []AddonElementFile   `json:"yaml_templates,omitempty"`
-	DefSchemas     []AddonElementFile   `json:"def_schemas,omitempty"`
-	AppTemplate    *v1beta1.Application `json:"app_template"`
-}
-
-// AddonMeta defines the format for a single addon
-type AddonMeta struct {
-	Name          string             `json:"name" validate:"required"`
-	Version       string             `json:"version"`
-	Description   string             `json:"description"`
-	Icon          string             `json:"icon"`
-	URL           string             `json:"url,omitempty"`
-	Tags          []string           `json:"tags,omitempty"`
-	DeployTo      *AddonDeployTo     `json:"deployTo,omitempty"`
-	Dependencies  []*AddonDependency `json:"dependencies,omitempty"`
-	NeedNamespace []string           `json:"needNamespace,omitempty"`
-	Invisible     bool               `json:"invisible"`
-}
-
-// AddonDeployTo defines where the addon to deploy to
-type AddonDeployTo struct {
-	ControlPlane   bool `json:"control_plane"`
-	RuntimeCluster bool `json:"runtime_cluster"`
-}
-
-// AddonDependency defines the other addons it depends on
-type AddonDependency struct {
-	Name string `json:"name,omitempty"`
-}
-
-// AddonElementFile can be addon's definition or addon's component
-type AddonElementFile struct {
-	Data string
-	Name string
-}

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -96,8 +96,8 @@ var (
 )
 
 // GetAddonsFromReader list addons from AsyncReader
-func GetAddonsFromReader(r AsyncReader, opt ListOptions) ([]*types.Addon, error) {
-	var addons []*types.Addon
+func GetAddonsFromReader(r AsyncReader, opt ListOptions) ([]*Addon, error) {
+	var addons []*Addon
 	var err error
 	var wg sync.WaitGroup
 	var errs []error
@@ -158,7 +158,7 @@ func compactErrors(message string, errs []error) error {
 }
 
 // GetSingleAddonFromReader read single addon from Reader
-func GetSingleAddonFromReader(r AsyncReader, addonName string, opt ListOptions) (*types.Addon, error) {
+func GetSingleAddonFromReader(r AsyncReader, addonName string, opt ListOptions) (*Addon, error) {
 	var wg sync.WaitGroup
 	var errs []error
 	waitCh := make(chan struct{})
@@ -221,7 +221,7 @@ forLoop:
 }
 
 // appendFile will add AddonElementFile to a slice, lock to avoid goroutine race
-func appendFile(lock *sync.Mutex, slice *[]types.AddonElementFile, file types.AddonElementFile) {
+func appendFile(lock *sync.Mutex, slice *[]AddonElementFile, file AddonElementFile) {
 	lock.Lock()
 	*slice = append(*slice, file)
 	lock.Unlock()
@@ -296,7 +296,7 @@ func readResFile(wg *sync.WaitGroup, reader AsyncReader, readPath string) {
 		reader.Addon().Parameters = b
 		return
 	}
-	file := types.AddonElementFile{Data: b, Name: path.Base(readPath)}
+	file := AddonElementFile{Data: b, Name: path.Base(readPath)}
 	switch filepath.Ext(filename) {
 	case ".cue":
 		appendFile(reader.Mutex(), &reader.Addon().CUETemplates, file)
@@ -313,7 +313,7 @@ func readDefSchemaFile(wg *sync.WaitGroup, reader AsyncReader, readPath string) 
 		reader.SendErr(err)
 		return
 	}
-	reader.Addon().DefSchemas = append(reader.Addon().DefSchemas, types.AddonElementFile{Data: b, Name: path.Base(readPath)})
+	reader.Addon().DefSchemas = append(reader.Addon().DefSchemas, AddonElementFile{Data: b, Name: path.Base(readPath)})
 }
 
 func readDefinitions(wg *sync.WaitGroup, reader AsyncReader, readPath string) {
@@ -344,7 +344,7 @@ func readDefFile(wg *sync.WaitGroup, reader AsyncReader, readPath string) {
 		return
 	}
 	filename := path.Base(readPath)
-	file := types.AddonElementFile{Data: b, Name: path.Base(readPath)}
+	file := AddonElementFile{Data: b, Name: path.Base(readPath)}
 	switch filepath.Ext(filename) {
 	case ".cue":
 		appendFile(reader.Mutex(), &reader.Addon().CUEDefinitions, file)
@@ -400,7 +400,7 @@ func (h *gitHelper) readRepo(relativePath string) (*github.RepositoryContent, []
 	return file, items, nil
 }
 
-func genAddonAPISchema(addonRes *types.Addon) error {
+func genAddonAPISchema(addonRes *Addon) error {
 	param, err := utils2.PrepareParameterCue(addonRes.Name, addonRes.Parameters)
 	if err != nil {
 		return err
@@ -424,7 +424,7 @@ func genAddonAPISchema(addonRes *types.Addon) error {
 }
 
 // RenderApp render a K8s application
-func RenderApp(addon *types.Addon, config *rest.Config, args map[string]interface{}) (*v1beta1.Application, error) {
+func RenderApp(addon *Addon, config *rest.Config, args map[string]interface{}) (*v1beta1.Application, error) {
 	if args == nil {
 		args = map[string]interface{}{}
 	}
@@ -530,7 +530,7 @@ func RenderApp(addon *types.Addon, config *rest.Config, args map[string]interfac
 }
 
 // RenderDefinitions render definition objects if needed
-func RenderDefinitions(addon *types.Addon, config *rest.Config) ([]*unstructured.Unstructured, error) {
+func RenderDefinitions(addon *Addon, config *rest.Config) ([]*unstructured.Unstructured, error) {
 	defObjs := make([]*unstructured.Unstructured, 0)
 
 	if isDeployToRuntimeOnly(addon) {
@@ -556,7 +556,7 @@ func RenderDefinitions(addon *types.Addon, config *rest.Config) ([]*unstructured
 }
 
 // RenderDefinitionSchema will render definitions' schema in addons.
-func RenderDefinitionSchema(addon *types.Addon) ([]*unstructured.Unstructured, error) {
+func RenderDefinitionSchema(addon *Addon) ([]*unstructured.Unstructured, error) {
 	schemaConfigmaps := make([]*unstructured.Unstructured, 0)
 
 	if isDeployToRuntimeOnly(addon) {
@@ -570,14 +570,14 @@ func RenderDefinitionSchema(addon *types.Addon) ([]*unstructured.Unstructured, e
 	}
 	return schemaConfigmaps, nil
 }
-func isDeployToRuntimeOnly(addon *types.Addon) bool {
+func isDeployToRuntimeOnly(addon *Addon) bool {
 	if addon.DeployTo == nil {
 		return false
 	}
 	return addon.DeployTo.RuntimeCluster
 }
 
-func renderObject(elem types.AddonElementFile) (*unstructured.Unstructured, error) {
+func renderObject(elem AddonElementFile) (*unstructured.Unstructured, error) {
 	obj := &unstructured.Unstructured{}
 	dec := k8syaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	_, _, err := dec.Decode([]byte(elem.Data), nil, obj)
@@ -596,7 +596,7 @@ func renderNamespace(namespace string) *unstructured.Unstructured {
 }
 
 // renderRawComponent will return a component in raw type from string
-func renderRawComponent(elem types.AddonElementFile) (*common2.ApplicationComponent, error) {
+func renderRawComponent(elem AddonElementFile) (*common2.ApplicationComponent, error) {
 	baseRawComponent := common2.ApplicationComponent{
 		Type: "raw",
 		Name: strings.ReplaceAll(elem.Name, ".", "-"),
@@ -609,7 +609,7 @@ func renderRawComponent(elem types.AddonElementFile) (*common2.ApplicationCompon
 	return &baseRawComponent, nil
 }
 
-func renderSchemaConfigmap(elem types.AddonElementFile) (*unstructured.Unstructured, error) {
+func renderSchemaConfigmap(elem AddonElementFile) (*unstructured.Unstructured, error) {
 	jsonData, err := yaml.YAMLToJSON([]byte(elem.Data))
 	if err != nil {
 		return nil, err
@@ -624,7 +624,7 @@ func renderSchemaConfigmap(elem types.AddonElementFile) (*unstructured.Unstructu
 }
 
 // renderCUETemplate will return a component from cue template
-func renderCUETemplate(elem types.AddonElementFile, parameters string, args map[string]interface{}) (*common2.ApplicationComponent, error) {
+func renderCUETemplate(elem AddonElementFile, parameters string, args map[string]interface{}) (*common2.ApplicationComponent, error) {
 	bt, err := json.Marshal(args)
 	if err != nil {
 		return nil, err
@@ -671,7 +671,7 @@ func Convert2AppName(name string) string {
 }
 
 // RenderArgsSecret render addon enable argument to secret
-func RenderArgsSecret(addon *types.Addon, args map[string]interface{}) *unstructured.Unstructured {
+func RenderArgsSecret(addon *Addon, args map[string]interface{}) *unstructured.Unstructured {
 	data := make(map[string]string)
 	for k, v := range args {
 		switch v := v.(type) {
@@ -705,7 +705,7 @@ func Convert2SecName(name string) string {
 // Handler helps addon enable, dependency-check, dispatch resources
 type Handler struct {
 	ctx    context.Context
-	addon  *types.Addon
+	addon  *Addon
 	config *rest.Config
 	cli    client.Client
 	apply  apply.Applicator
@@ -713,7 +713,7 @@ type Handler struct {
 	args   map[string]interface{}
 }
 
-func newAddonHandler(ctx context.Context, addon *types.Addon, cli client.Client, apply apply.Applicator, config *rest.Config, source Source, args map[string]interface{}) Handler {
+func newAddonHandler(ctx context.Context, addon *Addon, cli client.Client, apply apply.Applicator, config *rest.Config, source Source, args map[string]interface{}) Handler {
 	return Handler{
 		ctx:    ctx,
 		addon:  addon,

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
-
-	"github.com/oam-dev/kubevela/apis/types"
 )
 
 var paths = []string{
@@ -122,7 +120,7 @@ func TestRenderApp(t *testing.T) {
 
 func TestRenderDeploy2RuntimeAddon(t *testing.T) {
 	addonDeployToRuntime := baseAddon
-	addonDeployToRuntime.AddonMeta.DeployTo = &types.AddonDeployTo{
+	addonDeployToRuntime.Meta.DeployTo = &DeployTo{
 		ControlPlane:   true,
 		RuntimeCluster: true,
 	}
@@ -141,12 +139,12 @@ func TestRenderDeploy2RuntimeAddon(t *testing.T) {
 	assert.Equal(t, steps[len(steps)-1].Type, "deploy2runtime")
 }
 
-var baseAddon = types.Addon{
-	AddonMeta: types.AddonMeta{
+var baseAddon = Addon{
+	Meta: Meta{
 		Name:          "test-render-cue-definition-addon",
 		NeedNamespace: []string{"test-ns"},
 	},
-	CUEDefinitions: []types.AddonElementFile{
+	CUEDefinitions: []ElementFile{
 		{
 			Data: testCueDef,
 			Name: "test-def",

--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -29,7 +29,7 @@ import (
 )
 
 // EnableAddon will enable addon with dependency check, source is where addon from.
-func EnableAddon(ctx context.Context, addon *types.Addon, cli client.Client, apply apply.Applicator, config *rest.Config, source Source, args map[string]interface{}) error {
+func EnableAddon(ctx context.Context, addon *Addon, cli client.Client, apply apply.Applicator, config *rest.Config, source Source, args map[string]interface{}) error {
 	h := newAddonHandler(ctx, addon, cli, apply, config, source, args)
 	err := h.enableAddon()
 	if err != nil {

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/go-github/v32/github"
 	"github.com/pkg/errors"
 
-	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/utils"
 )
 
@@ -47,8 +46,8 @@ const (
 
 // Source is where to get addons
 type Source interface {
-	GetAddon(name string, opt ListOptions) (*types.Addon, error)
-	ListAddons(opt ListOptions) ([]*types.Addon, error)
+	GetAddon(name string, opt ListOptions) (*Addon, error)
+	ListAddons(opt ListOptions) ([]*Addon, error)
 }
 
 // GitAddonSource defines the information about the Git as addon source
@@ -65,7 +64,7 @@ type OSSAddonSource struct {
 }
 
 // GetAddon from OSSAddonSource
-func (o *OSSAddonSource) GetAddon(name string, opt ListOptions) (*types.Addon, error) {
+func (o *OSSAddonSource) GetAddon(name string, opt ListOptions) (*Addon, error) {
 	reader, err := NewAsyncReader(o.EndPoint, o.Bucket, "", ossType)
 	if err != nil {
 		return nil, err
@@ -78,7 +77,7 @@ func (o *OSSAddonSource) GetAddon(name string, opt ListOptions) (*types.Addon, e
 }
 
 // ListAddons from OSSAddonSource
-func (o *OSSAddonSource) ListAddons(opt ListOptions) ([]*types.Addon, error) {
+func (o *OSSAddonSource) ListAddons(opt ListOptions) ([]*Addon, error) {
 	reader, err := NewAsyncReader(o.EndPoint, o.Bucket, "", ossType)
 	if err != nil {
 		return nil, err
@@ -91,7 +90,7 @@ func (o *OSSAddonSource) ListAddons(opt ListOptions) ([]*types.Addon, error) {
 }
 
 // GetAddon get an addon info from GitAddonSource, can be used for get or enable
-func (git *GitAddonSource) GetAddon(name string, opt ListOptions) (*types.Addon, error) {
+func (git *GitAddonSource) GetAddon(name string, opt ListOptions) (*Addon, error) {
 	reader, err := NewAsyncReader(git.URL, git.Path, git.Token, gitType)
 	if err != nil {
 		return nil, err
@@ -104,7 +103,7 @@ func (git *GitAddonSource) GetAddon(name string, opt ListOptions) (*types.Addon,
 }
 
 // ListAddons list addons' info from GitAddonSource
-func (git *GitAddonSource) ListAddons(opt ListOptions) ([]*types.Addon, error) {
+func (git *GitAddonSource) ListAddons(opt ListOptions) ([]*Addon, error) {
 	r, err := NewAsyncReader(git.URL, git.Path, git.Token, "git")
 	if err != nil {
 		return nil, err
@@ -130,7 +129,7 @@ type AsyncReader interface {
 	// Read should accept relative path to github repo/path or OSS bucket
 	Read(path string) (content string, subItem []Item, err error)
 	// Addon returns a addon to be readed
-	Addon() *types.Addon
+	Addon() *Addon
 	// SendErr to outside and quit
 	SendErr(err error)
 	// ErrCh will get the reader's channel to send error
@@ -145,14 +144,14 @@ type AsyncReader interface {
 
 // baseReader will contain basic parts for async reading addon file
 type baseReader struct {
-	a       *types.Addon
+	a       *Addon
 	errChan chan error
 	// mutex is needed when append to addon's Definitions/CUETemplate/YAMLTemplate slices
 	mutex *sync.Mutex
 }
 
 // Addon for baseReader
-func (b *baseReader) Addon() *types.Addon {
+func (b *baseReader) Addon() *Addon {
 	return b.a
 }
 
@@ -184,7 +183,7 @@ type gitReader struct {
 func (g *gitReader) WithNewAddonAndMutex() AsyncReader {
 	return &gitReader{
 		baseReader: baseReader{
-			a:       &types.Addon{},
+			a:       &Addon{},
 			errChan: make(chan error),
 			mutex:   &sync.Mutex{},
 		},
@@ -323,7 +322,7 @@ func (o *ossReader) RelativePath(item Item) string {
 func (o *ossReader) WithNewAddonAndMutex() AsyncReader {
 	return &ossReader{
 		baseReader: baseReader{
-			a:       &types.Addon{},
+			a:       &Addon{},
 			errChan: make(chan error),
 			mutex:   &sync.Mutex{},
 		},
@@ -345,7 +344,7 @@ const (
 // 2. OSS endpoint and bucket
 func NewAsyncReader(baseURL, dirOrBucket, token string, rdType ReaderType) (AsyncReader, error) {
 	bReader := baseReader{
-		a:       &types.Addon{},
+		a:       &Addon{},
 		errChan: make(chan error),
 		mutex:   &sync.Mutex{},
 	}

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -2,55 +2,56 @@ package addon
 
 import (
 	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"
 )
 
 // Addon contains all information represent an addon
 type Addon struct {
-	AddonMeta
+	Meta
 
 	APISchema *openapi3.Schema     `json:"schema"`
 	UISchema  []*utils.UIParameter `json:"uiSchema"`
 
 	// More details about the addon, e.g. README
 	Detail         string               `json:"detail,omitempty"`
-	Definitions    []AddonElementFile   `json:"definitions"`
-	CUEDefinitions []AddonElementFile   `json:"cue_definitions"`
+	Definitions    []ElementFile   `json:"definitions"`
+	CUEDefinitions []ElementFile   `json:"cue_definitions"`
 	Parameters     string               `json:"parameters"`
-	CUETemplates   []AddonElementFile   `json:"cue_templates"`
-	YAMLTemplates  []AddonElementFile   `json:"yaml_templates,omitempty"`
-	DefSchemas     []AddonElementFile   `json:"def_schemas,omitempty"`
+	CUETemplates   []ElementFile   `json:"cue_templates"`
+	YAMLTemplates  []ElementFile   `json:"yaml_templates,omitempty"`
+	DefSchemas     []ElementFile   `json:"def_schemas,omitempty"`
 	AppTemplate    *v1beta1.Application `json:"app_template"`
 }
 
-// AddonMeta defines the format for a single addon
-type AddonMeta struct {
-	Name          string             `json:"name" validate:"required"`
-	Version       string             `json:"version"`
-	Description   string             `json:"description"`
-	Icon          string             `json:"icon"`
-	URL           string             `json:"url,omitempty"`
-	Tags          []string           `json:"tags,omitempty"`
-	DeployTo      *AddonDeployTo     `json:"deployTo,omitempty"`
-	Dependencies  []*AddonDependency `json:"dependencies,omitempty"`
-	NeedNamespace []string           `json:"needNamespace,omitempty"`
-	Invisible     bool               `json:"invisible"`
+// Meta defines the format for a single addon
+type Meta struct {
+	Name          string        `json:"name" validate:"required"`
+	Version       string        `json:"version"`
+	Description   string        `json:"description"`
+	Icon          string        `json:"icon"`
+	URL           string        `json:"url,omitempty"`
+	Tags          []string      `json:"tags,omitempty"`
+	DeployTo      *DeployTo     `json:"deployTo,omitempty"`
+	Dependencies  []*Dependency `json:"dependencies,omitempty"`
+	NeedNamespace []string      `json:"needNamespace,omitempty"`
+	Invisible     bool          `json:"invisible"`
 }
 
-// AddonDeployTo defines where the addon to deploy to
-type AddonDeployTo struct {
+// DeployTo defines where the addon to deploy to
+type DeployTo struct {
 	ControlPlane   bool `json:"control_plane"`
 	RuntimeCluster bool `json:"runtime_cluster"`
 }
 
-// AddonDependency defines the other addons it depends on
-type AddonDependency struct {
+// Dependency defines the other addons it depends on
+type Dependency struct {
 	Name string `json:"name,omitempty"`
 }
 
-// AddonElementFile can be addon's definition or addon's component
-type AddonElementFile struct {
+// ElementFile can be addon's definition or addon's component
+type ElementFile struct {
 	Data string
 	Name string
 }

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package addon
 
 import (

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -1,0 +1,56 @@
+package addon
+
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"
+)
+
+// Addon contains all information represent an addon
+type Addon struct {
+	AddonMeta
+
+	APISchema *openapi3.Schema     `json:"schema"`
+	UISchema  []*utils.UIParameter `json:"uiSchema"`
+
+	// More details about the addon, e.g. README
+	Detail         string               `json:"detail,omitempty"`
+	Definitions    []AddonElementFile   `json:"definitions"`
+	CUEDefinitions []AddonElementFile   `json:"cue_definitions"`
+	Parameters     string               `json:"parameters"`
+	CUETemplates   []AddonElementFile   `json:"cue_templates"`
+	YAMLTemplates  []AddonElementFile   `json:"yaml_templates,omitempty"`
+	DefSchemas     []AddonElementFile   `json:"def_schemas,omitempty"`
+	AppTemplate    *v1beta1.Application `json:"app_template"`
+}
+
+// AddonMeta defines the format for a single addon
+type AddonMeta struct {
+	Name          string             `json:"name" validate:"required"`
+	Version       string             `json:"version"`
+	Description   string             `json:"description"`
+	Icon          string             `json:"icon"`
+	URL           string             `json:"url,omitempty"`
+	Tags          []string           `json:"tags,omitempty"`
+	DeployTo      *AddonDeployTo     `json:"deployTo,omitempty"`
+	Dependencies  []*AddonDependency `json:"dependencies,omitempty"`
+	NeedNamespace []string           `json:"needNamespace,omitempty"`
+	Invisible     bool               `json:"invisible"`
+}
+
+// AddonDeployTo defines where the addon to deploy to
+type AddonDeployTo struct {
+	ControlPlane   bool `json:"control_plane"`
+	RuntimeCluster bool `json:"runtime_cluster"`
+}
+
+// AddonDependency defines the other addons it depends on
+type AddonDependency struct {
+	Name string `json:"name,omitempty"`
+}
+
+// AddonElementFile can be addon's definition or addon's component
+type AddonElementFile struct {
+	Data string
+	Name string
+}

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -32,12 +32,12 @@ type Addon struct {
 
 	// More details about the addon, e.g. README
 	Detail         string               `json:"detail,omitempty"`
-	Definitions    []ElementFile   `json:"definitions"`
-	CUEDefinitions []ElementFile   `json:"cue_definitions"`
+	Definitions    []ElementFile        `json:"definitions"`
+	CUEDefinitions []ElementFile        `json:"cue_definitions"`
 	Parameters     string               `json:"parameters"`
-	CUETemplates   []ElementFile   `json:"cue_templates"`
-	YAMLTemplates  []ElementFile   `json:"yaml_templates,omitempty"`
-	DefSchemas     []ElementFile   `json:"def_schemas,omitempty"`
+	CUETemplates   []ElementFile        `json:"cue_templates"`
+	YAMLTemplates  []ElementFile        `json:"yaml_templates,omitempty"`
+	DefSchemas     []ElementFile        `json:"def_schemas,omitempty"`
 	AppTemplate    *v1beta1.Application `json:"app_template"`
 }
 

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -97,7 +97,7 @@ type EnableAddonRequest struct {
 
 // ListAddonResponse defines the format for addon list response
 type ListAddonResponse struct {
-	Addons []*types.AddonMeta `json:"addons"`
+	Addons []*addon.Meta `json:"addons"`
 }
 
 // ListEnabledAddonResponse defines the format for enabled addon list response
@@ -107,7 +107,7 @@ type ListEnabledAddonResponse struct {
 
 // DetailAddonResponse defines the format for showing the addon details
 type DetailAddonResponse struct {
-	types.AddonMeta
+	addon.Meta
 
 	APISchema *openapi3.Schema     `json:"schema"`
 	UISchema  []*utils.UIParameter `json:"uiSchema"`

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -61,8 +61,8 @@ type AddonUsecase interface {
 	UpdateAddon(ctx context.Context, name string, args apis.EnableAddonRequest) error
 }
 
-// AddonImpl2AddonRes convert types.Addon to the type apiserver need
-func AddonImpl2AddonRes(impl *types.Addon) (*apis.DetailAddonResponse, error) {
+// AddonImpl2AddonRes convert pkgaddon.Addon to the type apiserver need
+func AddonImpl2AddonRes(impl *pkgaddon.Addon) (*apis.DetailAddonResponse, error) {
 	var defs []*apis.AddonDefinition
 	for _, def := range impl.Definitions {
 		obj := &unstructured.Unstructured{}
@@ -115,7 +115,7 @@ type addonUsecaseImpl struct {
 
 // GetAddon will get addon information
 func (u *addonUsecaseImpl) GetAddon(ctx context.Context, name string, registry string) (*apis.DetailAddonResponse, error) {
-	var addon *types.Addon
+	var addon *pkgaddon.Addon
 	var err error
 	var exist bool
 
@@ -200,8 +200,8 @@ func (u *addonUsecaseImpl) StatusAddon(ctx context.Context, name string) (*apis.
 }
 
 func (u *addonUsecaseImpl) ListAddons(ctx context.Context, registry, query string) ([]*apis.DetailAddonResponse, error) {
-	var addons []*types.Addon
-	var listAddons []*types.Addon
+	var addons []*pkgaddon.Addon
+	var listAddons []*pkgaddon.Addon
 	rs, err := u.ListAddonRegistries(ctx)
 	if err != nil {
 		return nil, err
@@ -238,7 +238,7 @@ func (u *addonUsecaseImpl) ListAddons(ctx context.Context, registry, query strin
 	}
 
 	if query != "" {
-		var filtered []*types.Addon
+		var filtered []*pkgaddon.Addon
 		for i, addon := range addons {
 			if strings.Contains(addon.Name, query) || strings.Contains(addon.Description, query) {
 				filtered = append(filtered, addons[i])
@@ -338,7 +338,7 @@ func (u *addonUsecaseImpl) ListAddonRegistries(ctx context.Context) ([]*apis.Add
 	return list, nil
 }
 
-func (u *addonUsecaseImpl) tryGetAddonFromCache(registry, addonName string) (*types.Addon, bool) {
+func (u *addonUsecaseImpl) tryGetAddonFromCache(registry, addonName string) (*pkgaddon.Addon, bool) {
 	if u.isRegistryCacheUpToDate(registry) {
 		addons := u.getRegistryCache(registry)
 		for _, a := range addons {
@@ -351,7 +351,7 @@ func (u *addonUsecaseImpl) tryGetAddonFromCache(registry, addonName string) (*ty
 }
 
 func (u *addonUsecaseImpl) EnableAddon(ctx context.Context, name string, args apis.EnableAddonRequest) error {
-	var addon *types.Addon
+	var addon *pkgaddon.Addon
 	var err error
 	registries, err := u.ListAddonRegistries(ctx)
 	if err != nil {
@@ -379,11 +379,11 @@ func (u *addonUsecaseImpl) EnableAddon(ctx context.Context, name string, args ap
 	return bcode.ErrAddonNotExist
 }
 
-func (u *addonUsecaseImpl) getRegistryCache(name string) []*types.Addon {
-	return u.addonRegistryCache[name].GetData().([]*types.Addon)
+func (u *addonUsecaseImpl) getRegistryCache(name string) []*pkgaddon.Addon {
+	return u.addonRegistryCache[name].GetData().([]*pkgaddon.Addon)
 }
 
-func (u *addonUsecaseImpl) putRegistryCache(name string, addons []*types.Addon) {
+func (u *addonUsecaseImpl) putRegistryCache(name string, addons []*pkgaddon.Addon) {
 	u.addonRegistryCache[name] = restutils.NewMemoryCache(addons, time.Minute*10)
 }
 
@@ -436,7 +436,7 @@ func (u *addonUsecaseImpl) UpdateAddon(ctx context.Context, name string, args ap
 		return err
 	}
 
-	var addon *types.Addon
+	var addon *pkgaddon.Addon
 	registries, err := u.ListAddonRegistries(ctx)
 	if err != nil {
 		return err
@@ -472,7 +472,7 @@ func addonRegistryModelFromCreateAddonRegistryRequest(req apis.CreateAddonRegist
 	}
 }
 
-func mergeAddons(a1, a2 []*types.Addon) []*types.Addon {
+func mergeAddons(a1, a2 []*pkgaddon.Addon) []*pkgaddon.Addon {
 	for _, item := range a2 {
 		if hasAddon(a1, item.Name) {
 			continue
@@ -482,7 +482,7 @@ func mergeAddons(a1, a2 []*types.Addon) []*types.Addon {
 	return a1
 }
 
-func hasAddon(addons []*types.Addon, name string) bool {
+func hasAddon(addons []*pkgaddon.Addon, name string) bool {
 	for _, addon := range addons {
 		if addon.Name == name {
 			return true

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -78,7 +78,7 @@ func AddonImpl2AddonRes(impl *pkgaddon.Addon) (*apis.DetailAddonResponse, error)
 		})
 	}
 	return &apis.DetailAddonResponse{
-		AddonMeta:   impl.AddonMeta,
+		Meta:        impl.Meta,
 		APISchema:   impl.APISchema,
 		UISchema:    impl.UISchema,
 		Detail:      impl.Detail,

--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -20,8 +20,7 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 
-	"github.com/oam-dev/kubevela/apis/types"
-
+	pkgaddon "github.com/oam-dev/kubevela/pkg/addon"
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/usecase"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
@@ -123,10 +122,10 @@ func (s *addonWebService) listAddons(req *restful.Request, res *restful.Response
 		return
 	}
 
-	var addons []*types.AddonMeta
+	var addons []*pkgaddon.Meta
 
 	for _, d := range detailAddons {
-		addons = append(addons, &d.AddonMeta)
+		addons = append(addons, &d.Meta)
 	}
 
 	err = res.WriteEntity(apis.ListAddonResponse{Addons: addons})

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -215,7 +215,7 @@ func NewAddonStatusCommand(ioStream cmdutil.IOStreams) *cobra.Command {
 }
 
 func enableAddon(ctx context.Context, k8sClient client.Client, config *rest.Config, name string, args map[string]interface{}) error {
-	var addon *types.Addon
+	var addon *pkgaddon.Addon
 	var err error
 	registryDS := pkgaddon.NewRegistryDataStore(k8sClient)
 	registries, err := registryDS.ListRegistries(ctx)
@@ -269,7 +269,7 @@ func statusAddon(name string) error {
 }
 
 func listAddons(ctx context.Context, registry string) error {
-	var addons []*types.Addon
+	var addons []*pkgaddon.Addon
 	var err error
 	registryDS := pkgaddon.NewRegistryDataStore(clt)
 	registries, err := registryDS.ListRegistries(ctx)
@@ -362,7 +362,7 @@ func fetchAddonStatus(ctx context.Context, client client.Client, name string) (s
 	return statusEnabling, nil
 }
 
-func mergeAddons(a1, a2 []*types.Addon) []*types.Addon {
+func mergeAddons(a1, a2 []*pkgaddon.Addon) []*pkgaddon.Addon {
 	for _, item := range a2 {
 		if hasAddon(a1, item.Name) {
 			continue
@@ -372,7 +372,7 @@ func mergeAddons(a1, a2 []*types.Addon) []*types.Addon {
 	return a1
 }
 
-func hasAddon(addons []*types.Addon, name string) bool {
+func hasAddon(addons []*pkgaddon.Addon, name string) bool {
 	for _, addon := range addons {
 		if addon.Name == name {
 			return true


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Addon's api shouldn't be in types.go. It will block sync api to kubevela-api-core. This PR move it to pkg/addon. 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->