### PR TITLE
Feat: reset re-sync time

### DIFF
--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -130,7 +130,7 @@ spec:
             {{ if .Values.multicluster.enabled }}
             - "--enable-cluster-gateway"
             {{ end }}
-            - "--informer-re-sync-interval={{ .Values.controllerArgs.reSyncInterval }}"
+            - "--application-re-sync-period={{ .Values.controllerArgs.reSyncPeriod }}"
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
           resources:

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -130,6 +130,7 @@ spec:
             {{ if .Values.multicluster.enabled }}
             - "--enable-cluster-gateway"
             {{ end }}
+            - "--informer-re-sync-interval={{ .Values.controllerArgs.reSyncInterval }}"
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
           resources:

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -62,6 +62,9 @@ affinity: {}
 rbac:
   create: true
 
+controllerArgs:
+  reSyncInterval: 5m
+
 admissionWebhooks:
   enabled: true
   failurePolicy: Fail

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -63,7 +63,7 @@ rbac:
   create: true
 
 controllerArgs:
-  reSyncInterval: 5m
+  reSyncPeriod: 5m
 
 admissionWebhooks:
   enabled: true

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -74,7 +74,6 @@ func main() {
 	var healthAddr string
 	var disableCaps string
 	var storageDriver string
-	var syncPeriod time.Duration
 	var applyOnceOnly string
 	var qps float64
 	var burst int
@@ -110,8 +109,8 @@ func main() {
 		"For the purpose of some production environment that workload or trait should not be affected if no spec change, available options: on, off, force.")
 	flag.StringVar(&disableCaps, "disable-caps", "", "To be disabled builtin capability list.")
 	flag.StringVar(&storageDriver, "storage-driver", "Local", "Application file save to the storage driver")
-	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 5*time.Minute,
-		"controller shared informer lister full re-sync period")
+	flag.DurationVar(&commonconfig.ApplicationReSyncPeriod, "application-re-sync-period", 5*time.Minute,
+		"Re-sync period for application to re-sync, also known as the state-keep interval.")
 	flag.DurationVar(&commonconfig.ReconcileTimeout, "reconcile-timeout", time.Minute*3,
 		"the timeout for controller reconcile")
 	flag.StringVar(&oam.SystemDefinitonNamespace, "system-definition-namespace", "vela-system", "define the namespace of the system-level definition")
@@ -205,7 +204,6 @@ func main() {
 		Port:                       webhookPort,
 		CertDir:                    certDir,
 		HealthProbeBindAddress:     healthAddr,
-		SyncPeriod:                 &syncPeriod,
 		LeaderElectionResourceLock: leaderElectionResourceLock,
 		LeaseDuration:              &leaseDuration,
 		RenewDeadline:              &renewDeadline,

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -208,7 +208,12 @@ func main() {
 		LeaseDuration:              &leaseDuration,
 		RenewDeadline:              &renewDeadline,
 		RetryPeriod:                &retryPeriod,
-		ClientDisableCacheFor:      []client.Object{&appsv1.ControllerRevision{}},
+		// SyncPeriod is configured with default value, aka. 10h. First, controller-runtime does not
+		// recommend use it as a time trigger, instead, it is expected to work for failure tolerance
+		// of controller-runtime. Additionally, set this value will affect not only application
+		// controller but also all other controllers like definition controller. Therefore, for
+		// functionalities like state-keep, they should be invented in other ways.
+		ClientDisableCacheFor: []client.Object{&appsv1.ControllerRevision{}},
 	})
 	if err != nil {
 		klog.ErrorS(err, "Unable to create a controller manager")

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -110,7 +110,7 @@ func main() {
 		"For the purpose of some production environment that workload or trait should not be affected if no spec change, available options: on, off, force.")
 	flag.StringVar(&disableCaps, "disable-caps", "", "To be disabled builtin capability list.")
 	flag.StringVar(&storageDriver, "storage-driver", "Local", "Application file save to the storage driver")
-	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 60*time.Minute,
+	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 5*time.Minute,
 		"controller shared informer lister full re-sync period")
 	flag.DurationVar(&commonconfig.ReconcileTimeout, "reconcile-timeout", time.Minute*3,
 		"the timeout for controller reconcile")

--- a/design/api/vela-controller-params-reference.md
+++ b/design/api/vela-controller-params-reference.md
@@ -21,7 +21,7 @@
 |       apply-once-only       | string |               false               | For the purpose of some production environment that workload or trait should not be affected if no spec change, available options: on, off, force. |
 |        disable-caps         | string |                ""                 |           To be disabled builtin capability list.            |
 |       storage-driver        | string |               Local               |         Application file save to the storage driver          |
