### PR TITLE
Fix: return reasonable error make multi-registry work

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -892,7 +892,7 @@ func (h *Installer) loadInstallPackage(name string) (*InstallPackage, error) {
 
 	meta, ok := metas[name]
 	if !ok {
-		return nil, fmt.Errorf("fail to find the addon meta of %s", name)
+		return nil, ErrNotExist
 	}
 	var uiData *UIData
 	uiData, err = h.cache.GetUIData(*h.r, name)


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>

When getting addon from multiple registries, registries from second will be omitted. Fix this by return a typed error so caller can judge the situation.

![image](https://user-images.githubusercontent.com/47812250/147329632-20822a29-30be-4990-a385-9ef9f13b8e0a.png)


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes https://github.com/oam-dev/kubevela/issues/2992

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->