### PR TITLE
Fix: check error when client not created

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -65,7 +65,11 @@ var clientArgs common.Args
 
 func init() {
 	clientArgs, _ = common.InitBaseRestConfig()
-	clt, _ = clientArgs.GetClient()
+	var err error
+	clt, err = clientArgs.GetClient()
+	if err != nil {
+		panic(fmt.Sprintf("fail to create K8s client %v", err))
+	}
 
 	// assume KubeVela 1.2 needn't consider the compatibility of 1.1
 	// legacyAddonNamespace = map[string]string{


### PR DESCRIPTION
### Description of your changes

We should check error when client not initialized, and report the error reason.

Before:

![image](https://user-images.githubusercontent.com/2173670/148015285-b1438b6e-f3df-4cb5-8d6e-34475a88716a.png)

After:

![image](https://user-images.githubusercontent.com/2173670/148015303-7bbad718-4c71-47af-8ead-2d8a76f74664.png)



I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->