### PR TITLE
Feat: gc process ignore cluster not exists

### DIFF
--- a/pkg/multicluster/errors.go
+++ b/pkg/multicluster/errors.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package multicluster
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+)
 
 var (
 	// ErrClusterExists cluster already exists
@@ -27,3 +32,18 @@ var (
 
 // ClusterManagementError multicluster management error
 type ClusterManagementError error
+
+// IsClusterNotExists check if error is cluster not exists
+func IsClusterNotExists(err error) bool {
+	return strings.Contains(err.Error(), "no such cluster")
+}
+
+// IsNotFoundOrClusterNotExists check if error is not found or cluster not exists
+func IsNotFoundOrClusterNotExists(err error) bool {
+	return kerrors.IsNotFound(err) || IsClusterNotExists(err)
+}
+
+// IsClusterDisconnect check if error is cluster disconnect
+func IsClusterDisconnect(err error) bool {
+	return strings.Contains(err.Error(), "dial tcp")
+}

--- a/pkg/multicluster/errors_test.go
+++ b/pkg/multicluster/errors_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicluster
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCluster(t *testing.T) {
+	r := require.New(t)
+	err := errors.New("no such cluster: example-cluster")
+	r.True(IsNotFoundOrClusterNotExists(err))
+	err = errors.New("dial tcp: 127.0.0.1")
+	r.True(IsClusterDisconnect(err))
+}

--- a/pkg/resourcekeeper/cache.go
+++ b/pkg/resourcekeeper/cache.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -90,7 +89,7 @@ func (cache *resourceCache) get(ctx context.Context, mr v1beta1.ManagedResource)
 	}
 	if !entry.loaded {
 		if err := cache.cli.Get(multicluster.ContextWithClusterName(ctx, mr.Cluster), mr.NamespacedName(), entry.obj); err != nil {
-			if kerrors.IsNotFound(err) {
+			if multicluster.IsNotFoundOrClusterNotExists(err) {
 				entry.exists = false
 			} else {
 				entry.err = errors.Wrapf(err, "failed to get resource %s", key)

--- a/pkg/resourcekeeper/gc.go
+++ b/pkg/resourcekeeper/gc.go
@@ -266,7 +266,7 @@ func (h *gcHandler) GarbageCollectComponentRevisionResourceTracker(ctx context.C
 		if _, exists := inUseComponents[cr.ComponentKey()]; !exists && !skipGC {
 			_cr := &v1.ControllerRevision{}
 			err := h.Client.Get(multicluster.ContextWithClusterName(ctx, cr.Cluster), cr.NamespacedName(), _cr)
-			if err != nil && !kerrors.IsNotFound(err) {
+			if err != nil && !multicluster.IsNotFoundOrClusterNotExists(err) {
 				return errors.Wrapf(err, "failed to get component revision %s", cr.ResourceKey())
 			}
 			if err == nil {


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

During GC, ignore ClusterNotExists error. This is usually caused by some incorrect operation on cluster (such as directly removing cluster secret instead of using `vela cluster detach`, which will bypass the usage check) 

Notice that ClusterDisconnect is not ignored since it could be caused by some temporarily network failure.

Fixes #2986 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->