-|  informer-re-sync-interval  |  time  |                1h                 | Controller shared informer lister full re-sync period, the interval between two routinely reconciles for one CR (like Application) if no changes made to it. |
+|  informer-re-sync-interval  |  time  |                5m                 | Controller shared informer lister full re-sync period, the interval between two routinely reconciles for one CR (like Application) if no changes made to it. Also work as the state-keep interval. |
 |      reconcile-timeout      |  time  |                3m                 |           The timeout for controller reconcile.              |
 | system-definition-namespace | string |            vela-system            |     define the namespace of the system-level definition      |
 |    concurrent-reconciles    |  int   |                 4                 | The concurrent reconcile number of the controller. You can increase the degree of concurrency if a large number of CPU cores are provided to the controller. |

--- a/design/api/vela-controller-params-reference.md
+++ b/design/api/vela-controller-params-reference.md
@@ -21,7 +21,7 @@
 |       apply-once-only       | string |               false               | For the purpose of some production environment that workload or trait should not be affected if no spec change, available options: on, off, force. |
 |        disable-caps         | string |                ""                 |           To be disabled builtin capability list.            |
 |       storage-driver        | string |               Local               |         Application file save to the storage driver          |
-|  informer-re-sync-interval  |  time  |                5m                 | Controller shared informer lister full re-sync period, the interval between two routinely reconciles for one CR (like Application) if no changes made to it. Also work as the state-keep interval. |
+| application-re-sync-period  |  time  |                5m                 | Re-sync period for application to re-sync, also known as the state-keep interval. |
 |      reconcile-timeout      |  time  |                3m                 |           The timeout for controller reconcile.              |
 | system-definition-namespace | string |            vela-system            |     define the namespace of the system-level definition      |
 |    concurrent-reconciles    |  int   |                 4                 | The concurrent reconcile number of the controller. You can increase the degree of concurrency if a large number of CPU cores are provided to the controller. |

--- a/pkg/controller/common/context.go
+++ b/pkg/controller/common/context.go
@@ -29,6 +29,8 @@ var (
 var (
 	// ReconcileTimeout timeout for controller to reconcile
 	ReconcileTimeout = time.Minute * 3
+	// ApplicationReSyncPeriod re-sync period to reconcile application
+	ApplicationReSyncPeriod = time.Minute * 5
 )
 
 // NewReconcileContext create context with default timeout (60s)

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -101,7 +101,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if !kerrors.IsNotFound(err) {
 			logCtx.Error(err, "get application")
 		}
-		return ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, client.IgnoreNotFound(err)
+		return r.result(client.IgnoreNotFound(err)).ret()
 	}
 
 	logCtx.AddTag("resource_version", app.ResourceVersion)
@@ -211,7 +211,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	case common.WorkflowStateExecuting:
 		logCtx.Info("Workflow return state=Executing")
 		_, err = r.gcResourceTrackers(logCtx, handler, common.ApplicationRunningWorkflow, false)
-		return reconcile.Result{RequeueAfter: wf.GetBackoffWaitTime()}, err
+		return r.result(err).requeue(wf.GetBackoffWaitTime()).ret()
 	case common.WorkflowStateSucceeded:
 		logCtx.Info("Workflow return state=Succeeded")
 		if err := r.doWorkflowFinish(app, wf); err != nil {
@@ -224,7 +224,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	case common.WorkflowStateFinished:
 		logCtx.Info("Workflow state=Finished")
 		if status := app.Status.Workflow; status != nil && status.Terminated {
-			return ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, nil
+			return r.result(nil).ret()
 		}
 	}
 
@@ -275,13 +275,41 @@ func (r *Reconciler) gcResourceTrackers(logCtx monitorContext.Context, handler *
 			cond.Message = fmt.Sprintf("Waiting for %s to delete. (At least %d resources are deleting.)", waiting[0].DisplayName(), len(waiting))
 		}
 		handler.app.Status.SetConditions(cond)
-		return ctrl.Result{RequeueAfter: baseGCBackoffWaitTime}, r.patchStatus(logCtx, handler.app, phase)
+		return r.result(r.patchStatus(logCtx, handler.app, phase)).requeue(baseGCBackoffWaitTime).ret()
 	}
 	logCtx.Info("GarbageCollected resourcetrackers")
 	if phase == common.ApplicationRendering {
-		return ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, r.updateStatus(logCtx, handler.app, common.ApplicationRunningWorkflow)
+		return r.result(r.updateStatus(logCtx, handler.app, common.ApplicationRunningWorkflow)).ret()
 	}
