### PR TITLE
Feat: append messages for helm type component definition custom status

### DIFF
--- a/charts/vela-core/templates/addons/fluxcd.yaml
+++ b/charts/vela-core/templates/addons/fluxcd.yaml
@@ -5818,20 +5818,40 @@ data:
                   +usage=The release name\n\treleaseName?: string\n\t// +usage=Chart values\n\tvalues?:
                   #nestedmap\n}\n\n#nestedmap: {\n\t...\n}\n"
             status:
-              customStatus: "repoMessage:    string\nreleaseMessage: string\nif context.output.status
-                == _|_ {\n\trepoMessage:    \"Fetching repository\"\n\treleaseMessage:
-                \"Wating repository ready\"\n}\nif context.output.status != _|_ {\n\trepoStatus:
-                context.output.status\n\tif repoStatus.conditions[0][\"type\"] != \"Ready\"
-                {\n\t\trepoMessage: \"Fetch repository fail\"\n\t}\n\tif repoStatus.conditions[0][\"type\"]
-                == \"Ready\" {\n\t\trepoMessage: \"Fetch repository successfully\"\n\t}\n\n\tif
-                context.outputs.release.status == _|_ {\n\t\treleaseMessage: \"Creating
-                helm release\"\n\t}\n\tif context.outputs.release.status != _|_ {\n\t\tif
-                context.outputs.release.status.conditions[0][\"message\"] == \"Release
-                reconciliation succeeded\" {\n\t\t\treleaseMessage: \"Create helm release
-                successfully\"\n\t\t}\n\t\tif context.outputs.release.status.conditions[0][\"message\"]
-                != \"Release reconciliation succeeded\" {\n\t\t\treleaseMessage: \"Create
-                helm release fail, message: \" + context.outputs.release.status.conditions[0][\"message\"]\n\t\t}\n\t}\n\n}\nmessage:
-                repoMessage + \", \" + releaseMessage"
+              customStatus: |-
+                repoMessage:    string
+                releaseMessage: string
+                if context.output.status == _|_ {
+                        repoMessage:    "Fetching repository"
+                        releaseMessage: "Wating repository ready"
+                }
+                if context.output.status != _|_ {
+                        repoStatus: context.output.status
+                        if repoStatus.conditions[0]["type"] != "Ready" {
+                                repoMessage: "Fetch repository fail"
+                        }
+                        if repoStatus.conditions[0]["type"] == "Ready" {
+                                repoMessage: "Fetch repository successfully"
+                        }
+
+                        if context.outputs.release.status == _|_ {
+                                releaseMessage: "Creating helm release"
+                        }
+                        if context.outputs.release.status != _|_ {
+                                if context.outputs.release.status.conditions[0]["message"] == "Release reconciliation succeeded" {
+                                        releaseMessage: "Create helm release successfully"
+                                }
+                                if context.outputs.release.status.conditions[0]["message"] != "Release reconciliation succeeded" {
+                                        if len(context.outputs.release.status.conditions) == 1 {
+                                                releaseMessage: "Create helm release fail, message: " + context.outputs.release.status.conditions[0]["message"]
+                                        }
+                                        if len(context.outputs.release.status.conditions) > 1 {
+                                                releaseMessage: "Create helm release fail, message: " + context.outputs.release.status.conditions[0]["message"] + ", " + context.outputs.release.status.conditions[1]["message"]
+                                        }
+                                }
+                        }
+                }
+                message: repoMessage + ", " + releaseMessage
               healthPolicy: 'isHealth: len(context.outputs.release.status.conditions)
                 != 0 && context.outputs.release.status.conditions[0]["status"]=="True"'
             workload:


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
When installing helm failed，the application can only get rough information from the custom status of the helm component, like this:
```
  services:
  - healthy: false
    message: |-
      Fetch repository successfully, Create helm release fail, message: install retries exhausted
    name: msp-msp
```
expect:
```
  services:
  - healthy: false
    message: |-
      Fetch repository successfully, Create helm release fail, message: install retries exhausted, Helm install failed: timed out waiting for the condition

      Last Helm logs:

      creating 5 resource(s)
      beginning wait for 5 resources with timeout of 5m0s
      Deployment is not ready: default/msp-portal. 0 out of 3 expected pods are ready
    name: msp-msp
    workloadDefinition:
      apiVersion: ""
      kind: ""
```

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->