### PR TITLE
Feat: support logs for velaql

### DIFF
--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -34,3 +34,18 @@
 	cluster: string
 	...
 }
+
+#CollectLogsInPod: {
+	#do:       "collectLogsInPod"
+	#provider: "query"
+	cluster:   string
+	namespace: string
+	pod:       string
+	container: string
+	outputs?: {
+		logs: string
+		err?: string
+		...
+	}
+	...
+}

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -41,10 +41,22 @@
 	cluster:   string
 	namespace: string
 	pod:       string
-	container: string
+	options: {
+		container:    string
+		previous:     *false | bool
+		sinceSeconds: *null | int
+		sinceTime:    *null | string
+		timestamps:   *false | bool
+		tailLines:    *null | int
+		limitBytes:   *null | int
+	}
 	outputs?: {
 		logs: string
 		err?: string
+		info: {
+			fromDate: string
+			toDate:   string
+		}
 		...
 	}
 	...

--- a/pkg/stdlib/ql.cue
+++ b/pkg/stdlib/ql.cue
@@ -9,3 +9,5 @@
 #CollectPods: query.#CollectPods
 
 #SearchEvents: query.#SearchEvents
+
+#CollectLogsInPod: query.#CollectLogsInPod

--- a/pkg/velaql/providers/query/handler_test.go
+++ b/pkg/velaql/providers/query/handler_test.go
@@ -333,12 +333,28 @@ pod: "hello-world"`, nil, "")
 			Expect(err).Should(Succeed())
 			err = prd.CollectLogsInPod(nil, v, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("var(path=container) not exist"))
+			Expect(err.Error()).Should(ContainSubstring("var(path=options) not exist"))
 
 			v, err = value.NewValue(`cluster: "local"
 namespace: "default"
 pod: "hello-world"
-container: "main"`, nil, "")
+options: {
+  container: 1
+}`, nil, "")
+			Expect(err).Should(Succeed())
+			err = prd.CollectLogsInPod(nil, v, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("invalid log options content"))
+
+			v, err = value.NewValue(`cluster: "local"
+namespace: "default"
+pod: "hello-world"
+options: {
+  container: "main"
+  previous: true
+  sinceSeconds: 100
+  tailLines: 50
+}`, nil, "")
 			Expect(err).Should(Succeed())
 			Expect(prd.CollectLogsInPod(nil, v, nil)).Should(Succeed())
 			_, err = v.GetString("outputs", "logs")

--- a/pkg/velaql/suite_test.go
+++ b/pkg/velaql/suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func(done Done) {
 	pd, err := packages.NewPackageDiscover(cfg)
 	Expect(err).To(BeNil())
 
-	viewHandler = NewViewHandler(k8sClient, dm, pd)
+	viewHandler = NewViewHandler(k8sClient, cfg, dm, pd)
 	ctx := context.Background()
 
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "vela-system"}}

