### PR TITLE
Feat: support query service endpoints by velaQL

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -48,6 +48,10 @@ const (
 	LabelDefinitionDeprecated = "custom.definition.oam.dev/deprecated"
 	// LabelDefinitionHidden is the label which describe whether the capability is hidden by UI
 	LabelDefinitionHidden = "custom.definition.oam.dev/ui-hidden"
+	// AnnoIngressControllerHTTPSPort define ingress controller listen port for https
+	AnnoIngressControllerHTTPSPort = "ingress.controller/https-port"
+	// AnnoIngressControllerHTTPPort define ingress controller listen port for http
+	AnnoIngressControllerHTTPPort = "ingress.controller/http-port"
 )
 
 const (

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -61,3 +61,27 @@
 	}
 	...
 }
+
+#CollectServiceEndpoints: {
+	#do:       "collectServiceEndpoints"
+	#provider: "query"
+	app: {
+		name:      string
+		namespace: string
+		filter?: {
+			cluster?:          string
+			clusterNamespace?: string
+		}
+	}
+	list?: [...{
+		endpoint: {
+			protocol:    string
+			appProtocol: string
+			host?:       string
+			port:        int
+			path?:       string
+		}
+		ref: {...}
+	}]
+	...
+}

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+// StringsContain strings contain
+func StringsContain(items []string, source string) bool {
+	for _, item := range items {
+		if item == source {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/velaql/providers/query/collector.go
+++ b/pkg/velaql/providers/query/collector.go
@@ -28,6 +28,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	networkv1beta1 "k8s.io/api/networking/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -344,6 +345,32 @@ func (c *HelmReleaseCollector) CollectWorkloads(cluster string) ([]unstructured.
 		workloads = append(workloads, workloadsList[i]...)
 	}
 	return workloads, nil
+}
+
+// CollectServices collect service of HelmRelease
+func (c *HelmReleaseCollector) CollectServices(ctx context.Context, cluster string) ([]corev1.Service, error) {
+	cctx := multicluster.ContextWithClusterName(ctx, cluster)
+	listOptions := []client.ListOption{
+		client.MatchingLabels(c.matchLabels),
+	}
+	var services corev1.ServiceList
+	if err := c.cli.List(cctx, &services, listOptions...); err != nil {
+		return nil, err
+	}
+	return services.Items, nil
+}
+
+// CollectIngress collect ingress of HelmRelease
+func (c *HelmReleaseCollector) CollectIngress(ctx context.Context, cluster string) ([]networkv1beta1.Ingress, error) {
+	cctx := multicluster.ContextWithClusterName(ctx, cluster)
+	listOptions := []client.ListOption{
+		client.MatchingLabels(c.matchLabels),
+	}
+	var ingreses networkv1beta1.IngressList
+	if err := c.cli.List(cctx, &ingreses, listOptions...); err != nil {
+		return nil, err
+	}
+	return ingreses.Items, nil
 }
 
 // helmReleasePodCollector collect pods created by helmRelease


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

Generate access endpoint information for the application. By reading Ingress and Service resources. Support common component type and helm component.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

/cc @wangyikewxgm 