### PR TITLE
Fix: implement addons/observability/status API

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -102,10 +102,20 @@ var (
 	CLIMetaOptions = ListOptions{}
 )
 
+const (
+	// ObservabilityAddon is the name of the observability addon
+	ObservabilityAddon = "observability"
+	// ObservabilityAddonEndpointComponent is the endpoint component name of the observability addon
+	ObservabilityAddonEndpointComponent = "grafana"
+	// ObservabilityAddonDomainArg is the domain argument name of the observability addon
+	ObservabilityAddonDomainArg = "domain"
+)
+
 // ObservabilityEnvironment contains the Observability addon's domain for each cluster
 type ObservabilityEnvironment struct {
-	Cluster string
-	Domain  string
+	Cluster        string
+	Domain         string
+	LoadBalancerIP string
 }
 
 // ObservabilityEnvBindingValues is a list of ObservabilityEnvironment and will be used to render observability-env-binding.yaml
@@ -480,7 +490,7 @@ func RenderApp(ctx context.Context, addon *InstallPackage, config *rest.Config, 
 		if err != nil {
 			return nil, ErrRenderCueTmpl
 		}
-		if addon.Name == "observability" && strings.HasSuffix(comp.Name, ".cue") {
+		if addon.Name == ObservabilityAddon && strings.HasSuffix(comp.Name, ".cue") {
 			comp.Name = strings.Split(comp.Name, ".cue")[0]
 		}
 		app.Spec.Components = append(app.Spec.Components, *comp)
@@ -500,8 +510,8 @@ func RenderApp(ctx context.Context, addon *InstallPackage, config *rest.Config, 
 				Name: "deploy-runtime",
 				Type: "deploy2runtime",
 			})
-	case addon.Name == "observability":
-		arg, ok := args["domain"]
+	case addon.Name == ObservabilityAddon:
+		arg, ok := args[ObservabilityAddonDomainArg]
 		if !ok {
 			return nil, ErrorNoDomain
 		}

--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -18,14 +18,17 @@ package addon
 
 import (
 	"context"
+	"encoding/json"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	commontypes "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
-
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	commontypes "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/utils/apply"
 )
 
@@ -89,6 +92,57 @@ func GetAddonStatus(ctx context.Context, cli client.Client, name string) (Status
 	default:
 		return Status{AddonPhase: enabling, AppStatus: &app.Status}, nil
 	}
+}
+
+// GetObservabilityAccessibilityInfo will get the accessibility info of addon in local cluster and multiple clusters
+func GetObservabilityAccessibilityInfo(ctx context.Context, k8sClient client.Client, domain string) ([]ObservabilityEnvironment, error) {
+	domains, err := allocateDomainForAddon(ctx, k8sClient, domain)
+	if err != nil {
+		return nil, err
+	}
+
+	obj := new(unstructured.Unstructured)
+	obj.SetKind("Ingress")
+	obj.SetAPIVersion("networking.k8s.io/v1")
+	key := client.ObjectKeyFromObject(obj)
+	key.Namespace = types.DefaultKubeVelaNS
+	key.Name = ObservabilityAddonEndpointComponent
+	for i, d := range domains {
+		if err != nil {
+			return nil, err
+		}
+		readCtx := multicluster.ContextWithClusterName(ctx, d.Cluster)
+		if err := k8sClient.Get(readCtx, key, obj); err != nil {
+			return nil, err
+		}
+		var ingress networkingv1.Ingress
+		data, err := obj.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(data, &ingress); err != nil {
+			return nil, err
+		}
+		if ingress.Status.LoadBalancer.Ingress != nil && len(ingress.Status.LoadBalancer.Ingress) == 1 {
+			domains[i].LoadBalancerIP = ingress.Status.LoadBalancer.Ingress[0].IP
+		}
+	}
+	// set domain for the cluster if there is no child clusters
+	if len(domains) == 0 {
+		var ingress networkingv1.Ingress
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: ObservabilityAddonEndpointComponent, Namespace: types.DefaultKubeVelaNS}, &ingress); err != nil {
+			return nil, err
+		}
+		if ingress.Status.LoadBalancer.Ingress != nil && len(ingress.Status.LoadBalancer.Ingress) == 1 {
+			domains = []ObservabilityEnvironment{
+				{
+					Domain:         domain,
+					LoadBalancerIP: ingress.Status.LoadBalancer.Ingress[0].IP,
+				},
+			}
+		}
+	}
+	return domains, nil
 }
 
 // Status contain addon phase and related app status

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -140,6 +140,8 @@ type AddonStatusResponse struct {
 
 	EnablingProgress *EnablingProgress `json:"enabling_progress,omitempty"`
 	AppStatus        common.AppStatus  `json:"appStatus,omitempty"`
+	// the status of multiple clusters
+	Clusters map[string]map[string]interface{} `json:"clusters,omitempty"`
 }
 
 // EnablingProgress defines the progress of enabling an addon

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -178,6 +178,7 @@ func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*ap
 		Name:      name,
 		Phase:     apis.AddonPhase(status.AddonPhase),
 		AppStatus: *status.AppStatus,
