### PR TITLE
Fix:  deprecate CRD discovery for CUE import in Definition to prevent memory leak and OOM crash

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -1280,7 +1280,7 @@ var _ = Describe("Test Application Controller", func() {
 		}, appRevision)).Should(BeNil())
 	})
 
-	It("app-import-pkg will create workload by imported kube package", func() {
+	PIt("app-import-pkg will create workload by imported kube package", func() {
 
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/components/componentdefinition/componentdefinition_controller_test.go
@@ -706,11 +706,9 @@ spec:
   schematic:
     cue:
       template: |
-        import (
-          ev1 "example.com/v1"
-        )
-        output: ev1.#Foo
         output: {
+          kind: "Foo"
+          apiVersion: "example.com/v1"
           spec: key: parameter.key1
           status: key: parameter.key2
         }

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller_test.go
@@ -268,11 +268,9 @@ spec:
   schematic:
     cue:
       template: |
-        import (
-          ev1 "example.com/v1"
-        )
-        output: ev1.#Foo
         output: {
+          metadata: kind: "Foo"
+          metadata: apiVersion: "example.com/v1"
           spec: key: parameter.key1
           status: key: parameter.key2
         }

--- a/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/core/traits/traitdefinition/traitdefinition_controller_test.go
@@ -269,8 +269,8 @@ spec:
     cue:
       template: |
         output: {
-          metadata: kind: "Foo"
-          metadata: apiVersion: "example.com/v1"
+          kind: "Foo"
+          apiVersion: "example.com/v1"
           spec: key: parameter.key1
           status: key: parameter.key2
         }

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -318,9 +318,9 @@ func RefreshPackageDiscover(ctx context.Context, k8sClient client.Client, dm dis
 	}
 
 	// Test whether the refresh is successful
-	if exist := pd.Exist(targetGVK); !exist {
-		return fmt.Errorf("get CRD %s error", targetGVK.String())
-	}
+	// if exist := pd.Exist(targetGVK); !exist {
+	//	 return fmt.Errorf("get CRD %s error", targetGVK.String())
+	// }
 	return nil
 }
 

--- a/pkg/cue/package_suit_test.go
+++ b/pkg/cue/package_suit_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 var _ = Describe("Package discovery resources for definition from K8s APIServer", func() {
-	It("check that all built-in k8s resource are registered", func() {
+	PIt("check that all built-in k8s resource are registered", func() {
 		var localSchemeBuilder = runtime.SchemeBuilder{
 			admissionregistrationv1.AddToScheme,
 			appsv1.AddToScheme,
@@ -95,7 +95,7 @@ var _ = Describe("Package discovery resources for definition from K8s APIServer"
 		}
 	})
 
-	It("discovery built-in k8s resource with kube prefix", func() {
+	PIt("discovery built-in k8s resource with kube prefix", func() {
 
 		By("test ingress in kube package")
 		bi := build.NewContext().NewInstance("", nil)
@@ -388,7 +388,7 @@ output: {
 
 	})
 
-	It("discovery built-in k8s resource with third-party path", func() {
+	PIt("discovery built-in k8s resource with third-party path", func() {
 
 		By("test ingress in kube package")
 		bi := build.NewContext().NewInstance("", nil)

--- a/pkg/cue/packages/package.go
+++ b/pkg/cue/packages/package.go
@@ -17,7 +17,6 @@ limitations under the License.
 package packages
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -131,11 +130,12 @@ func (pd *PackageDiscover) ListPackageKinds() map[string][]VersionKind {
 
 // RefreshKubePackagesFromCluster will use K8s client to load/refresh all K8s open API as a reference kube package using in template
 func (pd *PackageDiscover) RefreshKubePackagesFromCluster() error {
-	body, err := pd.client.Get().AbsPath("/openapi/v2").Do(context.Background()).Raw()
-	if err != nil {
-		return err
-	}
-	return pd.addKubeCUEPackagesFromCluster(string(body))
+	return nil
+	//body, err := pd.client.Get().AbsPath("/openapi/v2").Do(context.Background()).Raw()
+	//if err != nil {
+	//	return err
+	//}
+	//return pd.addKubeCUEPackagesFromCluster(string(body))
 }
 
 // Exist checks if the GVK exists in the built-in packages

--- a/pkg/cue/packages/package.go
+++ b/pkg/cue/packages/package.go
@@ -131,11 +131,11 @@ func (pd *PackageDiscover) ListPackageKinds() map[string][]VersionKind {
 // RefreshKubePackagesFromCluster will use K8s client to load/refresh all K8s open API as a reference kube package using in template
 func (pd *PackageDiscover) RefreshKubePackagesFromCluster() error {
 	return nil
-	//body, err := pd.client.Get().AbsPath("/openapi/v2").Do(context.Background()).Raw()
-	//if err != nil {
-	//	return err
-	//}
-	//return pd.addKubeCUEPackagesFromCluster(string(body))
+	// body, err := pd.client.Get().AbsPath("/openapi/v2").Do(context.Background()).Raw()
+	// if err != nil {
+	//	 return err
+	// }
+	// return pd.addKubeCUEPackagesFromCluster(string(body))
 }
 
 // Exist checks if the GVK exists in the built-in packages

--- a/references/appfile/dryrun/testdata/cd-myworker.yaml
+++ b/references/appfile/dryrun/testdata/cd-myworker.yaml
@@ -10,10 +10,10 @@ spec:
   schematic:
     cue:
       template: |
-        import (
-           apps "kube/apps/v1"
-        )
-        output: apps.#Deployment
+        output: {
+          apiVersion: "apps/v1"
+          kind: "Deployment"
+        }
         output: {
         	spec: {
         		selector: matchLabels: {

--- a/references/appfile/dryrun/testdata/diff-apprevision.yaml
+++ b/references/appfile/dryrun/testdata/diff-apprevision.yaml
@@ -117,15 +117,14 @@ spec:
       spec:
         schematic:
           cue:
-            template: "import (\n   apps \"kube/apps/v1\"\n)\noutput: apps.#Deployment\noutput:
-              {\n\tspec: {\n\t\tselector: matchLabels: {\n\t\t\t\"app.oam.dev/component\":
-              context.name\n\t\t}\n\n\t\ttemplate: {\n\t\t\tmetadata: labels: {\n\t\t\t\t\"app.oam.dev/component\":
-              context.name\n\t\t\t}\n\n\t\t\tspec: {\n\t\t\t\tcontainers: [{\n\t\t\t\t\tname:
-              \ context.name\n\t\t\t\t\timage: parameter.image\n\n\t\t\t\t\tif parameter[\"cmd\"]
-              != _|_ {\n\t\t\t\t\t\tcommand: parameter.cmd\n\t\t\t\t\t}\n\t\t\t\t}]\n\t\t\t}\n\t\t}\n\t}\n}\n\nparameter:
-              {\n\t// +usage=Which image would you like to use for your service\n\t//
-              +short=i\n\timage: string\n\t// +usage=Commands to run in the container\n\tcmd?:
-              [...string]\n}\n"
+            template: "output: {\n  apiVersion: \"apps/v1\"\n  kind: \"Deployment\"\n}\noutput:
+        {\n\tspec: {\n\t\tselector: matchLabels: {\n\t\t\t\"app.oam.dev/component\":
+        context.name\n\t\t}\n\n\t\ttemplate: {\n\t\t\tmetadata: labels: {\n\t\t\t\t\"app.oam.dev/component\":
+        context.name\n\t\t\t}\n\n\t\t\tspec: {\n\t\t\t\tcontainers: [{\n\t\t\t\t\tname:
+        \ context.name\n\t\t\t\t\timage: parameter.image\n\n\t\t\t\t\tif parameter[\"cmd\"]
+        != _|_ {\n\t\t\t\t\t\tcommand: parameter.cmd\n\t\t\t\t\t}\n\t\t\t\t}]\n\t\t\t}\n\t\t}\n\t}\n}\n\nparameter:
+        {\n\t// +usage=Which image would you like to use for your service\n\t// +short=i\n\timage:
+        string\n\t// +usage=Commands to run in the container\n\tcmd?: [...string]\n}\n"
         workload:
           definition:
             apiVersion: apps/v1
@@ -219,18 +218,17 @@ spec:
           name: ""
         schematic:
           cue:
-            template: "import (\n\tkubev1 \"kube/v1\"\n\tnetwork \"kube/networking.k8s.io/v1beta1\"\n)\n\nparameter:
-              {\n\tdomain: string\n\thttp: [string]: int\n}\n\noutputs: {\nservice:
-              kubev1.#Service\ningress: network.#Ingress\n}\n\n// trait template can
-              have multiple outputs in one trait\noutputs: service: {\n\tmetadata:\n\t\tname:
-              context.name\n\tspec: {\n\t\tselector:\n\t\t\t\"app.oam.dev/component\":
-              context.name\n\t\tports: [\n\t\t\tfor k, v in parameter.http {\n\t\t\t\tport:
-              \      v\n\t\t\t\ttargetPort: v\n\t\t\t},\n\t\t]\n\t}\n}\n\noutputs:
-              ingress: {\n\tmetadata:\n\t\tname: context.name\n\tspec: {\n\t\trules:
-              [{\n\t\t\thost: parameter.domain\n\t\t\thttp: {\n\t\t\t\tpaths: [\n\t\t\t\t\tfor
-              k, v in parameter.http {\n\t\t\t\t\t\tpath: k\n\t\t\t\t\t\tbackend:
-              {\n\t\t\t\t\t\t\tserviceName: context.name\n\t\t\t\t\t\t\tservicePort:
-              v\n\t\t\t\t\t\t}\n\t\t\t\t\t},\n\t\t\t\t]\n\t\t\t}\n\t\t}]\n\t}\n}\n"
+            template: "parameter: {\n\tdomain: string\n\thttp: [string]: int\n}\n\noutputs:
+        {\n  service: {\n    apiVersion: \"v1\"\n    kind: \"Service\"\n  }\n  ingress:
+        {\n    apiVersion: \"networking.k8s.io/v1beta1\"\n    kind: \"Ingress\"\n
+        \ }\n}\n\n// trait template can have multiple outputs in one trait\noutputs:
+        service: {\n\tmetadata:\n\t\tname: context.name\n\tspec: {\n\t\tselector:\n\t\t\t\"app.oam.dev/component\":
+        context.name\n\t\tports: [\n\t\t\tfor k, v in parameter.http {\n\t\t\t\tport:
+        \      v\n\t\t\t\ttargetPort: v\n\t\t\t},\n\t\t]\n\t}\n}\n\noutputs: ingress:
+        {\n\tmetadata:\n\t\tname: context.name\n\tspec: {\n\t\trules: [{\n\t\t\thost:
+        parameter.domain\n\t\t\thttp: {\n\t\t\t\tpaths: [\n\t\t\t\t\tfor k, v in parameter.http
+        {\n\t\t\t\t\t\tpath: k\n\t\t\t\t\t\tbackend: {\n\t\t\t\t\t\t\tserviceName:
+        context.name\n\t\t\t\t\t\t\tservicePort: v\n\t\t\t\t\t\t}\n\t\t\t\t\t},\n\t\t\t\t]\n\t\t\t}\n\t\t}]\n\t}\n}\n"
       status: {}
     myscaler:
       apiVersion: core.oam.dev/v1beta1

--- a/references/appfile/dryrun/testdata/td-myingress.yaml
+++ b/references/appfile/dryrun/testdata/td-myingress.yaml
@@ -9,19 +9,20 @@ spec:
   schematic:
     cue:
       template: |
-        import (
-        	kubev1 "kube/v1"
-        	network "kube/networking.k8s.io/v1beta1"
-        )
-
         parameter: {
         	domain: string
         	http: [string]: int
         }
 
         outputs: {
-        service: kubev1.#Service
-        ingress: network.#Ingress
+          service: {
+            apiVersion: "v1"
+            kind: "Service"
+          }
+          ingress: {
+            apiVersion: "networking.k8s.io/v1beta1"
+            kind: "Ingress"
+          }
         }
 
         // trait template can have multiple outputs in one trait


### PR DESCRIPTION
Signed-off-by: Jian.Li <lj176172@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

Disable package discover from kubernetes open api.
Alternative solution: [issues 2924](https://github.com/oam-dev/kubevela/issues/2924)