### PR TITLE
Feat: detect directory without addon

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -110,7 +110,7 @@ func GetAddonsFromReader(r AsyncReader, opt ListOptions) ([]*Addon, error) {
 	}
 	var l sync.Mutex
 	for _, subItem := range items {
-		if subItem.GetType() != "dir" || !IsAddon(r, subItem) {
+		if !IsAddon(r, subItem) {
 			continue
 		}
 		wg.Add(1)
@@ -147,7 +147,11 @@ forLoop:
 	return addons, nil
 }
 
+// IsAddon judges if an item is an addon directory
 func IsAddon(r AsyncReader, item Item) bool {
+	if item.GetType() != DirType {
+		return false
+	}
 	metaItem := OssItem{path: path.Join(item.GetPath(), MetadataFileName), name: MetadataFileName, tp: FileType}
 	content, _, err := r.Read(r.RelativePath(metaItem))
 	if err != nil {

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -110,7 +110,7 @@ func GetAddonsFromReader(r AsyncReader, opt ListOptions) ([]*Addon, error) {
 	}
 	var l sync.Mutex
 	for _, subItem := range items {
-		if subItem.GetType() != "dir" {
+		if subItem.GetType() != "dir" || !IsAddon(r, subItem) {
 			continue
 		}
 		wg.Add(1)
@@ -145,6 +145,15 @@ forLoop:
 		return addons, compactErrors("error(s) happen when reading from registry: ", errs)
 	}
 	return addons, nil
+}
+
+func IsAddon(r AsyncReader, item Item) bool {
+	metaItem := OssItem{path: path.Join(item.GetPath(), MetadataFileName), name: MetadataFileName, tp: FileType}
+	content, _, err := r.Read(r.RelativePath(metaItem))
+	if err != nil {
+		return false
+	}
+	return len(content) > 0
 }
 
 func compactErrors(message string, errs []error) error {

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -321,7 +321,7 @@ func (o ossReader) convert2OssItem(files []File, nowPath string) []Item {
 			continue
 		}
 		name := fPath[0]
-		pathExistCount[name] += 1
+		pathExistCount[name]++
 		if count := pathExistCount[name]; count > 1 {
 			continue
 		}


### PR DESCRIPTION
Now when get addon files, for given "bueckt.endpoint.com" with path "addon-path". All directories under `addon-path` will be treated as an addon. This PR add logic for filter the directories  that is not an addon. The critira is whether the `metadata.yaml` exists.
Detect addon directory by
Signed-off-by: qiaozp <chivalry.pp@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->