### PR TITLE
Fix: message invalid in action `op.#ConditionalWait` and `op.#Break`

### DIFF
--- a/pkg/stdlib/op.cue
+++ b/pkg/stdlib/op.cue
@@ -7,11 +7,12 @@ import (
 #ConditionalWait: {
 	#do:      "wait"
 	continue: bool
+	message?: string
 }
 
 #Break: {
-	#do:     "break"
-	message: string
+	#do:      "break"
+	message?: string
 }
 
 #Apply: kube.#Apply

--- a/pkg/workflow/providers/workspace/workspace.go
+++ b/pkg/workflow/providers/workspace/workspace.go
@@ -146,14 +146,18 @@ func (h *provider) Wait(ctx wfContext.Context, v *value.Value, act types.Action)
 			}
 		}
 	}
-
-	act.Wait("")
+	msg, _ := v.GetString("message")
+	act.Wait(msg)
 	return nil
 }
 
 // Break let workflow terminate.
 func (h *provider) Break(ctx wfContext.Context, v *value.Value, act types.Action) error {
-	act.Terminate("")
+	var msg string
+	if v != nil {
+		msg, _ = v.GetString("message")
+	}
+	act.Terminate(msg)
 	return nil
 }
 

--- a/pkg/workflow/providers/workspace/workspace_test.go
+++ b/pkg/workflow/providers/workspace/workspace_test.go
@@ -187,24 +187,29 @@ func TestProvider_Wait(t *testing.T) {
 	act := &mockAction{}
 	v, err := value.NewValue(`
 continue: 100!=100
+message: "test log"
 `, nil, "")
 	assert.NilError(t, err)
 	err = p.Wait(wfCtx, v, act)
 	assert.NilError(t, err)
 	assert.Equal(t, act.wait, true)
+	assert.Equal(t, act.msg, "test log")
 
 	act = &mockAction{}
 	v, err = value.NewValue(`
 continue: 100==100
+message: "not invalid"
 `, nil, "")
 	assert.NilError(t, err)
 	err = p.Wait(wfCtx, v, act)
 	assert.NilError(t, err)
 	assert.Equal(t, act.wait, false)
+	assert.Equal(t, act.msg, "")
 
 	act = &mockAction{}
 	v, err = value.NewValue(`
 continue: bool
+message: string
 `, nil, "")
 	assert.NilError(t, err)
 	err = p.Wait(wfCtx, v, act)
@@ -226,6 +231,16 @@ func TestProvider_Break(t *testing.T) {
 	err := p.Break(wfCtx, nil, act)
 	assert.NilError(t, err)
 	assert.Equal(t, act.terminate, true)
+
+	act = &mockAction{}
+	v, err := value.NewValue(`
+message: "terminate"
+`, nil, "")
+	assert.NilError(t, err)
+	err = p.Break(wfCtx, v, act)
+	assert.NilError(t, err)
+	assert.Equal(t, act.terminate, true)
+	assert.Equal(t, act.msg, "terminate")
 }
 
 type mockAction struct {


### PR DESCRIPTION
Signed-off-by: Jian.Li <lj176172@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->