### PR TITLE
Fix: when a provider is set in ComponentDefinition, it should look for the provider

### DIFF
--- a/docs/examples/terraform/cloud-resource-provision-and-consume/application-aws-s3.yaml
+++ b/docs/examples/terraform/cloud-resource-provision-and-consume/application-aws-s3.yaml
@@ -1,0 +1,14 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-aws-s3
+spec:
+  components:
+    - name: sample-s3
+      type: aws-s3
+      properties:
+        bucket: vela-website-202110191745
+        acl: private
+
+        writeConnectionSecretToRef:
+          name: s3-conn

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -704,7 +704,14 @@ func generateTerraformConfigurationWorkload(wl *Workload, ns string) (*unstructu
 	}
 	if spec.ProviderReference != nil && !reflect.DeepEqual(configuration.Spec.ProviderReference, spec.ProviderReference) {
 		configuration.Spec.ProviderReference = spec.ProviderReference
+	} else if wl.FullTemplate != nil && wl.FullTemplate.ComponentDefinition != nil &&
+		wl.FullTemplate.ComponentDefinition.Spec.Schematic != nil &&
+		wl.FullTemplate.ComponentDefinition.Spec.Schematic.Terraform != nil &&
+		wl.FullTemplate.ComponentDefinition.Spec.Schematic.Terraform.ProviderReference != nil {
+		// Check whether the provider reference is set in ComponentDefinition
+		configuration.Spec.ProviderReference = wl.FullTemplate.ComponentDefinition.Spec.Schematic.Terraform.ProviderReference
 	}
+
 	if spec.Region != "" && configuration.Spec.Region != spec.Region {
 		configuration.Spec.Region = spec.Region
 	}


### PR DESCRIPTION
Fixed the issue "The error message is not correct when AWS provider is not available"

Fix #3046

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->