### PR TITLE
Feat: default enable the multicluster feature

### DIFF
--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -107,7 +107,7 @@ dependCheckWait: 30s
 OAMSpecVer: "v0.3"
 
 multicluster:
-  enabled: false
+  enabled: true
   clusterGateway:
     replicaCount: 1
     port: 9443


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

Multiple clusters is supported by default. You can disable this feature if it is not required in special scenarios.

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.