### PR TITLE
Fix: op.#Task couldn't work, debug task.cue and fix bugs

### DIFF
--- a/docs/examples/workflow/source-to-image/step-definition.yaml
+++ b/docs/examples/workflow/source-to-image/step-definition.yaml
@@ -10,46 +10,69 @@ spec:
         import ("vela/op")
 
         parameter: {
-           repoUrl: string
-           dockerfile: string
-           image: string
+          // +usage=Specify the SSH URL of git repository for your source codes, e.g. git@git.woa.com:my-git-repo/demo.git
+          repoUrl: string
+
+          // +usage=Specify the branch which you want to be checked out and built
+          branch: string
+
+          // +usage=Specify the filename of Dockerfile under the root folder in your git repository
+          dockerfile: string
+
+          // +usage=Specify the secret name for the docker repository in your namespace in your K8S cluster
+          dockerSecret: string
+
+          // +usage=Specify the address where the image built is pushed into
+          image: string
         }
 
-        let pushImage=image
-
         build: op.#Task & {
-                name:      "\(context.name)-\(context.stepId)"
-                namespace: context.namespace
+          name:      "\(context.name)-build-\(context.stepSessionID)"
+          namespace: context.namespace
 
-                // Declare workspaces that used to share data.
-                workspace: {
-                        "code-dir": {}
-                }
+          toolImage: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.27.2"
+          baseImage: "busybox:1.34"
 
-                steps: [
-                        // git clone code repo.
-                        {
-                                name:  "git-clone"
-                                image: "git-image-with-pull-ssh"
-                                workspaceMounts: [{workspace: workspace["code-dir"], mountPath: "/data/code"}]
-                                script: """
-                #! /bin/bash
-                git clone \(repourl) /data/code
-                """
-                        },
-                        // build and push image.
-                        {
-                                name:  "build-image"
-                                image: "gcr.io/kaniko-project/executor:v1.3.0"
-                                workspaceMounts: [{workspace: workspace["code-dir"], mountPath: "/data/build"}]
-                                script: """
-                #! /bin/bash
-                /kaniko/executor --dockerfile=/data/build/\(dockerfile) --context=/data/build --destination=\(pushImage)
-                """
-                        }]
+          // Declare workspaces that used to share data.
+          workspaces: {
+            "code-dir": {}
+          }
+
+          secrets: {
+            "\(parameter.dockerSecret)": {
+              items: [{
+                  key: ".dockerconfigjson"
+                  path: "config.json"
+              }]
+            }
+          }
+
+          steps: [
+            // git clone code repo.
+            {
+              name:  "git-clone"
+              image: "bitnami/git:2.34.1"
+              workspaceMounts: [{workspace: workspaces["code-dir"], mountPath: "/data/code"}]
+              script: """
+              #!/bin/bash
+              git clone -b \(parameter.branch)  \(parameter.repoUrl) /data/code
+              """
+            },
+            // build and push image.
+            {
+              name:  "build-image"
+              image: "gcr.io/kaniko-project/executor:debug"
+              workspaceMounts: [{workspace: workspaces["code-dir"], mountPath: "/data/build"}]
+              secretMounts: [{secret: secrets["\(parameter.dockerSecret)"], mountPath: "/kaniko/.docker/"}]
+              script: """
+              #!/busybox/sh
+              /kaniko/executor --dockerfile=/data/build/\(parameter.dockerfile) --context=/data/build --destination=\(parameter.image)
+              """
+            }]
         }
 
         // wait until deployment ready
         wait: op.#ConditionalWait & {
-           continue: build.do.status.phase == "successed"
+          continue: build.apply.value.status.phase == "Succeeded"
         }
+

--- a/pkg/stdlib/pkgs/task.cue
+++ b/pkg/stdlib/pkgs/task.cue
@@ -1,38 +1,58 @@
 
