### PR TITLE
Fix: panic bug of addon enable

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -892,7 +892,7 @@ func (h *Installer) loadInstallPackage(name string) (*InstallPackage, error) {
 
 	meta, ok := metas[name]
 	if !ok {
-		return nil, errors.Wrapf(err, "fail to find the addon meta of %s", name)
+		return nil, fmt.Errorf("fail to find the addon meta of %s", name)
 	}
 	var uiData *UIData
 	uiData, err = h.cache.GetUIData(*h.r, name)


### PR DESCRIPTION
Signed-off-by: wangyike <wangyike_wyk@163.com>

If enable a not exist addon will panic.

![image](https://user-images.githubusercontent.com/77846369/147204397-fa19ca66-85e8-4246-8156-e03c16f0dc91.png)


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->