### PR TITLE
Fix: add design docs for ResourceTracker

### DIFF
--- a/design/vela-core/resourcetracker_design.md
+++ b/design/vela-core/resourcetracker_design.md
@@ -1,0 +1,56 @@
+# ResourceTracker: Managing Resources behind Application
+
+- Owner: Da Yin (@somefive)
+- Reviewer: Jian Li (@leejanee), Jianbo Sun (@wonderflow)
+- Date: 12/10/2021
+- Status: Implemented
+
+## Intro
+
+As the release of Workflow in KubeVela v1.1, resources dispatched by application can be extremely dynamic.
+Instead of simply declaring in Application Component, users can have advanced control for applied resources by leveraging WorkflowSteps such as `ApplyObject` or operators such as `op.Delete`.
+Meanwhile, with EnvBinding Policy also released in KubeVela 1.1, users can have multiple same components but deployed in different clusters.
+These techniques raise new challenges for tracking and maintaining of resources.
+
+## Goal
+
+To tackle these challenges, a new architecture of ResourceTracker is proposed and implemented.
+Generally, there are several major technical changes compared to the previous version:
+
+1. Resources do not use OwnerReference to track their ResourceTracker anymore. In other word, the previous bi-directional binding is simplified into uni-directional, which allows us to have more flexible resource management strategies (such as releasing the control of resources).
+2. Resources rendered manifests are recorded in ResourceTracker optionally. Based on that, we can prevent configuration drift by leveraging the reconciling mechanism of the Kubernetes operator pattern. 
+3. ResourceTracker deletion now use finalizer and leverage ApplicationController to reconcile. This ensures the deletion of Application truly removes all managed resources. Also, it allows users to manage versioned resource manually. 
+4. ResourceTracker in the HubCluster can track resources in ManagedClusters, so that no ResourceTracker is needed anymore in ManagedCluster. Now we can use caches for ResourceTracker again. Additionally, we do not individual multicluster garbage-collect logic anymore.
+
+From the perspective of users, the direct new-incoming capabilities include:
+1. Users can prevent configuration drift by default, which is a common usage of the classical Application model. Alternatively, they can only dispatch resources by leveraging [ApplyOnce](../../docs/examples/app-with-policy/apply-once-policy) Policy, which is the mode of Application-as-Workflow.
+2. Users can have customized life-cycle control for application resources by leveraging [GarbageCollect](../../docs/examples/app-with-policy/gc-policy) Policy. For example, users might want to keep resources after version updates or application removal.
+
+## Implementations
+
+### ResourceTracker Types
+
+There are several *ResourceTrackers* maintained for one Application.
+- **Versioned ResourceTracker**: Each ResourceTracker keeps the record for the resources of one Application generation. Most resources are kept here. When application spec is updated, new versioned ResourceTracker will be created and used. 
+- **Root ResourceTracker**: This ResourceTracker keeps the record of the resources that shares the life-cycle with the Application instead of a single version. Resources recorded here will not be recycled until Application is deleted.
+- **ControllerRevision ResourceTracker**: This ResourceTracker tracks all the dispatched component revisions. When some components are not in use in new versions, this ResourceTracker can elegantly recycle the revisions for those components. 
+
+### ResourceKeeper
+
+The main implementation of the resource management logic locates at [pkg/resourcekeeper](../../pkg/resourcekeeper).
+The **ResourceKeeper** takes charge of the dispatching, tracking, and recycling of all resources.
+- **Dispatch**: First record resources in **ResourceTracker**, then apply resources. Depending on the life-cycle of resources, either **Versioned ResourceTracker** or **Root ResourceTracker** will be used.
+- **Delete**: First mark resources as deleted in **ResourceTracker**, then delete resources.
+- **StateKeep**: Ranging over all managed resources in the latest **Versioned ResourceTracker** and **Root ResourceTracker**, re-apply those resources.
+- **GarbageCollect**: Mark outdated or unused ResourceTrackers as deleted and garbage-collect their managed resources. Details will be delivered below.
+
+### Garbage Collection Details
+
+The **GarbageCollect** process includes several steps.
+0. **Init**: Scanning over all managed resources in all **Versioned ResourceTrackers** and **Root ResourceTracker** (do not retrieve content from APIServer), aggregating the trackers of each resource and calculate which one RT is responsible for garbage collecting it. 
+1. **Mark Stage**: Ranging over all ResourceTrackers. If `KeepLegacyResources` is not enabled, outdated ResourceTrackers will be marked as deleted. If enabled, inactive ResourceTrackers, that have all managed resources removed or managed by newer ResourceTrackers, will be marked as deleted. 
+2. **Sweep Stage**: For all ResourceTrackers marked as deleted, check if all inactive managed resources (managed by newer RT or deleted) are removed (do not exist). If true, remove the finalizer of the ResourceTracker (truly remove it).
+3. **Finalize Stage**: For all ResourceTrackers marked as deleted, deleting all inactive managed resources.
+4. **GarbageCollectComponentRevisionResourceTracker**: Ranging over all resources in active ResourceTrackers and calculate the component usage. For ComponentRevisions whose component is not in-use anymore, remove them.
+
+The **Mark Stage** and **GarbageCollectComponentRevisionResourceTracker** will only run when application workflow succeeded, which means when application is still running workflow or new release is not successful, outdated ResourceTrackers will not be marked and resources will not be recycled.

