### PR TITLE
Fix: vela port-forward supports Addon Observability

### DIFF
--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -344,7 +344,7 @@ func askToChooseOneResource(app *v1beta1.Application, filters ...clusterObjectRe
 	return nil, fmt.Errorf("choosing resource err %w", err)
 }
 
-func filterClusterObjectRefFromAddonObservability(resources []common.ClusterObjectReference) []common.ClusterObjectReference{
+func filterClusterObjectRefFromAddonObservability(resources []common.ClusterObjectReference) []common.ClusterObjectReference {
 	var observabilityResources []common.ClusterObjectReference
 	for _, res := range resources {
 		if res.Namespace == types.DefaultKubeVelaNS && res.Name == AddonObservabilityGrafanaSvc {

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/types"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -353,4 +355,16 @@ patch: {
 	assert.NoError(t, err)
 	_, err = RefineParameterInstance(inst)
 	assert.NotNil(t, err)
+}
+
+func TestFilterClusterObjectRefFromAddonObservability(t *testing.T) {
+	ref := common.ClusterObjectReference{}
+	ref.Name = AddonObservabilityGrafanaSvc
+	ref.Namespace = types.DefaultKubeVelaNS
+	resources := []common.ClusterObjectReference{ref}
+
+	res := filterClusterObjectRefFromAddonObservability(resources)
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, "Service", res[0].Kind)
+	assert.Equal(t, "v1", res[0].APIVersion)
 }

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
-	"github.com/oam-dev/kubevela/apis/types"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -34,6 +32,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/types"
 )
 
 var ResponseString = "Hello HTTP Get."

--- a/references/cli/utils.go
+++ b/references/cli/utils.go
@@ -59,5 +59,10 @@ func getCompNameFromClusterObjectReference(ctx context.Context, k8sClient client
 	if labels == nil {
 		return "", nil
 	}
+	// Addon observability --> some Helm typed components --> some fluxcd objects --> some services. Those services
+	// are not labeled with oam.LabelAppComponent
+	if r.Name == common.AddonObservabilityGrafanaSvc {
+		return r.Name, nil
+	}
 	return labels[oam.LabelAppComponent], nil
 }


### PR DESCRIPTION
Support port forwarding service of Addon Observability in
multiple clusters

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->