### PR TITLE
Fix: error case is not tested when generate api schema

### DIFF
--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -316,12 +316,12 @@ func TestRefineParameterInstance(t *testing.T) {
 	s := `parameter: #parameter
 #parameter: {
 	x?: string
-	if x != _|_ {
+	if x != "" {
 	y: string
 	}
 }
 patch: {
-	if parameter.x != _|_ {
+	if parameter.x != "" {
 	label: parameter.x
 	}
 }`
@@ -333,7 +333,7 @@ patch: {
 	// test #parameter not exist but parameter exists
 	s = `parameter: {
 	x?: string
-	if x != _|_ {
+	if x != "" {
 	y: string
 	}
 }`


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>

When we fix error logs in the definition controller in https://github.com/oam-dev/kubevela/pull/2063 The code works as expected. However, the error case is not actually tested. 

In short, we use `LookupDef` to get `cue.Value` and then generate `cue.ast`.
When using cue.format package to print `cue.ast`, we'll get a bad case for old code. Notice the unexpected `close` after if clause.
```cue
close({
	x?: string
	if x != "" close({ // this "close" makes it impossible to turn it back to cue.Value
		y: string
	})
})
```

But in the unit test, it's not tested. In another word, we can pass the test even we roll back the code.

This is how we do In the unit test, following `cue.ast` will be generated which is valid.
```cue
close({
	x?: string
})
```
### Description of your changes 

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->