+		Clusters:  status.Clusters,
 	}
 
 	if res.Phase != apis.AddonPhaseEnabled {
@@ -197,34 +198,6 @@ func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*ap
 		}
 	}
 
-	if name == pkgaddon.ObservabilityAddon {
-		res.Args = make(map[string]string, len(sec.Data))
-		for k, v := range sec.Data {
-			res.Args[k] = string(v)
-		}
-
-		var domain string
-		if v, ok := sec.Data[pkgaddon.ObservabilityAddonDomainArg]; ok {
-			domain = string(v)
-		}
-		observability, err := pkgaddon.GetObservabilityAccessibilityInfo(ctx, u.kubeClient, domain)
-		if err != nil {
-			return nil, err
-		}
-		var cluster = make(map[string]map[string]interface{})
-		for _, o := range observability {
-			var access = fmt.Sprintf("No loadBalancer found, visiting by using 'vela port-forward %s", pkgaddon.ObservabilityAddon)
-			if o.LoadBalancerIP != "" {
-				access = fmt.Sprintf("Visiting URL: %s, IP: %s", o.Domain, o.LoadBalancerIP)
-			}
-			cluster[o.Cluster] = map[string]interface{}{
-				"domain":         o.Domain,
-				"LoadBalancerIP": o.LoadBalancerIP,
-				"Access":         access,
-			}
-		}
-		res.Clusters = cluster
-	}
 	return &res, nil
 }
 

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -163,7 +163,6 @@ func (u *defaultAddonHandler) GetAddon(ctx context.Context, name string, registr
 }
 
 func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*apis.AddonStatusResponse, error) {
-
 	status, err := pkgaddon.GetAddonStatus(ctx, u.kubeClient, name)
 	if err != nil {
 		return nil, bcode.ErrGetAddonApplication
@@ -196,7 +195,35 @@ func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*ap
 		for k, v := range sec.Data {
 			res.Args[k] = string(v)
 		}
+	}
 
+	if name == pkgaddon.ObservabilityAddon {
+		res.Args = make(map[string]string, len(sec.Data))
+		for k, v := range sec.Data {
+			res.Args[k] = string(v)
+		}
+
+		var domain string
+		if v, ok := sec.Data[pkgaddon.ObservabilityAddonDomainArg]; ok {
+			domain = string(v)
+		}
+		observability, err := pkgaddon.GetObservabilityAccessibilityInfo(ctx, u.kubeClient, domain)
+		if err != nil {
+			return nil, err
+		}
+		var cluster = make(map[string]map[string]interface{})
+		for _, o := range observability {
+			var access = fmt.Sprintf("No loadBalancer found, visiting by using 'vela port-forward %s", pkgaddon.ObservabilityAddon)
+			if o.LoadBalancerIP != "" {
+				access = fmt.Sprintf("Visiting URL: %s, IP: %s", o.Domain, o.LoadBalancerIP)
+			}
+			cluster[o.Cluster] = map[string]interface{}{
+				"domain":         o.Domain,
+				"LoadBalancerIP": o.LoadBalancerIP,
+				"Access":         access,
+			}
+		}
+		res.Clusters = cluster
 	}
 	return &res, nil
 }


### PR DESCRIPTION
Return all domains and the IPs from all clusters. And
provider the way to visit the console of observability

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->