-let toolImage = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.27.2"
-let baseImage = "gcr.io/distroless/base@sha256:aa4fd987555ea10e1a4ec8765da8158b5ffdfef1e72da512c7ede509bc9966c4"
+let defaultToolImage = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.27.2"
+let defaultBaseImage = "gcr.io/distroless/base@sha256:aa4fd987555ea10e1a4ec8765da8158b5ffdfef1e72da512c7ede509bc9966c4"
 
 #Task: {
 	#do:       "steps"
 	name:      string
 	namespace: string
-	workspace: [_name_=string]: #workspace & {name: "\(_name_)"}
+	workspaces: [_name_=string]: #workspace & {name: "\(_name_)"}
+	secrets: [_name_=string]:    #secret & {name:    "\(_name_)"}
 	steps: [...#Script]
 
-	_name:      name
-	_namespace: namespace
-	_generate_scripts: [ for i, x in steps {"""
-scriptfile="/vela/scripts/script-\(i)"
-touch ${scriptfile} && chmod +x ${scriptfile}
-cat > ${scriptfile} << '_EOF_'
-\(base64.Encode(null, x.script))
-_EOF_
-"""}]
-	do: {
+	toolImage: *defaultToolImage | string
+	baseImage: *defaultBaseImage | string
+
+	generate_scripts_: [ for i, x in steps {
+		"""
+        scriptfile="/vela/scripts/script-\(i)"
+        touch ${scriptfile} && chmod +x ${scriptfile}
+        cat > ${scriptfile} << _EOF_
+        \(base64.Encode(null, x.script))
+        _EOF_
+        /vela/tools/entrypoint decode-script ${scriptfile}
+
+        """
+	}]
+
+	name_:      name
+	namespace_: namespace
+
+	apply: #Apply & {
 		value: #PodTask & {
-			_scripts:   strings.Join(_generate_scripts, "")
-			_workspace: workspace
+			_settings: {
+				scripts_:    strings.Join(generate_scripts_, "")
+				workspaces_: workspaces
+				secrets_:    secrets
+				toolImage_:  toolImage
+				baseImage_:  baseImage
+			}
+
 			metadata: {
-				name:      _name
-				namespace: _namespace
+				name:      name_
+				namespace: namespace_
 			}
 			spec: containers: [ for i, step in steps {
 				#StepContainer
-				name:             step.name
-				image:            step.image
-				env:              step.envs
-				_workspaceMounts: workspace
-				_index:           i
+				name:  step.name
+				image: step.image
+				env:   step.envs
+
+				_settings: {
+					workspaceMounts_: step.workspaceMounts
+					secretMounts_:    step.secretMounts
+					index_:           i
+				}
 			}]
 		}
 	}
@@ -44,16 +64,29 @@ _EOF_
 	script: string
 	envs: [...{name: string, value: string}]
 	workspaceMounts: [...{workspace: #workspace, mountPath: string}]
+	secretMounts: [...{secret: #secret, mountPath: string}]
 }
 
 #workspace: {
 	name: string
 }
 
+#secret: {
+	name: string
+	items: [...{key: string, path: string}]
+}
+
 #PodTask: {
-	_scripts: string
-	_workspace: {...}
-	_volumes: [ for x in _workspace {name: x.name, emptyDir: {}}]
+	_settings: {
+		scripts_: string
+		workspaces_: {...}
+		secrets_: {...}
+		volumes_: [ for x in workspaces_ {name: x.name, emptyDir: {}}]
+		secretVolumes_: [ for x in secrets_ {name: x.name, secret: {secretName: x.name, items: x.items}}]
+		toolImage_: string
+		baseImage_: string
+	}
+
 	apiVersion: "v1"
 	kind:       "Pod"
 	metadata: {
@@ -67,15 +100,15 @@ _EOF_
 			{
 				name: "place-tools"
 				command: ["/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/vela/tools/entrypoint"]
-				image:           toolImage
+				image:           _settings.toolImage_
 				imagePullPolicy: "IfNotPresent"
 				volumeMounts: [{name: "vela-internal-tools", mountPath: "/vela/tools"}]
 			}, {
 				name:            "place-scripts"
 				imagePullPolicy: "IfNotPresent"
-				image:           baseImage
+				image:           _settings.baseImage_
 				command: ["sh"]
-				args: ["-c", _scripts + "\n/vela/tools/entrypoint decode-script \"${scriptfile}\""]
+				args: ["-c", _settings.scripts_]
 				volumeMounts: [{name: "vela-internal-scripts", mountPath: "/vela/scripts"}, {name: "vela-internal-tools", mountPath: "/vela/tools"}]
 			}]
 		volumes: [
@@ -108,23 +141,29 @@ _EOF_
 				}]
 			}
 					name: "vela-internal-downward"