-	return ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, r.patchStatus(logCtx, handler.app, phase)
+	return r.result(r.patchStatus(logCtx, handler.app, phase)).ret()
+}
+
+type reconcileResult struct {
+	time.Duration
+	err error
+}
+
+func (r *reconcileResult) requeue(d time.Duration) *reconcileResult {
+	r.Duration = d
+	return r
+}
+
+func (r *reconcileResult) ret() (ctrl.Result, error) {
+	if r.Duration.Seconds() != 0 {
+		return ctrl.Result{RequeueAfter: r.Duration}, r.err
+	} else if r.err != nil {
+		return ctrl.Result{}, r.err
+	}
+	return ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, nil
+}
+
+func (r *reconcileResult) end(endReconcile bool) (bool, ctrl.Result, error) {
+	ret, err := r.ret()
+	return endReconcile, ret, err
+}
+
+func (r *Reconciler) result(err error) *reconcileResult {
+	return &reconcileResult{err: err}
 }
 
 // NOTE Because resource tracker is cluster-scoped resources, we cannot garbage collect them
@@ -292,13 +320,13 @@ func (r *Reconciler) handleFinalizers(ctx monitorContext.Context, app *v1beta1.A
 		if !meta.FinalizerExists(app, resourceTrackerFinalizer) {
 			meta.AddFinalizer(app, resourceTrackerFinalizer)
 			ctx.Info("Register new finalizer for application", "finalizer", resourceTrackerFinalizer)
-			return true, ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, errors.Wrap(r.Client.Update(ctx, app), errUpdateApplicationFinalizer)
+			return r.result(errors.Wrap(r.Client.Update(ctx, app), errUpdateApplicationFinalizer)).end(true)
 		}
 	} else {
 		if meta.FinalizerExists(app, resourceTrackerFinalizer) {
 			rootRT, currentRT, historyRTs, cvRT, err := resourcetracker.ListApplicationResourceTrackers(ctx, r.Client, app)
 			if err != nil {
-				return true, ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, err
+				return r.result(err).end(true)
 			}
 			result, err := r.gcResourceTrackers(ctx, handler, common.ApplicationDeleting, true)
 			if err != nil {
@@ -306,20 +334,20 @@ func (r *Reconciler) handleFinalizers(ctx monitorContext.Context, app *v1beta1.A
 			}
 			if rootRT == nil && currentRT == nil && len(historyRTs) == 0 && cvRT == nil {
 				meta.RemoveFinalizer(app, resourceTrackerFinalizer)
-				return true, ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, errors.Wrap(r.Client.Update(ctx, app), errUpdateApplicationFinalizer)
+				return r.result(errors.Wrap(r.Client.Update(ctx, app), errUpdateApplicationFinalizer)).end(true)
 			}
 			return true, result, err
 		}
 	}
-	return false, ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, nil
+	return r.result(nil).end(false)
 }
 
 func (r *Reconciler) endWithNegativeCondition(ctx context.Context, app *v1beta1.Application, condition condition.Condition, phase common.ApplicationPhase) (ctrl.Result, error) {
 	app.SetConditions(condition)
 	if err := r.patchStatus(ctx, app, phase); err != nil {
-		return ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, errors.WithMessage(err, "cannot update application status")
+		return r.result(errors.WithMessage(err, "cannot update application status")).ret()
 	}
-	return ctrl.Result{RequeueAfter: common2.ApplicationReSyncPeriod}, fmt.Errorf("object level reconcile error, type: %q, msg: %q", string(condition.Type), condition.Message)
+	return r.result(fmt.Errorf("object level reconcile error, type: %q, msg: %q", string(condition.Type), condition.Message)).ret()
 }
 
 func (r *Reconciler) patchStatus(ctx context.Context, app *v1beta1.Application, phase common.ApplicationPhase) error {
@@ -471,6 +499,7 @@ func filterManagedFieldChangesUpdate(e ctrlEvent.UpdateEvent) bool {
 		return true
 	}
 	new.ManagedFields = old.ManagedFields
+	new.ResourceVersion = old.ResourceVersion
 	return !reflect.DeepEqual(new, old)
 }
 


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The default 1h re-sync time is a bit long for state-keep. In community version, users can experience the state-keep feature within 5 min now.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->