### PR TITLE
Feat: add request logging for the api server

### DIFF
--- a/pkg/apiserver/rest/utils/http.go
+++ b/pkg/apiserver/rest/utils/http.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ClientIP get client ip
+func ClientIP(r *http.Request) string {
+	xForwardedFor := r.Header.Get("X-Forwarded-For")
+	ip := strings.TrimSpace(strings.Split(xForwardedFor, ",")[0])
+	if ip != "" {
+		return ip
+	}
+
+	ip = strings.TrimSpace(r.Header.Get("X-Real-Ip"))
+	if ip != "" {
+		return ip
+	}
+
+	if ip, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr)); err == nil {
+		return ip
+	}
+
+	return ""
+}
+
+// ResponseCapture capture response and get response info
+type ResponseCapture struct {
+	http.ResponseWriter
+	wroteHeader bool
+	status      int
+	body        *bytes.Buffer
+}
+
+// NewResponseCapture new response capture
+func NewResponseCapture(w http.ResponseWriter) *ResponseCapture {
+	return &ResponseCapture{
+		ResponseWriter: w,
+		wroteHeader:    false,
+		body:           new(bytes.Buffer),
+	}
+}
+
+// Header return response writer header
+func (c ResponseCapture) Header() http.Header {
+	return c.ResponseWriter.Header()
+}
+
+// Write write data to response writer and body
+func (c ResponseCapture) Write(data []byte) (int, error) {
+	if !c.wroteHeader {
+		c.WriteHeader(http.StatusOK)
+	}
+	c.body.Write(data)
+	return c.ResponseWriter.Write(data)
+}
+
+// WriteHeader write header to response writer
+func (c *ResponseCapture) WriteHeader(statusCode int) {
+	c.status = statusCode
+	c.wroteHeader = true
+	c.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Bytes return response body bytes
+func (c ResponseCapture) Bytes() []byte {
+	return c.body.Bytes()
+}
+
+// StatusCode return status code
+func (c ResponseCapture) StatusCode() int {
+	return c.status
+}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

log format:
```
{"level":"info","ts":1640599745.817394,"caller":"rest/rest_server.go:223","msg":"","clientIP":"127.0.0.1","path":"/api/v1/applications","method":"GET","status":200,"time":"2.393168736s","responseSize":1358}
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.