### PR TITLE
Fix: Generate doc for Terraform typed ComponentDefinition

### DIFF
--- a/apis/types/capability.go
+++ b/apis/types/capability.go
@@ -179,6 +179,8 @@ type Capability struct {
 
 	// Terraform
 	TerraformConfiguration string `json:"terraformConfiguration,omitempty"`
+	ConfigurationType      string `json:"configurationType,omitempty"`
+	Path                   string `json:"path,omitempty"`
 
 	// KubeTemplate
 	KubeTemplate  runtime.RawExtension   `json:"kubetemplate,omitempty"`

--- a/hack/references/generate.go
+++ b/hack/references/generate.go
@@ -27,7 +27,14 @@ import (
 func main() {
 	ref := &plugins.MarkdownReference{}
 	ctx := context.Background()
-	if err := ref.GenerateReferenceDocs(ctx, plugins.BaseRefPath); err != nil {
+	path := plugins.BaseRefPath
+
+	if len(os.Args) == 2 {
+		ref.DefinitionName = os.Args[1]
+		path = plugins.KubeVelaIOTerraformPath
+	}
+
+	if err := ref.GenerateReferenceDocs(ctx, path); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -140,7 +140,7 @@ func (def *CapabilityComponentDefinition) GetOpenAPISchema(pd *packages.PackageD
 func GetOpenAPISchemaFromTerraformComponentDefinition(configuration string) ([]byte, error) {
 	schemas := make(map[string]*openapi3.Schema)
 	var required []string
-	variables, err := common.ParseTerraformVariables(configuration)
+	variables, _, err := common.ParseTerraformVariables(configuration)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate capability properties")
 	}
@@ -187,7 +187,8 @@ func GetOpenAPISchemaFromTerraformComponentDefinition(configuration string) ([]b
 	return generateJSONSchemaWithRequiredProperty(schemas, required)
 }
 
-func getTerraformConfigurationFromRemote(name, remoteURL, remotePath string) (string, error) {
+// GetTerraformConfigurationFromRemote gets Terraform Configuration(HCL)
+func GetTerraformConfigurationFromRemote(name, remoteURL, remotePath string) (string, error) {
 	tmpPath := filepath.Join("./tmp/terraform", name)
 	_, err := git.PlainClone(tmpPath, false, &git.CloneOptions{
 		URL:      remoteURL,
@@ -333,7 +334,7 @@ func (def *CapabilityComponentDefinition) StoreOpenAPISchema(ctx context.Context
 		}
 		configuration := def.Terraform.Configuration
 		if def.Terraform.Type == "remote" {
-			configuration, err = getTerraformConfigurationFromRemote(def.Name, def.Terraform.Configuration, def.Terraform.Path)
+			configuration, err = GetTerraformConfigurationFromRemote(def.Name, def.Terraform.Configuration, def.Terraform.Path)
 			if err != nil {
 				return "", fmt.Errorf("cannot get Terraform configuration %s from remote: %w", def.Name, err)
 			}

--- a/pkg/controller/utils/capability_test.go
+++ b/pkg/controller/utils/capability_test.go
@@ -429,7 +429,7 @@ variable "aaa" {
 			err = ioutil.WriteFile(filepath.Clean(filepath.Join(tmpPath, "main.tf")), tc.data, 0644)
 			assert.NilError(t, err)
 
-			conf, err := getTerraformConfigurationFromRemote(tc.name, tc.url, tc.path)
+			conf, err := GetTerraformConfigurationFromRemote(tc.name, tc.url, tc.path)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nGetTerraformConfigurationFromRemote(...): -want error, +got error:\n%s", name, diff)
 			}

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -447,18 +447,18 @@ func ReadYamlToObject(path string, object k8sruntime.Object) error {
 }
 
 // ParseTerraformVariables get variables from Terraform Configuration
-func ParseTerraformVariables(configuration string) (map[string]*tfconfig.Variable, error) {
+func ParseTerraformVariables(configuration string) (map[string]*tfconfig.Variable, map[string]*tfconfig.Output, error) {
 	p := hclparse.NewParser()
 	hclFile, diagnostic := p.ParseHCL([]byte(configuration), "")
 	if diagnostic != nil {
-		return nil, errors.New(diagnostic.Error())
+		return nil, nil, errors.New(diagnostic.Error())
 	}
-	mod := tfconfig.Module{Variables: map[string]*tfconfig.Variable{}}
+	mod := tfconfig.Module{Variables: map[string]*tfconfig.Variable{}, Outputs: map[string]*tfconfig.Output{}}
 	diagnostic = tfconfig.LoadModuleFromFile(hclFile, &mod)
 	if diagnostic != nil {
-		return nil, errors.New(diagnostic.Error())
+		return nil, nil, errors.New(diagnostic.Error())
 	}
-	return mod.Variables, nil
+	return mod.Variables, mod.Outputs, nil
 }
 
 // GenerateUnstructuredObj generate UnstructuredObj

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -302,7 +302,7 @@ variable "mapVar" {
   type = "map"
 }`
 
-	variables, err := ParseTerraformVariables(configuration)
+	variables, _, err := ParseTerraformVariables(configuration)
 	assert.NoError(t, err)
 	_, passwordExisted := variables["password"]
 	assert.True(t, passwordExisted)

--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -253,6 +253,8 @@ func HandleTemplate(in *runtime.RawExtension, schematic *commontypes.Schematic, 
 		if schematic.Terraform != nil {
 			tmp.Category = types.TerraformCategory
 			tmp.TerraformConfiguration = schematic.Terraform.Configuration
+			tmp.ConfigurationType = schematic.Terraform.Type
+			tmp.Path = schematic.Terraform.Path
 			return tmp, nil
 		}
 		if schematic.KUBE != nil {

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -402,6 +402,19 @@ variable "acl" {
 				tableName2: "#### writeConnectionSecretToRef",
 			},
 		},
+		"configuration is in git remote": {
+			args: args{
+				cap: types.Capability{
+					TerraformConfiguration: "https://github.com/zzxwill/terraform-alibaba-eip.git",
+					ConfigurationType:      "remote",
+				},
+			},
+			want: want{
+				errMsg:     "",
+				tableName1: "### Properties",
+				tableName2: "#### writeConnectionSecretToRef",
+			},
+		},
 		"configuration is not valid": {
 			args: args{
 				cap: types.Capability{

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -436,3 +436,44 @@ variable "acl" {
 		}
 	}
 }
+
+func TestPrepareTerraformOutputs(t *testing.T) {
+	type args struct {
+		tableName     string
+		parameterList []ReferenceParameter
+	}
+
+	param := ReferenceParameter{}
+	param.Name = "ID"
+	param.Usage = "Identity of the cloud resource"
+
+	testcases := []struct {
+		args   args
+		expect string
+	}{
+		{
+			args: args{
+				tableName:     "",
+				parameterList: nil,
+			},
+			expect: "",
+		},
+		{
+			args: args{
+				tableName:     "abc",
+				parameterList: []ReferenceParameter{param},
+			},
+			expect: "\n\nabc\n\nName | Description\n------------ | ------------- \n ID | Identity of the cloud resource\n",
+		},
+	}
+	ref := &MarkdownReference{}
+	for _, tc := range testcases {
+		t.Run("", func(t *testing.T) {
+			content := ref.prepareTerraformOutputs(tc.args.tableName, tc.args.parameterList)
+			if content != tc.expect {
+				t.Errorf("prepareTerraformOutputs(...): -want, +got:\n%s\n", cmp.Diff(tc.expect, content))
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
When the configuration of a Terraform Typed ComponentDefinition is in
remote Git, generate the properties for it. And generated outputs for
all Terraform ComponentDefinition

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->