### PR TITLE
Fix: add e2e test for Addon Observability

### DIFF
--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -132,7 +132,7 @@ func GetAddonStatus(ctx context.Context, cli client.Client, name string) (Status
 	}
 }
 
-// GetObservabilityAccessibilityInfo will get the accessibility info of addon in local cluster and multiple clusters
+// GetObservabilityAccessibilityInfo will get the accessibility info of an addon from local and children clusters
 func GetObservabilityAccessibilityInfo(ctx context.Context, k8sClient client.Client, domain string) ([]ObservabilityEnvironment, error) {
 	domains, err := allocateDomainForAddon(ctx, k8sClient, domain)
 	if err != nil {

--- a/test/e2e-addon-test/addon_test.go
+++ b/test/e2e-addon-test/addon_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Addon tests", func() {
 			time.Second*30, time.Millisecond*500).ShouldNot(BeNil())
 	})
 
-	PIt("Addon observability is successfully enabled", func() {
+	It("Addon observability is successfully enabled", func() {
 		By("Install Addon Observability")
 		output, err := exec.Command("bash", "-c", "/tmp/vela addon enable observability domain=abc.com disk-size=20Gi").Output()
 		var ee *exec.ExitError


### PR DESCRIPTION
Added an e2e testcase for Addon Observability and address the comments
from https://github.com/oam-dev/kubevela/pull/2966#discussion_r773145708

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->