### PR TITLE
Feat: support specified existing namespace while creating a project

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -3304,6 +3304,27 @@
 		}
 	},
 	"definitions": {
+		"addon.Dependency": {
+			"properties": {
+				"name": {
+					"type": "string"
+				}
+			}
+		},
+		"addon.DeployTo": {
+			"required": [
+				"control_plane",
+				"runtime_cluster"
+			],
+			"properties": {
+				"control_plane": {
+					"type": "boolean"
+				},
+				"runtime_cluster": {
+					"type": "boolean"
+				}
+			}
+		},
 		"addon.GitAddonSource": {
 			"properties": {
 				"path": {
@@ -3317,16 +3338,70 @@
 				}
 			}
 		},
+		"addon.Meta": {
+			"required": [
+				"name",
+				"version",
+				"description",
+				"icon",
+				"invisible"
+			],
+			"properties": {
+				"dependencies": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/addon.Dependency"
+					}
+				},
+				"deployTo": {
+					"$ref": "#/definitions/addon.DeployTo"
+				},
+				"description": {
+					"type": "string"
+				},
+				"icon": {
+					"type": "string"
+				},
+				"invisible": {
+					"type": "boolean"
+				},
+				"name": {
+					"type": "string"
+				},
+				"needNamespace": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"url": {
+					"type": "string"
+				},
+				"version": {
+					"type": "string"
+				}
+			}
+		},
 		"addon.OSSAddonSource": {
 			"required": [
 				"end_point",
-				"bucket"
+				"bucket",
+				"path"
 			],
 			"properties": {
 				"bucket": {
 					"type": "string"
 				},
 				"end_point": {
+					"type": "string"
+				},
+				"path": {
 					"type": "string"
 				}
 			}
@@ -3405,11 +3480,11 @@
 		},
 		"common.AppRolloutStatus": {
 			"required": [
-				"upgradedReplicas",
-				"rollingState",
-				"currentBatch",
 				"upgradedReadyReplicas",
+				"rollingState",
 				"batchRollingState",
+				"currentBatch",
+				"upgradedReplicas",
 				"lastTargetAppRevision"
 			],
 			"properties": {
@@ -4224,77 +4299,6 @@
 				}
 			}
 		},