--- a/docs/examples/app-with-policy/apply-once-policy/apply-once.md
+++ b/docs/examples/app-with-policy/apply-once-policy/apply-once.md
@@ -1,0 +1,31 @@
+# How to use ApplyOnce policy
+
+By default, the KubeVela operator will prevent configuration drift for applied resources by reconciling them routinely. This is useful if you want to keep your application always have the desired configuration in avoid of some unintentional changes by external modifiers.
+
+However, sometimes, you might want to use KubeVela Application to do the dispatch job and recycle job but want to leave resources mutable after workflow is finished. In this case, you can use the following ApplyOnce policy. 
+
+```shell
+$ cat <<EOF | kubectl apply -f -
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: apply-once-app
+spec:
+  components:
+    - name: hello-world
+      type: webservice
+      properties:
+        image: crccheck/hello-world
+      traits:
+        - type: scaler
+          properties:
+            replicas: 1
+  policies:
+    - name: apply-once
+      type: apply-once
+      properties:
+        enable: true
+EOF
+```
+
+In this case, if you change the replicas of the `hello-world` deployment after Application enters `running` state, it would be brought back. On the contrary, if you set the `apply-once` policy to be disabled (by default), any changes to the replicas of `hello-world` application will be brought back in the next reconcile loop.

--- a/docs/examples/app-with-policy/gc-policy/keep-legacy-resources.md
+++ b/docs/examples/app-with-policy/gc-policy/keep-legacy-resources.md
@@ -1,4 +1,4 @@
-## How to use garbage-collect policy
+## How to keep legacy resources
 
 Suppose you want to keep the resources created by the old version of the app. You only need to specify garbage-collect in the policy field of the app and enable the option `keepLegacyResource`.
 

--- a/docs/examples/app-with-policy/gc-policy/persist-resources.md
+++ b/docs/examples/app-with-policy/gc-policy/persist-resources.md
@@ -1,0 +1,79 @@
+# How to persist resources
+
+By leveraging the garbage-collect policy, users can persist some resources, which skip the normal garbage-collect process when application is updated.
+
+Take the following app as an example, in the garbage-collect policy, a rule is added which marks all the resources created by the `expose` trait to use the `onAppDelete` strategy. This will keep those services until application is deleted.
+```shell
+$ cat <<EOF | kubectl apply -f -
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: garbage-collect-app
+spec:
+  components:
+    - name: hello-world
+      type: webservice
+      properties:
+        image: crccheck/hello-world
+      traits:
+        - type: expose
+          properties:
+            port: [8000]
+  policies:
+    - name: garbage-collect
+      type: garbage-collect
+      properties:
+        rules:
+          - selector:
+              traitTypes:
+                - expose
+            strategy: onAppDelete
+EOF
+```
+
+You can find deployment and service are created.
+```shell
+$ kubectl get deployment
+NAME          READY   UP-TO-DATE   AVAILABLE   AGE
+hello-world   1/1     1            1           74s
+$ kubectl get service   
+NAME          TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+hello-world   ClusterIP   10.96.160.208   <none>        8000/TCP   78s
+```
+
+If you upgrade the application and use a different component, you will find the old versioned deployment is deleted by the service is kept.
+```shell
+$ cat <<EOF | kubectl apply -f -
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: garbage-collect-app
+spec:
+  components:
+    - name: hello-world-new
+      type: webservice
+      properties:
+        image: crccheck/hello-world
+      traits:
+        - type: expose
+          properties:
+            port: [8000]
+  policies:
+    - name: garbage-collect
+      type: garbage-collect
+      properties:
+        rules:
+          - selector:
+              traitTypes:
+                - expose
+            strategy: onAppDelete
+EOF
+
+$ kubectl get deployment
+NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+hello-world-new   1/1     1            1           10s
+$ kubectl get service   
+NAME              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+hello-world       ClusterIP   10.96.160.208   <none>        8000/TCP   5m56s
+hello-world-new   ClusterIP   10.96.20.4      <none>        8000/TCP   13s
+```