--- a/pkg/velaql/view.go
+++ b/pkg/velaql/view.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
@@ -48,6 +49,7 @@ const (
 // ViewHandler view handler
 type ViewHandler struct {
 	cli       client.Client
+	cfg       *rest.Config
 	viewTask  v1beta1.WorkflowStep
 	dm        discoverymapper.DiscoveryMapper
 	pd        *packages.PackageDiscover
@@ -55,9 +57,10 @@ type ViewHandler struct {
 }
 
 // NewViewHandler new view handler
-func NewViewHandler(cli client.Client, dm discoverymapper.DiscoveryMapper, pd *packages.PackageDiscover) *ViewHandler {
+func NewViewHandler(cli client.Client, cfg *rest.Config, dm discoverymapper.DiscoveryMapper, pd *packages.PackageDiscover) *ViewHandler {
 	return &ViewHandler{
 		cli:       cli,
+		cfg:       cfg,
 		dm:        dm,
 		pd:        pd,
 		namespace: qlNs,
@@ -79,7 +82,7 @@ func (handler *ViewHandler) QueryView(ctx context.Context, qv QueryView) (*value
 		Outputs:    queryKey.Outputs,
 	}
 
-	taskDiscover := tasks.NewViewTaskDiscover(handler.pd, handler.cli, handler.dispatch, handler.delete, handler.namespace)
+	taskDiscover := tasks.NewViewTaskDiscover(handler.pd, handler.cli, handler.cfg, handler.dispatch, handler.delete, handler.namespace)
 	genTask, err := taskDiscover.GetTaskGenerator(ctx, handler.viewTask.Type)
 	if err != nil {
 		return nil, err

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
@@ -114,11 +115,11 @@ func (tr *suspendTaskRunner) Pending(ctx wfContext.Context) bool {
 }
 
 // NewViewTaskDiscover will create a client for load task generator.
-func NewViewTaskDiscover(pd *packages.PackageDiscover, cli client.Client, apply kube.Dispatcher, delete kube.Deleter, viewNs string) types.TaskDiscover {
+func NewViewTaskDiscover(pd *packages.PackageDiscover, cli client.Client, cfg *rest.Config, apply kube.Dispatcher, delete kube.Deleter, viewNs string) types.TaskDiscover {
 	handlerProviders := providers.NewProviders()
 
 	// install builtin provider
-	query.Install(handlerProviders, cli)
+	query.Install(handlerProviders, cli, cfg)
 	time.Install(handlerProviders)
 	kube.Install(handlerProviders, cli, apply, delete)
 	http.Install(handlerProviders, cli, viewNs)

--- a/test/e2e-apiserver-test/testdata/collect-logs.yaml
+++ b/test/e2e-apiserver-test/testdata/collect-logs.yaml
@@ -9,17 +9,43 @@ data:
         "vela/ql"
     )
 
-    collectLogs: ql.#CollectLogsInPod & parameter
+    collectLogs: ql.#CollectLogsInPod & {
+      cluster: parameter.cluster
+      namespace: parameter.namespace
+      pod: parameter.pod
+      options: {
+        container: parameter.container
+        previous?: parameter.previous
+        sinceSeconds?: parameter.sinceSeconds
+        sinceTime?: parameter.sinceTime
+        timestamps?: parameter.timestamps
+        tailLines?: parameter.tailLines
+        limitBytes?: parameter.limitBytes
+      }
+    }
     status: collectLogs.outputs
 
     parameter: {
-        // +usage=Specify the cluster of the pod
-        cluster: string
-        // +usage=Specify the namespace of the pod
-        namespace: string
-        // +usage=Specify the name of the pod
-        pod: string
-        // +usage=Specify the name of the container
-        container: string
+      // +usage=Specify the cluster of the pod
+      cluster: string
+      // +usage=Specify the namespace of the pod
+      namespace: string
+      // +usage=Specify the name of the pod
+      pod: string
+
+      // +usage=Specify the name of the container
+      container: string
+      // +usage=If true, return previous terminated container logs
+      previous: *false | bool
+      // +usage=If set, show logs in relative times
+      sinceSeconds: *null | int
+      // +usage=RFC3339 timestamp, if set, show logs since this time
+      sinceTime: *null | string
+      // +usage=If true, add timestamp at the beginning of every line
+      timestamps: *false | bool
+      // +usage=If set, return the number of lines from the end of logs
+      tailLines: *null | int
+      // +usage=If set, limit the size of returned bytes
+      limitBytes: *null | int
     }
 

--- a/test/e2e-apiserver-test/testdata/collect-logs.yaml
+++ b/test/e2e-apiserver-test/testdata/collect-logs.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-collect-logs
+  namespace: vela-system
+data:
+  template: |
+    import (
+        "vela/ql"
+    )
+
+    collectLogs: ql.#CollectLogsInPod & parameter
+    status: collectLogs.outputs
+
+    parameter: {
+        // +usage=Specify the cluster of the pod
+        cluster: string
+        // +usage=Specify the namespace of the pod
+        namespace: string
+        // +usage=Specify the name of the pod
+        pod: string
+        // +usage=Specify the name of the container
+        container: string
+    }
+


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support stream logs for apiserver to query pod.

#### Usage

```bash
curl http://127.0.0.1:8000/api/v1/query?velaql=collect-logs{cluster=local,namespace=default,pod=example-pod,container=main-container}.status
```

#### Outputs

```json
{
    "info": {
        "fromDate": "2021-12-28T06:26:20Z",
        "toDate": "2021-12-28T08:15:47Z"
    },
    "logs": "hello-world\n"
}
```

#### Advance parameters

##### Only show last 10 lines
`/api/v1/query?velaql=collect-logs{cluster=local,namespace=default,pod=example-pod,container=main-container,tailLines=10}.status`

##### Only show last 100 bytes
`/api/v1/query?velaql=collect-logs{cluster=local,namespace=default,pod=example-pod,container=main-container,limitBytes=100}.status`

##### Add timestamp to the head of each line
`/api/v1/query?velaql=collect-logs{cluster=local,namespace=default,pod=example-pod,container=main-container,timestamps=true}.status`

##### Only show logs in last 100 seconds
`/api/v1/query?velaql=collect-logs{cluster=local,namespace=default,pod=example-pod,container=main-container,sinceSeconds=100}.status`

##### Only show logs since 2021-12-28T06:26:20.445643504Z
`/api/v1/query?velaql=collect-logs{cluster=local,namespace=default,pod=example-pod,container=main-container,sinceTime=2021-12-28T06:26:20.445643504Z}.status`

##### Show logs in previous terminated pod
`/api/v1/query?velaql=collect-logs{cluster=local,namespace=default,pod=example-pod,container=main-container,previous=true}.status`

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
- [ ] Update catalog.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->