-		"types.AddonDependency": {
-			"properties": {
-				"name": {
-					"type": "string"
-				}
-			}
-		},
-		"types.AddonDeployTo": {
-			"required": [
-				"control_plane",
-				"runtime_cluster"
-			],
-			"properties": {
-				"control_plane": {
-					"type": "boolean"
-				},
-				"runtime_cluster": {
-					"type": "boolean"
-				}
-			}
-		},
-		"types.AddonMeta": {
-			"required": [
-				"name",
-				"version",
-				"description",
-				"icon",
-				"invisible"
-			],
-			"properties": {
-				"dependencies": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/types.AddonDependency"
-					}
-				},
-				"deployTo": {
-					"$ref": "#/definitions/types.AddonDeployTo"
-				},
-				"description": {
-					"type": "string"
-				},
-				"icon": {
-					"type": "string"
-				},
-				"invisible": {
-					"type": "boolean"
-				},
-				"name": {
-					"type": "string"
-				},
-				"needNamespace": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"tags": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"url": {
-					"type": "string"
-				},
-				"version": {
-					"type": "string"
-				}
-			}
-		},
 		"types.Parameter": {
 			"required": [
 				"name"
@@ -4500,6 +4504,9 @@
 				"args"
 			],
 			"properties": {
+				"appStatus": {
+					"$ref": "#/definitions/common.AppStatus"
+				},
 				"args": {
 					"type": "object",
 					"additionalProperties": {
@@ -4583,14 +4590,14 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
-				"status",
-				"reason",
 				"deployUser",
 				"note",
 				"envName",
 				"triggerType",
 				"createTime",
-				"version"
+				"version",
+				"status",
+				"reason"
 			],
 			"properties": {
 				"createTime": {
@@ -5424,6 +5431,9 @@
 				},
 				"name": {
 					"type": "string"
+				},
+				"namespace": {
+					"type": "string"
 				}
 			}
 		},
@@ -5520,11 +5530,11 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"name",
 				"invisible",
 				"version",
 				"description",
 				"icon",
+				"name",
 				"schema",
 				"uiSchema",
 				"definitions"
@@ -5539,11 +5549,11 @@
 				"dependencies": {
 					"type": "array",
 					"items": {
-						"$ref": "#/definitions/types.AddonDependency"
+						"$ref": "#/definitions/addon.Dependency"
 					}
 				},
 				"deployTo": {
-					"$ref": "#/definitions/types.AddonDeployTo"
+					"$ref": "#/definitions/addon.DeployTo"
 				},
 				"description": {
 					"type": "string"
@@ -5591,13 +5601,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
+				"createTime",
 				"updateTime",
 				"icon",
 				"name",
 				"alias",
 				"project",
 				"description",
-				"createTime",
 				"policies",
 				"envBindings",
 				"status",
@@ -5659,19 +5669,19 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"alias",
-				"icon",
-				"labels",
-				"status",
-				"apiServerURL",
-				"dashboardURL",
-				"kubeConfigSecret",
-				"model",
-				"name",
 				"description",
+				"icon",
+				"status",
 				"reason",
 				"provider",
 				"kubeConfig",
+				"kubeConfigSecret",
+				"model",
+				"name",
+				"alias",
+				"labels",
+				"apiServerURL",
+				"dashboardURL",
 				"resourceInfo"
 			],
 			"properties": {
@@ -5725,12 +5735,12 @@
 		"v1.DetailComponentResponse": {
 			"required": [
 				"appPrimaryKey",
-				"creator",
+				"name",
 				"alias",
-				"type",
+				"creator",
 				"createTime",
 				"updateTime",
-				"name"
+				"type"
 			],
 			"properties": {
 				"alias": {
@@ -5825,10 +5835,10 @@
 		},
 		"v1.DetailDeliveryTargetResponse": {
 			"required": [
+				"project",
 				"createTime",
 				"updateTime",
-				"name",
-				"project"
+				"name"
 			],
 			"properties": {
 				"alias": {
@@ -5865,13 +5875,13 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"updateTime",
 				"name",
 				"type",
 				"description",
 				"creator",
 				"properties",
-				"createTime"
+				"createTime",
+				"updateTime"
 			],
 			"properties": {
 				"createTime": {
@@ -5901,17 +5911,17 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
+				"status",
+				"triggerType",
+				"createTime",
+				"version",
 				"reason",
 				"deployUser",
 				"note",
 				"workflowName",
-				"createTime",
-				"appPrimaryKey",
-				"version",
-				"status",
-				"triggerType",
 				"envName",
-				"updateTime"
+				"updateTime",
+				"appPrimaryKey"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -5959,12 +5969,12 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"status",
-				"name",
 				"namespace",
 				"workflowName",
 				"workflowAlias",
 				"applicationRevision",
+				"status",
+				"name",
 				"deployTime",
 				"deployUser",
 				"note",
@@ -6016,14 +6026,14 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"default",
-				"createTime",
 				"name",
 				"alias",
 				"description",
+				"default",
+				"createTime",
+				"updateTime",
 				"enable",
-				"envName",
-				"updateTime"
+				"envName"
 			],
 			"properties": {
 				"alias": {
@@ -6177,7 +6187,7 @@
 				"addons": {
 					"type": "array",
 					"items": {
-						"$ref": "#/definitions/types.AddonMeta"
+						"$ref": "#/definitions/addon.Meta"
 					}
 				}
 			}

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -483,6 +483,7 @@ type CreateProjectRequest struct {
 	Name        string `json:"name" validate:"checkname"`
 	Alias       string `json:"alias" validate:"checkalias" optional:"true"`
 	Description string `json:"description" optional:"true"`
+	Namespace   string `json:"namespace" optional:"true"`
 }
 
 // ListDefinitionResponse list definition response model

--- a/pkg/apiserver/rest/usecase/testdata/ui-schema.yaml
+++ b/pkg/apiserver/rest/usecase/testdata/ui-schema.yaml
@@ -51,6 +51,13 @@
     - valueFrom
     label: Add By Secret
   subParameters:
+  - description: Environment variable name
+    jsonKey: name
+    label: Name
+    sort: 100
+    uiType: Input
+    validate:
+      required: true
   - description: The value of the environment variable
     jsonKey: value
     label: Value
@@ -87,13 +94,6 @@
         required: true
     uiType: InnerGroup
     validate: {}
-  - description: Environment variable name
-    jsonKey: name
-    label: Name
-    sort: 100
-    uiType: Input
-    validate:
-      required: true
   uiType: Structs
   validate: {}
 - description: Instructions for assessing whether the container is in a suitable state
@@ -102,62 +102,6 @@
   label: ReadinessProbe
   sort: 13
   subParameters:
-  - description: Instructions for assessing container health by executing an HTTP
-      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
-      MUST be specified. This attribute is mutually exclusive with both the exec attribute
-      and the tcpSocket attribute.
-    jsonKey: httpGet
-    label: HttpGet
-    sort: 100
-    subParameters:
-    - description: ""
-      jsonKey: httpHeaders
-      label: HttpHeaders
-      sort: 100
-      subParameters:
-      - description: ""
-        jsonKey: value
-        label: Value
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      - description: ""
-        jsonKey: name
-        label: Name
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      uiType: Structs
-      validate: {}
-    - description: The endpoint, relative to the port, to which the HTTP GET request
-        should be directed.
-      jsonKey: path
-      label: Path
-      sort: 100
-      uiType: Input
-      validate:
-        required: true
-    - description: The TCP socket within the container to which the HTTP GET request
-        should be directed.
-      jsonKey: port
-      label: Port
-      sort: 100
-      uiType: Number
-      validate:
-        required: true
-    uiType: Group
-    validate: {}
-  - description: Number of seconds after the container is started before the first
-      probe is initiated.
-    jsonKey: initialDelaySeconds
-    label: InitialDelaySeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 0
-      required: true
   - description: How often, in seconds, to execute the probe.
     jsonKey: periodSeconds
     label: PeriodSeconds
@@ -229,6 +173,62 @@
     uiType: Number
     validate:
       defaultValue: 3
+      required: true
+  - description: Instructions for assessing container health by executing an HTTP
+      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
+      MUST be specified. This attribute is mutually exclusive with both the exec attribute
+      and the tcpSocket attribute.
+    jsonKey: httpGet
+    label: HttpGet
+    sort: 100
+    subParameters:
+    - description: ""
+      jsonKey: httpHeaders
+      label: HttpHeaders
+      sort: 100
+      subParameters:
+      - description: ""
+        jsonKey: name
+        label: Name
+        sort: 100
+        uiType: Input
+        validate:
+          required: true
+      - description: ""
+        jsonKey: value
+        label: Value
+        sort: 100
+        uiType: Input
+        validate:
+          required: true
+      uiType: Structs
+      validate: {}
+    - description: The endpoint, relative to the port, to which the HTTP GET request
+        should be directed.
+      jsonKey: path
+      label: Path
+      sort: 100
+      uiType: Input
+      validate:
+        required: true
+    - description: The TCP socket within the container to which the HTTP GET request
+        should be directed.
+      jsonKey: port
+      label: Port
+      sort: 100
+      uiType: Number
+      validate:
+        required: true
+    uiType: Group
+    validate: {}
+  - description: Number of seconds after the container is started before the first
+      probe is initiated.
+    jsonKey: initialDelaySeconds
+    label: InitialDelaySeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 0
       required: true
   uiType: Group
   validate: {}
@@ -237,6 +237,88 @@
   label: LivenessProbe
   sort: 15
   subParameters:
+  - description: Number of consecutive failures required to determine the container
+      is not alive (liveness probe) or not ready (readiness probe).
+    jsonKey: failureThreshold
+    label: FailureThreshold
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 3
+      required: true
+  - description: Instructions for assessing container health by executing an HTTP
+      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
+      MUST be specified. This attribute is mutually exclusive with both the exec attribute
+      and the tcpSocket attribute.
+    jsonKey: httpGet
+    label: HttpGet
+    sort: 100
+    subParameters:
+    - description: The TCP socket within the container to which the HTTP GET request
+        should be directed.
+      jsonKey: port
+      label: Port
+      sort: 100
+      uiType: Number
+      validate:
+        required: true
+    - description: ""
+      jsonKey: httpHeaders
+      label: HttpHeaders
+      sort: 100
+      subParameters:
+      - description: ""
+        jsonKey: name
+        label: Name
+        sort: 100
+        uiType: Input
+        validate:
+          required: true
+      - description: ""
+        jsonKey: value
+        label: Value
+        sort: 100
+        uiType: Input
+        validate:
+          required: true
+      uiType: Structs
+      validate: {}
+    - description: The endpoint, relative to the port, to which the HTTP GET request
+        should be directed.
+      jsonKey: path
+      label: Path
+      sort: 100
+      uiType: Input
+      validate:
+        required: true
+    uiType: Group
+    validate: {}
+  - description: Number of seconds after the container is started before the first
+      probe is initiated.
+    jsonKey: initialDelaySeconds
+    label: InitialDelaySeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 0
+      required: true
+  - description: How often, in seconds, to execute the probe.
+    jsonKey: periodSeconds
+    label: PeriodSeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 10
+      required: true
+  - description: Minimum consecutive successes for the probe to be considered successful
+      after having failed.
+    jsonKey: successThreshold
+    label: SuccessThreshold
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 1
+      required: true
   - description: Instructions for assessing container health by probing a TCP socket.
       Either this attribute or the exec attribute or the httpGet attribute MUST be
       specified. This attribute is mutually exclusive with both the exec attribute
@@ -283,89 +365,22 @@
         required: true
     uiType: Group
     validate: {}
-  - description: Number of consecutive failures required to determine the container
-      is not alive (liveness probe) or not ready (readiness probe).
-    jsonKey: failureThreshold
-    label: FailureThreshold
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 3
-      required: true
-  - description: Instructions for assessing container health by executing an HTTP
-      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
-      MUST be specified. This attribute is mutually exclusive with both the exec attribute
-      and the tcpSocket attribute.
-    jsonKey: httpGet
-    label: HttpGet
-    sort: 100
-    subParameters:
-    - description: ""
-      jsonKey: httpHeaders
-      label: HttpHeaders
-      sort: 100
-      subParameters:
-      - description: ""
-        jsonKey: name
-        label: Name
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      - description: ""
-        jsonKey: value
-        label: Value
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      uiType: Structs
-      validate: {}
-    - description: The endpoint, relative to the port, to which the HTTP GET request
-        should be directed.
-      jsonKey: path
-      label: Path
-      sort: 100
-      uiType: Input
-      validate:
-        required: true
-    - description: The TCP socket within the container to which the HTTP GET request
-        should be directed.
-      jsonKey: port
-      label: Port
-      sort: 100
-      uiType: Number
-      validate:
-        required: true
-    uiType: Group
-    validate: {}
-  - description: Number of seconds after the container is started before the first
-      probe is initiated.
-    jsonKey: initialDelaySeconds
-    label: InitialDelaySeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 0
-      required: true
-  - description: How often, in seconds, to execute the probe.
-    jsonKey: periodSeconds
-    label: PeriodSeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 10
-      required: true
-  - description: Minimum consecutive successes for the probe to be considered successful
-      after having failed.
-    jsonKey: successThreshold
-    label: SuccessThreshold
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 1
-      required: true
   uiType: Group
+  validate: {}
+- description: Which port do you want customer traffic sent to
+  disable: true
+  jsonKey: port
+  label: Port
+  sort: 100
+  uiType: Number
+  validate:
+    defaultValue: 80
+    required: true
+- description: Specify image pull secrets for your service
+  jsonKey: imagePullSecrets
+  label: ImagePullSecrets
+  sort: 100
+  uiType: Strings
   validate: {}
 - description: Declare volumes and volumeMounts
   disable: true
@@ -414,19 +429,4 @@
   uiType: Switch
   validate:
     defaultValue: false
-    required: true
-- description: Specify image pull secrets for your service
-  jsonKey: imagePullSecrets
-  label: ImagePullSecrets
-  sort: 100
-  uiType: Strings
-  validate: {}
-- description: Which port do you want customer traffic sent to
-  disable: true
-  jsonKey: port
-  label: Port
-  sort: 100
-  uiType: Number
-  validate:
-    defaultValue: 80
     required: true

--- a/pkg/apiserver/rest/utils/bcode/namespace.go
+++ b/pkg/apiserver/rest/utils/bcode/namespace.go
@@ -21,3 +21,9 @@ var ErrProjectIsExist = NewBcode(400, 30001, "project name is exist")
 
 // ErrProjectIsNotExist project is not exist
 var ErrProjectIsNotExist = NewBcode(404, 30002, "project is not exist")
+
+// ErrProjectNamespaceFail project bind namespace failure
+var ErrProjectNamespaceFail = NewBcode(400, 30003, "project bind namespace failure")
+
+// ErrProjectNamespaceIsExist the namespace belongs to the other project
+var ErrProjectNamespaceIsExist = NewBcode(400, 30004, "the namespace belongs to the other project")

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -74,6 +74,9 @@ const (
 
 	// LabelProject Namesapce records the project name of namespace
 	LabelProjectNamesapce = "namespace.oam.dev/project"
+
+	// LabelUsageNamespace mark the usage of the namespace.
+	LabelUsageNamespace = "usage.oam.dev"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

support specified existing namespace while creating a project, but the namespace can not belong to other projects.

Fixes #2914

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.