--- a/e2e/application/application_test.go
+++ b/e2e/application/application_test.go
@@ -216,11 +216,11 @@ var ApplicationDeleteWithForceOptions = func(context string, appName string) boo
 			gomega.Expect(output).To(gomega.ContainSubstring("timed out"))
 
 			app = new(v1beta1.Application)
-			gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: appName, Namespace: "default"}, app)).NotTo(gomega.HaveOccurred())
-			meta.RemoveFinalizer(app, "test")
-			gomega.Eventually(func() error {
-				return k8sClient.Update(ctx, app)
-			}, time.Second*3, time.Millisecond*300).Should(gomega.BeNil())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: appName, Namespace: "default"}, app)).Should(gomega.Succeed())
+				meta.RemoveFinalizer(app, "test")
+				g.Expect(k8sClient.Update(ctx, app)).Should(gomega.Succeed())
+			}, time.Second*5, time.Millisecond*300).Should(gomega.Succeed())
 
 			cli = fmt.Sprintf("vela delete %s --force", appName)
 			output, err = e2e.ExecAndTerminate(cli)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -279,7 +279,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := handler.resourceKeeper.StateKeep(ctx); err != nil {
 		logCtx.Error(err, "Failed to run prevent-configuration-drift")
 		r.Recorder.Event(app, event.Warning(velatypes.ReasonFailedStateKeep, err))
-		return r.endWithNegativeCondition(logCtx, app, condition.ReconcileError(err), phase)
+		app.Status.SetConditions(condition.ErrorCondition("StateKeep", err))
 	}
 	if err := garbageCollection(logCtx, handler); err != nil {
 		logCtx.Error(err, "Failed to run garbage collection")

--- a/pkg/resourcekeeper/statekeep.go
+++ b/pkg/resourcekeeper/statekeep.go
@@ -39,7 +39,7 @@ func (h *resourceKeeper) StateKeep(ctx context.Context) error {
 					return entry.err
 				}
 				if mr.Deleted {
-					if entry.exists {
+					if entry.exists && entry.obj != nil && entry.obj.GetDeletionTimestamp() == nil {
 						if err := h.Client.Delete(multicluster.ContextWithClusterName(ctx, mr.Cluster), entry.obj); err != nil {
 							return errors.Wrapf(err, "failed to delete outdated resource %s in resourcetracker %s", mr.ResourceKey(), rt.Name)
 						}

--- a/test/e2e-test/resource_policy_test.go
+++ b/test/e2e-test/resource_policy_test.go
@@ -119,9 +119,11 @@ var _ = Describe("Application Resource-Related Policy Tests", func() {
 		}, 30*time.Second).Should(Succeed())
 
 		By("upgrade to v3 (new component)")
-		Expect(k8sClient.Get(ctx, appKey, app)).Should(Succeed())
-		app.Spec.Components[0].Name = "hello-world-new"
-		Expect(k8sClient.Update(ctx, app)).Should(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, appKey, app)).Should(Succeed())
+			app.Spec.Components[0].Name = "hello-world-new"
+			g.Expect(k8sClient.Update(ctx, app)).Should(Succeed())
+		}, 10*time.Second).Should(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(k8sClient.Get(ctx, appKey, app)).Should(Succeed())
 			g.Expect(app.Status.ObservedGeneration).Should(Equal(app.Generation))

--- a/test/e2e-test/testdata/app/app_garbage_collect.yaml
+++ b/test/e2e-test/testdata/app/app_garbage_collect.yaml
@@ -22,3 +22,7 @@ spec:
               traitTypes:
                 - expose
             strategy: onAppDelete
+    - name: apply-once
+      type: apply-once
+      properties:
+        enable: true


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

- Add design docs for ResourceTracker.
- Add examples for garbage-collect policy and apply-once policy.
- Enhance state-keep logic.
- Fix minor test bugs.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->