### PR TITLE
Fix: change Grafana service type and remove domain parameter

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -113,9 +113,9 @@ const (
 
 // ObservabilityEnvironment contains the Observability addon's domain for each cluster
 type ObservabilityEnvironment struct {
-	Cluster        string
-	Domain         string
-	LoadBalancerIP string
+	Cluster           string
+	Domain            string
+	LoadBalancerIP    string
 	ServiceExternalIP string
 }
 

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -154,11 +154,9 @@ func TestRender(t *testing.T) {
 			envs: []ObservabilityEnvironment{
 				{
 					Cluster: "c1",
-					Domain:  "a.com",
 				},
 				{
 					Cluster: "c2",
-					Domain:  "b.com",
 				},
 			},
 			tmpl: ObservabilityEnvBindingEnvTmpl,
@@ -169,27 +167,11 @@ func TestRender(t *testing.T) {
             placement:
               clusterSelector:
                 name: c1
-            patch:
-              components:
-                - name: grafana
-                  type: helm
-                  traits:
-                    - type: pure-ingress
-                      properties:
-                        domain: a.com
           
           - name: c2
             placement:
               clusterSelector:
                 name: c2
-            patch:
-              components:
-                - name: grafana
-                  type: helm
-                  traits:
-                    - type: pure-ingress
-                      properties:
-                        domain: b.com
           
         `,
 
@@ -199,11 +181,9 @@ func TestRender(t *testing.T) {
 			envs: []ObservabilityEnvironment{
 				{
 					Cluster: "c1",
-					Domain:  "a.com",
 				},
 				{
 					Cluster: "c2",
-					Domain:  "b.com",
 				},
 			},
 			tmpl: ObservabilityWorkflow4EnvBindingTmpl,
@@ -459,18 +439,6 @@ func TestRenderApp4Observability(t *testing.T) {
 				},
 			},
 			args:        map[string]interface{}{},
-			application: "",
-			err:         ErrorNoDomain,
-		},
-		{
-			addon: InstallPackage{
-				Meta: Meta{
-					Name: "observability",
-				},
-			},
-			args: map[string]interface{}{
-				"domain": "a.com",
-			},
 			application: `{"kind":"Application","apiVersion":"core.oam.dev/v1beta1","metadata":{"name":"addon-observability","namespace":"vela-system","creationTimestamp":null,"labels":{"addons.oam.dev/name":"observability"}},"spec":{"components":[],"policies":[{"name":"domain","type":"env-binding","properties":{"envs":null}}],"workflow":{"steps":[{"name":"deploy-control-plane","type":"apply-application-in-parallel"}]}},"status":{}}`,
 		},
 	}
@@ -517,10 +485,8 @@ func TestRenderApp4ObservabilityWithK8sData(t *testing.T) {
 					Name: "observability",
 				},
 			},
-			args: map[string]interface{}{
-				"domain": "a.com",
-			},
-			application: `{"kind":"Application","apiVersion":"core.oam.dev/v1beta1","metadata":{"name":"addon-observability","namespace":"vela-system","creationTimestamp":null,"labels":{"addons.oam.dev/name":"observability"}},"spec":{"components":[],"policies":[{"name":"domain","type":"env-binding","properties":{"envs":[{"name":"test-secret","patch":{"components":[{"name":"grafana","traits":[{"properties":{"domain":"test-secret.a.com"},"type":"pure-ingress"}],"type":"helm"}]},"placement":{"clusterSelector":{"name":"test-secret"}}}]}}],"workflow":{"steps":[{"name":"deploy-control-plane","type":"apply-application-in-parallel"},{"name":"test-secret","type":"deploy2env","properties":{"env":"test-secret","parallel":true,"policy":"domain"}}]}},"status":{}}`,
+			args:        map[string]interface{}{},
+			application: `{"kind":"Application","apiVersion":"core.oam.dev/v1beta1","metadata":{"name":"addon-observability","namespace":"vela-system","creationTimestamp":null,"labels":{"addons.oam.dev/name":"observability"}},"spec":{"components":[],"policies":[{"name":"domain","type":"env-binding","properties":{"envs":[{"name":"test-secret","placement":{"clusterSelector":{"name":"test-secret"}}}]}}],"workflow":{"steps":[{"name":"deploy-control-plane","type":"apply-application-in-parallel"},{"name":"test-secret","type":"deploy2env","properties":{"env":"test-secret","parallel":true,"policy":"domain"}}]}},"status":{}}`,
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -367,13 +367,13 @@ func TestGetAddonStatus4Observability(t *testing.T) {
 	k8sClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(addonApplication, addonSecret, addonService).Build()
 	addonStatus, err = GetAddonStatus(context.Background(), k8sClient, ObservabilityAddon)
 	assert.NoError(t, err)
-	assert.Equal(t, addonStatus.AddonPhase, enabling)
+	assert.Equal(t, addonStatus.AddonPhase, enabled)
 
 	// Addon is installed in multiple clusters
 	assert.NoError(t, k8sClient.Create(ctx, clusterSecret))
 	addonStatus, err = GetAddonStatus(context.Background(), k8sClient, ObservabilityAddon)
 	assert.NoError(t, err)
-	assert.Equal(t, addonStatus.AddonPhase, enabling)
+	assert.Equal(t, addonStatus.AddonPhase, enabled)
 }
 
 var baseAddon = InstallPackage{

--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -134,7 +134,7 @@ func GetAddonStatus(ctx context.Context, cli client.Client, name string) (Status
 
 // GetObservabilityAccessibilityInfo will get the accessibility info of addon in local cluster and multiple clusters
 func GetObservabilityAccessibilityInfo(ctx context.Context, k8sClient client.Client, domain string) ([]ObservabilityEnvironment, error) {
-	domains, err := allocateDomainForAddon(ctx, k8sClient, domain)
+	domains, err := allocateDomainForAddon(ctx, k8sClient)
 	if err != nil {
 		return nil, err
 	}
@@ -153,16 +153,16 @@ func GetObservabilityAccessibilityInfo(ctx context.Context, k8sClient client.Cli
 		if err := k8sClient.Get(readCtx, key, obj); err != nil {
 			return nil, err
 		}
-		var ingress networkingv1.Ingress
+		var svc v1.Service
 		data, err := obj.MarshalJSON()
 		if err != nil {
 			return nil, err
 		}
-		if err := json.Unmarshal(data, &ingress); err != nil {
+		if err := json.Unmarshal(data, &svc); err != nil {
 			return nil, err
 		}
-		if ingress.Status.LoadBalancer.Ingress != nil && len(ingress.Status.LoadBalancer.Ingress) == 1 {
-			domains[i].LoadBalancerIP = ingress.Status.LoadBalancer.Ingress[0].IP
+		if svc.Status.LoadBalancer.Ingress != nil && len(svc.Status.LoadBalancer.Ingress) == 1 {
+			domains[i].ServiceExternalIP = svc.Status.LoadBalancer.Ingress[0].IP
 		}
 	}
 	// set domain for the cluster if there is no child clusters


### PR DESCRIPTION
Use Grafana service's external IP to visit the dashboard and
remove the prameter domain

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->