### PR TITLE
Feat: support parallel apply in deploy2env

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/deploy2env.yaml
+++ b/charts/vela-core/templates/defwithtemplate/deploy2env.yaml
@@ -16,9 +16,10 @@ spec:
         )
 
         app: op.#ApplyEnvBindApp & {
-        	env:    parameter.env
-        	policy: parameter.policy
-        	app:    context.name
+        	env:      parameter.env
+        	policy:   parameter.policy
+        	parallel: parameter.parallel
+        	app:      context.name
         	// context.namespace indicates the namespace of the app
         	namespace: context.namespace
         }
@@ -27,5 +28,7 @@ spec:
         	policy: *"" | string
         	// +usage=Declare the name of the env in policy
         	env: string
+        	// +usage=components are applied in parallel
+        	parallel: *false | bool
         }
 

--- a/pkg/stdlib/pkgs/oam.cue
+++ b/pkg/stdlib/pkgs/oam.cue
@@ -1,8 +1,9 @@
 #ApplyComponent: {
-	#provider: "oam"
-	#do:       "component-apply"
-	cluster:   *"" | string
-	env:       *"" | string
+	#provider:   "oam"
+	#do:         "component-apply"
+	cluster:     *"" | string
+	env:         *"" | string
+	waitHealthy: *true | bool
 	value: {...}
 	patch?: {...}
 	...

--- a/pkg/workflow/providers/oam/apply.go
+++ b/pkg/workflow/providers/oam/apply.go
@@ -106,7 +106,12 @@ func (p *provider) ApplyComponent(ctx wfContext.Context, v *value.Value, act wfT
 		}
 	}
 
-	if !healthy {
+	waitHealthy, err := v.GetBool("waitHealthy")
+	if err != nil {
+		waitHealthy = true
+	}
+
+	if waitHealthy && !healthy {
 		act.Wait("wait healthy")
 	}
 

--- a/vela-templates/definitions/internal/workflowstep/deploy2env.cue
+++ b/vela-templates/definitions/internal/workflowstep/deploy2env.cue
@@ -10,9 +10,10 @@ import (
 }
 template: {
 	app: op.#ApplyEnvBindApp & {
-		env:    parameter.env
-		policy: parameter.policy
-		app:    context.name
+		env:      parameter.env
+		policy:   parameter.policy
+		parallel: parameter.parallel
+		app:      context.name
 		// context.namespace indicates the namespace of the app
 		namespace: context.namespace
 	}
@@ -22,5 +23,7 @@ template: {
 		policy: *"" | string
 		// +usage=Declare the name of the env in policy
 		env: string
+		// +usage=components are applied in parallel
+		parallel: *false | bool
 	}
 }


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Previous deploy2env will deploy resources one by one. Only when the last resource is healthy will the next resource be applied. This will cost lots of time for some heavy applications with lots of components such as addons.

It would be better to support `DependOn` in deploy2env but it is not very easy currently. This PR provides an alternative feature which allows resources to be deploy together at first and then health check, which means resources in one deploy2env step can be deployed without waiting each others.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->