### PR TITLE
Feat: support automatically creating scaler trait for webservice component

### DIFF
--- a/pkg/apiserver/rest/usecase/application_test.go
+++ b/pkg/apiserver/rest/usecase/application_test.go
@@ -89,10 +89,17 @@ var _ = Describe("Test application usecase function", func() {
 				Description: "test env",
 				TargetNames: []string{"test-target"},
 			}},
+			Component: &v1.CreateComponentRequest{
+				Name:          "component-name",
+				ComponentType: "webservice",
+			},
 		}
 		base, err := appUsecase.CreateApplication(context.TODO(), req)
 		Expect(err).Should(BeNil())
 		Expect(cmp.Diff(base.Description, req.Description)).Should(BeEmpty())
+		detail, err := appUsecase.DetailComponent(context.TODO(), &model.Application{Name: "test-app", Project: testProject}, "component-name")
+		Expect(err).Should(BeNil())
+		Expect(cmp.Diff(len(detail.Traits), 1)).Should(BeEmpty())
 
 		_, err = appUsecase.CreateApplication(context.TODO(), req)
 		equal := cmp.Equal(err, bcode.ErrApplicationExist, cmpopts.EquateErrors())

--- a/pkg/apiserver/rest/usecase/testdata/ui-schema.yaml
+++ b/pkg/apiserver/rest/usecase/testdata/ui-schema.yaml
@@ -51,6 +51,12 @@
     - valueFrom
     label: Add By Secret
   subParameters:
+  - description: The value of the environment variable
+    jsonKey: value
+    label: Value
+    sort: 100
+    uiType: Input
+    validate: {}
   - description: Specifies a source the value of this var should come from
     jsonKey: valueFrom
     label: Secret Selector
@@ -88,12 +94,6 @@
     uiType: Input
     validate:
       required: true
-  - description: The value of the environment variable
-    jsonKey: value
-    label: Value
-    sort: 100
-    uiType: Input
-    validate: {}
   uiType: Structs
   validate: {}
 - description: Instructions for assessing whether the container is in a suitable state
@@ -102,6 +102,70 @@
   label: ReadinessProbe
   sort: 13
   subParameters:
+  - description: Instructions for assessing container health by executing an HTTP
+      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
+      MUST be specified. This attribute is mutually exclusive with both the exec attribute
+      and the tcpSocket attribute.
+    jsonKey: httpGet
+    label: HttpGet
+    sort: 100
+    subParameters:
+    - description: ""
+      jsonKey: httpHeaders
+      label: HttpHeaders
+      sort: 100
+      subParameters:
+      - description: ""
+        jsonKey: value
+        label: Value
+        sort: 100
+        uiType: Input
+        validate:
+          required: true
+      - description: ""
+        jsonKey: name
+        label: Name
+        sort: 100
+        uiType: Input
+        validate:
+          required: true
+      uiType: Structs
+      validate: {}
+    - description: The endpoint, relative to the port, to which the HTTP GET request
+        should be directed.
+      jsonKey: path
+      label: Path
+      sort: 100
+      uiType: Input
+      validate:
+        required: true
+    - description: The TCP socket within the container to which the HTTP GET request
+        should be directed.
+      jsonKey: port
+      label: Port
+      sort: 100
+      uiType: Number
+      validate:
+        required: true
+    uiType: Group
+    validate: {}
+  - description: Number of seconds after the container is started before the first
+      probe is initiated.
+    jsonKey: initialDelaySeconds
+    label: InitialDelaySeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 0
+      required: true
+  - description: How often, in seconds, to execute the probe.
+    jsonKey: periodSeconds
+    label: PeriodSeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 10
+      required: true
   - description: Minimum consecutive successes for the probe to be considered successful
       after having failed.
     jsonKey: successThreshold
@@ -165,70 +229,6 @@
     uiType: Number
     validate:
       defaultValue: 3
-      required: true
-  - description: Instructions for assessing container health by executing an HTTP
-      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
-      MUST be specified. This attribute is mutually exclusive with both the exec attribute
-      and the tcpSocket attribute.
-    jsonKey: httpGet
-    label: HttpGet
-    sort: 100
-    subParameters:
-    - description: ""
-      jsonKey: httpHeaders
-      label: HttpHeaders
-      sort: 100
-      subParameters:
-      - description: ""
-        jsonKey: name
-        label: Name
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      - description: ""
-        jsonKey: value
-        label: Value
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      uiType: Structs
-      validate: {}
-    - description: The endpoint, relative to the port, to which the HTTP GET request
-        should be directed.
-      jsonKey: path
-      label: Path
-      sort: 100
-      uiType: Input
-      validate:
-        required: true
-    - description: The TCP socket within the container to which the HTTP GET request
-        should be directed.
-      jsonKey: port
-      label: Port
-      sort: 100
-      uiType: Number
-      validate:
-        required: true
-    uiType: Group
-    validate: {}
-  - description: Number of seconds after the container is started before the first
-      probe is initiated.
-    jsonKey: initialDelaySeconds
-    label: InitialDelaySeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 0
-      required: true
-  - description: How often, in seconds, to execute the probe.
-    jsonKey: periodSeconds
-    label: PeriodSeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 10
       required: true
   uiType: Group
   validate: {}
@@ -367,21 +367,6 @@
       required: true
   uiType: Group
   validate: {}
-- description: Which port do you want customer traffic sent to
-  disable: true
-  jsonKey: port
-  label: Port
-  sort: 100
-  uiType: Number
-  validate:
-    defaultValue: 80
-    required: true
-- description: Specify image pull secrets for your service
-  jsonKey: imagePullSecrets
-  label: ImagePullSecrets
-  sort: 100
-  uiType: Strings
-  validate: {}
 - description: Declare volumes and volumeMounts
   disable: true
   jsonKey: volumes
@@ -429,4 +414,19 @@
   uiType: Switch
   validate:
     defaultValue: false
+    required: true
+- description: Specify image pull secrets for your service
+  jsonKey: imagePullSecrets
+  label: ImagePullSecrets
+  sort: 100
+  uiType: Strings
+  validate: {}
+- description: Which port do you want customer traffic sent to
+  disable: true
+  jsonKey: port
+  label: Port
+  sort: 100
+  uiType: Number
+  validate:
+    defaultValue: 80
     required: true


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

The purpose of automatically creating traits is as follows:

1. The replications parameter is not included in the`webservice` component.
2. Provide users with trait best practices.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.