### PR TITLE
Feat: addon compatibility code for 1.1

### DIFF
--- a/pkg/addon/addon_suite_test.go
+++ b/pkg/addon/addon_suite_test.go
@@ -17,13 +17,140 @@ limitations under the License.
 package addon
 
 import (
-	"testing"
+	"context"
+	"fmt"
+	"time"
+
+	types2 "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 )
 
-func TestAddon(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Addon Suite")
-}
+var _ = Describe("Addon test", func() {
+	ctx := context.Background()
+	var app v1beta1.Application
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, &app)).Should(BeNil())
+	})
+
+	It("continueIfSuspend func test", func() {
+		app = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(appYaml), &app)).Should(BeNil())
+		app.SetNamespace(testns)
+		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+
+		Eventually(func() error {
+			checkApp := &v1beta1.Application{}
+			if err := k8sClient.Get(ctx, types2.NamespacedName{Namespace: app.Namespace, Name: app.Name}, checkApp); err != nil {
+				return err
+			}
+			appPatch := client.MergeFrom(checkApp.DeepCopy())
+			checkApp.Status.Workflow = &common.WorkflowStatus{Suspend: true}
+			if err := k8sClient.Status().Patch(ctx, checkApp, appPatch); err != nil {
+				return err
+			}
+			return nil
+		}, 30*time.Second, 300*time.Millisecond).Should(BeNil())
+
+		Eventually(func() error {
+			checkApp := &v1beta1.Application{}
+			if err := k8sClient.Get(ctx, types2.NamespacedName{Namespace: app.Namespace, Name: app.Name}, checkApp); err != nil {
+				return err
+			}
+			if !checkApp.Status.Workflow.Suspend {
+				return fmt.Errorf("app haven't not suspend")
+			}
+
+			h := Handler{ctx: ctx, cli: k8sClient, addon: &Addon{Meta: Meta{Name: "test-app"}}}
+			if err := h.continueIfSuspend(); err != nil {
+				return err
+			}
+			return nil
+		}, 30*time.Second, 300*time.Millisecond).Should(BeNil())
+
+		Eventually(func() error {
+			checkApp := &v1beta1.Application{}
+			if err := k8sClient.Get(ctx, types2.NamespacedName{Namespace: app.Namespace, Name: app.Name}, checkApp); err != nil {
+				return err
+			}
+			if checkApp.Status.Workflow.Suspend {
+				return fmt.Errorf("app haven't not continue")
+			}
+			return nil
+		}, 30*time.Second, 300*time.Millisecond).Should(BeNil())
+	})
+
+	It(" FetchAddonRelatedApp func test", func() {
+		app = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(legacyAppYaml), &app)).Should(BeNil())
+		app.SetNamespace(testns)
+		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+
+		Eventually(func() error {
+			app, err := FetchAddonRelatedApp(ctx, k8sClient, "legacy-addon")
+			if err != nil {
+				return err
+			}
+			if app.Name != "legacy-addon" {
+				return fmt.Errorf("error addon app name")
+			}
+			return nil
+		}, 30*time.Second, 300*time.Millisecond).Should(BeNil())
+	})
+
+	It(" determineAddonAppName func test", func() {
+		app = v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(legacyAppYaml), &app)).Should(BeNil())
+		app.SetNamespace(testns)
+		Expect(k8sClient.Create(ctx, &app)).Should(BeNil())
+
+		Eventually(func() error {
+			appName, err := determineAddonAppName(ctx, k8sClient, "legacy-addon")
+			if err != nil {
+				return err
+			}
+			if appName != "legacy-addon" {
+				return fmt.Errorf("error addon app name")
+			}
+			return nil
+		}, 30*time.Second, 300*time.Millisecond).Should(BeNil())
+
+		notExsitAppName, err := determineAddonAppName(ctx, k8sClient, "not-exist")
+		Expect(err).Should(BeNil())
+		Expect(notExsitAppName).Should(BeEquivalentTo("addon-not-exist"))
+	})
+})
+
+const (
+	appYaml = `apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: addon-test-app
+spec:
+  components:
+    - name: express-server
+      type: webservice
+      properties:
+        image: crccheck/hello-world
+        port: 8000
+`
+	legacyAppYaml = `apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: legacy-addon
+spec:
+  components:
+    - name: express-server
+      type: webservice
+      properties:
+        image: crccheck/hello-world
+        port: 8000
+`
+)

--- a/pkg/addon/suite_test.go
+++ b/pkg/addon/suite_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package addon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	v12 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	coreoam "github.com/oam-dev/kubevela/apis/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/cue/packages"
+	"github.com/oam-dev/kubevela/pkg/oam/discoverymapper"
+	// +kubebuilder:scaffold:imports
+)
+
+var cfg *rest.Config
+var scheme *runtime.Scheme
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var dm discoverymapper.DiscoveryMapper
+var pd *packages.PackageDiscover
+var testns string
+
+func TestAddon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Addon Suite test",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+	By("bootstrapping test environment")
+	useExistCluster := false
+	testEnv = &envtest.Environment{
+		ControlPlaneStartTimeout: time.Minute,
+		ControlPlaneStopTimeout:  time.Minute,
+		CRDDirectoryPaths:        []string{filepath.Join("..", "..", "charts", "vela-core", "crds")},
+		UseExistingCluster:       &useExistCluster,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+	scheme = runtime.NewScheme()
+	Expect(coreoam.AddToScheme(scheme)).NotTo(HaveOccurred())
+	Expect(clientgoscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+	Expect(v1beta1.AddToScheme(scheme)).NotTo(HaveOccurred())
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+	dm, err = discoverymapper.New(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(dm).ToNot(BeNil())
+	pd, err = packages.NewPackageDiscover(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(pd).ToNot(BeNil())
+	testns = "vela-system"
+	Expect(k8sClient.Create(context.Background(),
+		&v12.Namespace{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"}, ObjectMeta: metav1.ObjectMeta{
+			Name: testns,
+		}}))
+
+	close(done)
+}, 120)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -53,6 +53,10 @@ const (
 	AddonPhaseEnabled AddonPhase = "enabled"
 	// AddonPhaseEnabling indicates the addon is enabling
 	AddonPhaseEnabling AddonPhase = "enabling"
+	// AddonPhaseDisabling indicates the addon is enabling
+	AddonPhaseDisabling AddonPhase = "disabling"
+	// AddonPhaseSuspend indicates the addon is suspend
+	AddonPhaseSuspend AddonPhase = "suspend"
 )
 
 // EmptyResponse empty response, it will used for delete api


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This pr have done such things：

1.  application's name of addon in 1.2 is addon-{addonName}, but in 1.1 is just {addonName}, we cannot let user delete old app and enable addon again, so insert compatibility code.
2. algin the addon status of  apiserver and cli  
3. addon suspend status
4. enable addon will continue app workflow if workflow is suspending

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->