### PR TITLE
Fix: add registryName into addon list

### DIFF
--- a/charts/vela-core/templates/addon_registry.yaml
+++ b/charts/vela-core/templates/addon_registry.yaml
@@ -12,13 +12,5 @@ data:
       "bucket": "",
       "path": ""
     }
-  },
-  "KubeVela-Experimental":{
-    "name": "KubeVela-Experimental",
-    "oss": {
-      "end_point": "https://addons.kubevela.net",
-      "bucket": "",
-      "path": "experimental/"
-    }
   }
 }'

--- a/charts/vela-core/templates/addon_registry.yaml
+++ b/charts/vela-core/templates/addon_registry.yaml
@@ -12,5 +12,13 @@ data:
       "bucket": "",
       "path": ""
     }
+  },
+  "KubeVela-Experimental":{
+    "name": "KubeVela-Experimental",
+    "oss": {
+      "end_point": "https://addons.kubevela.net",
+      "bucket": "",
+      "path": "experimental/"
+    }
   }
 }'

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -188,7 +188,7 @@ func GetPatternFromItem(it Item, r AsyncReader, rootPath string) string {
 }
 
 // ListAddonUIDataFromReader list addons from AsyncReader
-func ListAddonUIDataFromReader(r AsyncReader, registryMeta map[string]SourceMeta, opt ListOptions) ([]*UIData, error) {
+func ListAddonUIDataFromReader(r AsyncReader, registryMeta map[string]SourceMeta, registryName string, opt ListOptions) ([]*UIData, error) {
 	var addons []*UIData
 	var err error
 	var wg sync.WaitGroup
@@ -206,6 +206,7 @@ func ListAddonUIDataFromReader(r AsyncReader, registryMeta map[string]SourceMeta
 				errCh <- err
 				return
 			}
+			addonRes.RegistryName = registryName
 			l.Lock()
 			addons = append(addons, addonRes)
 			l.Unlock()

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -123,7 +123,7 @@ func testReaderFunc(t *testing.T, reader AsyncReader) {
 	assert.True(t, len(uiData.Definitions) > 0)
 
 	// test get ui data
-	uiDataList, err := ListAddonUIDataFromReader(reader, registryMeta, UIMetaOptions)
+	uiDataList, err := ListAddonUIDataFromReader(reader, registryMeta, "KubeVela", UIMetaOptions)
 	assert.True(t, strings.Contains(err.Error(), "#parameter.example: preference mark not allowed at this position"))
 	assert.Equal(t, len(uiDataList), 3)
 

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -191,7 +191,7 @@ func (r *Registry) ListUIData(registryAddonMeta map[string]SourceMeta, opt ListO
 	if err != nil {
 		return nil, err
 	}
-	return ListAddonUIDataFromReader(reader, registryAddonMeta, opt)
+	return ListAddonUIDataFromReader(reader, registryAddonMeta, r.Name, opt)
 }
 
 // GetInstallPackage get install package which is all needed to enable an addon from addon registry

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -36,6 +36,7 @@ type UIData struct {
 	Definitions    []ElementFile `json:"definitions"`
 	CUEDefinitions []ElementFile `json:"CUEDefinitions"`
 	Parameters     string        `json:"parameters"`
+	RegistryName   string        `json:"registryName"`
 }
 
 // InstallPackage contains all necessary files that can be installed for an addon

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -107,6 +107,7 @@ type ListAddonResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
+// AddonInfo contain addon metaData and some baseInfo
 type AddonInfo struct {
 	*addon.Meta
 	RegistryName string `json:"registryName"`

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -101,10 +101,15 @@ type EnableAddonRequest struct {
 
 // ListAddonResponse defines the format for addon list response
 type ListAddonResponse struct {
-	Addons []*addon.Meta `json:"addons"`
+	Addons []*AddonInfo `json:"addons"`
 
 	// Message demonstrate the error info if exists
 	Message string `json:"message,omitempty"`
+}
+
+type AddonInfo struct {
+	*addon.Meta
+	RegistryName string `json:"registryName"`
 }
 
 // ListEnabledAddonResponse defines the format for enabled addon list response
@@ -126,8 +131,9 @@ type DetailAddonResponse struct {
 	UISchema  []*utils.UIParameter `json:"uiSchema"`
 
 	// More details about the addon, e.g. README
-	Detail      string             `json:"detail,omitempty"`
-	Definitions []*AddonDefinition `json:"definitions"`
+	Detail       string             `json:"detail,omitempty"`
+	Definitions  []*AddonDefinition `json:"definitions"`
+	RegistryName string             `json:"registryName,omitempty"`
 }
 
 // AddonDefinition is definition an addon can provide

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -78,11 +78,12 @@ func AddonImpl2AddonRes(impl *pkgaddon.UIData) (*apis.DetailAddonResponse, error
 		})
 	}
 	return &apis.DetailAddonResponse{
-		Meta:        impl.Meta,
-		APISchema:   impl.APISchema,
-		UISchema:    impl.UISchema,
-		Detail:      impl.Detail,
-		Definitions: defs,
+		Meta:         impl.Meta,
+		APISchema:    impl.APISchema,
+		UISchema:     impl.UISchema,
+		Detail:       impl.Detail,
+		Definitions:  defs,
+		RegistryName: impl.RegistryName,
 	}, nil
 }
 

--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -20,7 +20,6 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 
-	pkgaddon "github.com/oam-dev/kubevela/pkg/addon"
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/usecase"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
@@ -122,10 +121,10 @@ func (s *addonWebService) listAddons(req *restful.Request, res *restful.Response
 		return
 	}
 
-	var addons []*pkgaddon.Meta
+	var addons []*apis.AddonInfo
 
 	for _, d := range detailAddons {
-		addons = append(addons, &d.Meta)
+		addons = append(addons, &apis.AddonInfo{Meta: &d.Meta, RegistryName: d.RegistryName})
 	}
 
 	var message string

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -329,7 +329,7 @@ func listAddons(ctx context.Context, registry string) error {
 	}
 
 	table := uitable.New()
-	table.AddRow("NAME", "REGISTRY-NAME", "DESCRIPTION", "STATUS")
+	table.AddRow("NAME", "REGISTRY", "DESCRIPTION", "STATUS")
 
 	for _, addon := range addons {
 		status, err := pkgaddon.GetAddonStatus(ctx, clt, addon.Name)

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -329,14 +329,14 @@ func listAddons(ctx context.Context, registry string) error {
 	}
 
 	table := uitable.New()
-	table.AddRow("NAME", "DESCRIPTION", "STATUS")
+	table.AddRow("NAME", "REGISTRY-NAME", "DESCRIPTION", "STATUS")
 
 	for _, addon := range addons {
 		status, err := pkgaddon.GetAddonStatus(ctx, clt, addon.Name)
 		if err != nil {
 			return err
 		}
-		table.AddRow(addon.Name, addon.Description, status.AddonPhase)
+		table.AddRow(addon.Name, addon.RegistryName, addon.Description, status.AddonPhase)
 	}
 	fmt.Println(table.String())
 	return nil

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -294,7 +294,7 @@ func statusAddon(name string, ioStreams cmdutil.IOStreams, cmd *cobra.Command, c
 	}
 	fmt.Printf("addon %s status is %s \n", name, status.AddonPhase)
 	if status.AddonPhase != statusEnabled && status.AddonPhase != statusDisabled {
-		fmt.Printf("diagnose addon info from  realted application %s ", pkgaddon.Convert2AppName(name))
+		fmt.Printf("diagnose addon info from application %s", pkgaddon.Convert2AppName(name))
 		err := printAppStatus(context.Background(), clt, ioStreams, pkgaddon.Convert2AppName(name), types.DefaultKubeVelaNS, cmd, c)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: wangyike <wangyike_wyk@163.com>

Add registry-name in addon list

/api/v1/addons/ add registryName field 

```json
    "addons": [
        {
            "name": "fluxcd",
            "version": "1.0.0",
            "description": "Extended workload to do continuous and progressive delivery",
            "icon": "https://raw.githubusercontent.com/fluxcd/flux/master/docs/_files/weave-flux.png",
            "url": "https://fluxcd.io",
            "tags": [
                "extended_workload",
                "gitops"
            ],
            "deployTo": {
                "runtime_cluster": true,
                "disableControlPlane": false,
                "runtimeCluster": false
            },
            "needNamespace": [
                "flux-system"
            ],
            "invisible": false,
            "registryName": "KubeVela"
        },
```

Cli :

![image](https://user-images.githubusercontent.com/77846369/147333357-ce4baf05-aac8-460f-8787-bf4272f801de.png)


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->