-				}] + _volumes
+				}] + _settings.volumes_ + _settings.secretVolumes_
 		restartPolicy: "Never"
 	}
 }
 
 #StepContainer: {
-	_index:    int
-	_waitFile: *"/vela/downward/ready" | string
-	if _index != 0 {
-		_waitFile: "/vela/tools/\(_index)"
+	_settings: {
+		index_: int
+		workspaceMounts_: [...{workspace: #workspace, mountPath: string}]
+		volumeMounts_: [ for v in workspaceMounts_ {name: v.workspace.name, mountPath: v.mountPath}]
+
+		secretMounts_: [...{secret: #secret, mountPath: string}]
+		secretVolumeMounts_: [ for v in secretMounts_ {name: v.secret.name, mountPath: v.mountPath}]
 	}
-	_workspaceMounts: {...}
-	_volumeMounts: [ for v in _workspaceMounts {name: v.workspace.name, mountPath: v.mountPath}]
 
 	name: string
-	args: ["-wait_file", _waitFile, "-wait_file_content", "-post_file", "/vela/tools/\(_index)", "-termination_path", "/vela/termination", "-step_metadata_dir", "/vela/steps/step-\(name)", "-step_metadata_dir_link", "/vela/steps/\(_index)", "-entrypoint", "/vela/scripts/script-\(_index)", "--"]
 	command: ["/vela/tools/entrypoint"]
+
+	args: *["-wait_file", "/vela/downward/ready", "-wait_file_content", "-post_file", "/vela/tools/\(_settings.index_)", "-termination_path", "/vela/termination", "-step_metadata_dir", "/vela/steps/step-\(name)", "-step_metadata_dir_link", "/vela/steps/\(_settings.index_)", "-entrypoint", "/vela/scripts/script-\(_settings.index_)", "--"] | [...string]
+	if _settings.index_ > 0 {
+		args: ["-wait_file", "/vela/tools/\(_settings.index_-1)", "-post_file", "/vela/tools/\(_settings.index_)", "-termination_path", "/vela/termination", "-step_metadata_dir", "/vela/steps/step-\(name)", "-step_metadata_dir_link", "/vela/steps/\(_settings.index_)", "-entrypoint", "/vela/scripts/script-\(_settings.index_)", "--"]
+	}
+
 	env?:                     _
 	image:                    string
 	imagePullPolicy:          "Always"
@@ -151,5 +190,5 @@ _EOF_
 	}, {
 		name:      "vela-internal-steps"
 		mountPath: "/vela/steps"
-	}] + _volumeMounts
+	}] + _settings.volumeMounts_ + _settings.secretVolumeMounts_
 }


### PR DESCRIPTION
### Description of your changes

we found that the cue type "op.#Task" couldn't work properly when we used it to create "source to image" workflow step definition. we fixed all bugs and make little changes and some enhancements, such as following:

1) allow to override the default base images since generally the production environment couldn't pull the images from the outside repositories.

2) add additional feature to bind the secrets into the step image container.


Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

we have tested the changes with the "source to image" case, and can work properly now.


### Special notes for your reviewer

