### PR TITLE
Fix: generate docs for Terraform ComponentDefinition

### DIFF
--- a/hack/references/generate.go
+++ b/hack/references/generate.go
@@ -19,10 +19,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"os"
 
 	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/references/plugins"
 )
 

--- a/hack/references/generate.go
+++ b/hack/references/generate.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/references/plugins"
 )
 
@@ -34,7 +35,7 @@ func main() {
 		path = plugins.KubeVelaIOTerraformPath
 	}
 
-	if err := ref.GenerateReferenceDocs(ctx, path); err != nil {
+	if err := ref.GenerateReferenceDocs(ctx, path, types.DefaultKubeVelaNS); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/hack/references/generate.go
+++ b/hack/references/generate.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"os"
 
 	"github.com/oam-dev/kubevela/apis/types"
@@ -35,7 +36,13 @@ func main() {
 		path = plugins.KubeVelaIOTerraformPath
 	}
 
-	if err := ref.GenerateReferenceDocs(ctx, path, types.DefaultKubeVelaNS); err != nil {
+	c, err := common.InitBaseRestConfig()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if err := ref.GenerateReferenceDocs(ctx, c, path, types.DefaultKubeVelaNS); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -190,9 +190,16 @@ func GetOpenAPISchemaFromTerraformComponentDefinition(configuration string) ([]b
 // GetTerraformConfigurationFromRemote gets Terraform Configuration(HCL)
 func GetTerraformConfigurationFromRemote(name, remoteURL, remotePath string) (string, error) {
 	tmpPath := filepath.Join("./tmp/terraform", name)
+	// Check if the directory exists. If yes, remove it.
+	if _, err := os.Stat(tmpPath); err == nil {
+		err := os.RemoveAll(tmpPath)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to remove the directory")
+		}
+	}
 	_, err := git.PlainClone(tmpPath, false, &git.CloneOptions{
 		URL:      remoteURL,
-		Progress: os.Stdout,
+		Progress: nil,
 	})
 	if err != nil {
 		return "", err

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -75,7 +75,7 @@ func DefinitionCommandGroup(c common.Args, order string) *cobra.Command {
 		NewDefinitionDelCommand(c),
 		NewDefinitionInitCommand(c),
 		NewDefinitionValidateCommand(c),
-		NewDefinitionGenDocCommand(),
+		NewDefinitionGenDocCommand(c),
 	)
 	return cmd
 }
@@ -328,7 +328,7 @@ func NewDefinitionGetCommand(c common.Args) *cobra.Command {
 }
 
 // NewDefinitionGenDocCommand create the `vela def gen-doc` command to generate documentation of definitions
-func NewDefinitionGenDocCommand() *cobra.Command {
+func NewDefinitionGenDocCommand(c common.Args) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gen-doc NAME",
 		Short: "Generate documentation of definitions (Only Terraform typed definitions are supported)",
@@ -350,10 +350,10 @@ func NewDefinitionGenDocCommand() *cobra.Command {
 			ref.DefinitionName = args[0]
 			path := plugins.KubeVelaIOTerraformPath
 
-			if err := ref.GenerateReferenceDocs(ctx, path, namespace); err != nil {
+			if err := ref.GenerateReferenceDocs(ctx, c, path, namespace); err != nil {
 				return errors.Wrap(err, "failed to generate reference docs")
 			}
-			cmd.Print(fmt.Printf("Generated docs for %s in ./%s/components/%s.md", args[0], path, args[0]))
+			cmd.Printf("Generated docs for %s in ./%s/%s.md\n", args[0], path, args[0])
 			return nil
 		},
 	}

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -44,6 +44,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/cue/model/sets"
 	pkgdef "github.com/oam-dev/kubevela/pkg/definition"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/references/plugins"
 )
 
 const (
@@ -74,6 +75,7 @@ func DefinitionCommandGroup(c common.Args, order string) *cobra.Command {
 		NewDefinitionDelCommand(c),
 		NewDefinitionInitCommand(c),
 		NewDefinitionValidateCommand(c),
+		NewDefinitionGenDocCommand(),
 	)
 	return cmd
 }
@@ -322,6 +324,40 @@ func NewDefinitionGetCommand(c common.Args) *cobra.Command {
 	}
 	cmd.Flags().StringP(FlagType, "t", "", "Specify which definition type to get. If empty, all types will be searched. Valid types: "+strings.Join(pkgdef.ValidDefinitionTypes(), ", "))
 	cmd.Flags().StringP(Namespace, "n", "", "Specify which namespace to get. If empty, all namespaces will be searched.")
+	return cmd
+}
+
+// NewDefinitionGenDocCommand create the `vela def gen-doc` command to generate documentation of definitions
+func NewDefinitionGenDocCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gen-doc NAME",
+		Short: "Generate documentation of definitions (Only Terraform typed definitions are supported)",
+		Long:  "Generate documentation of definitions",
+		Example: "1. Generate documentation for ComponentDefinition alibaba-vpc:\n" +
+			"> vela def gen-doc alibaba-vpc -n vela-system\n",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("please specify definition name")
+			}
+
+			namespace, err := cmd.Flags().GetString(FlagNamespace)
+			if err != nil {
+				return errors.Wrapf(err, "failed to get `%s`", Namespace)
+			}
+
+			ref := &plugins.MarkdownReference{}
+			ctx := context.Background()
+			ref.DefinitionName = args[0]
+			path := plugins.KubeVelaIOTerraformPath
+
+			if err := ref.GenerateReferenceDocs(ctx, path, namespace); err != nil {
+				return errors.Wrap(err, "failed to generate reference docs")
+			}
+			cmd.Print(fmt.Printf("Generated docs for %s in ./%s/components/%s.md", args[0], path, args[0]))
+			return nil
+		},
+	}
+	cmd.Flags().StringP(Namespace, "n", "", "Specify the namespace of the definition.")
 	return cmd
 }
 

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"path/filepath"
@@ -229,16 +230,11 @@ func TestNewDefinitionGetCommand(t *testing.T) {
 
 func TestNewDefinitionGenDocCommand(t *testing.T) {
 	c := initArgs()
-
-	// normal test
 	cmd := NewDefinitionGenDocCommand(c)
-	initCommand(cmd)
-	traitName := createTrait(c, t)
-	cmd.SetArgs([]string{traitName})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("unexpeced error when executing gen-doc command: %v", err)
-	}
+	assert.NotNil(t, cmd.Execute())
 
+	cmd.SetArgs([]string{"alibaba-xxxxxxx"})
+	assert.NotNil(t, cmd.Execute())
 }
 
 func TestNewDefinitionListCommand(t *testing.T) {

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -19,7 +19,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"path/filepath"
@@ -27,9 +26,8 @@ import (
 	"testing"
 	"time"
 
-	pkgdef "github.com/oam-dev/kubevela/pkg/definition"
-
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,6 +35,7 @@ import (
 
 	common3 "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	pkgdef "github.com/oam-dev/kubevela/pkg/definition"
 	common2 "github.com/oam-dev/kubevela/pkg/utils/common"
 )
 

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -201,6 +201,7 @@ func TestNewDefinitionInitCommand(t *testing.T) {
 
 func TestNewDefinitionGetCommand(t *testing.T) {
 	c := initArgs()
+
 	// normal test
 	cmd := NewDefinitionGetCommand(c)
 	initCommand(cmd)
@@ -224,6 +225,20 @@ func TestNewDefinitionGetCommand(t *testing.T) {
 	if err := cmd.Execute(); err == nil {
 		t.Fatalf("expect found no trait error, but not found")
 	}
+}
+
+func TestNewDefinitionGenDocCommand(t *testing.T) {
+	c := initArgs()
+
+	// normal test
+	cmd := NewDefinitionGenDocCommand(c)
+	initCommand(cmd)
+	traitName := createTrait(c, t)
+	cmd.SetArgs([]string{traitName})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpeced error when executing gen-doc command: %v", err)
+	}
+
 }
 
 func TestNewDefinitionListCommand(t *testing.T) {

--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -353,6 +353,9 @@ func GetCapabilityByName(ctx context.Context, c common.Args, capabilityName stri
 		}
 		return capability, nil
 	}
+	if ns == types.DefaultKubeVelaNS {
+		return nil, fmt.Errorf("could not find %s in namespace %s", capabilityName, ns)
+	}
 	return nil, fmt.Errorf("could not find %s in namespace %s, or %s", capabilityName, ns, types.DefaultKubeVelaNS)
 }
 

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -487,6 +487,42 @@ func TestPrepareTerraformOutputs(t *testing.T) {
 				t.Errorf("prepareTerraformOutputs(...): -want, +got:\n%s\n", cmp.Diff(tc.expect, content))
 			}
 		})
+	}
+}
 
+func TestMakeReadableTitle(t *testing.T) {
+	type args struct {
+		title string
+	}
+	testcases := []struct {
+		args args
+		want string
+	}{
+		{
+			args: args{
+				title: "abc",
+			},
+			want: "Abc",
+		},
+		{
+			args: args{
+				title: "abc-def",
+			},
+			want: "Abc-Def",
+		},
+		{
+			args: args{
+				title: "alibaba-def-ghi",
+			},
+			want: "Alibaba Cloud DEF-GHI",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run("", func(t *testing.T) {
+			title := makeReadableTitle(tc.args.title)
+			if title != tc.want {
+				t.Errorf("makeReadableTitle(...): -want, +got:\n%s\n", cmp.Diff(tc.want, title))
+			}
+		})
 	}
 }

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -365,14 +365,12 @@ func setDisplayFormat(format string) {
 }
 
 // GenerateReferenceDocs generates reference docs
-func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, baseRefPath string, namespace string) error {
+func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, c common.Args, baseRefPath string, namespace string) error {
 	var (
 		caps []types.Capability
+		err error
 	)
-	c, err := common.InitBaseRestConfig()
-	if err != nil {
-		return err
-	}
+
 
 	if ref.DefinitionName == "" {
 		caps, err = LoadAllInstalledCapability("default", c)
@@ -393,28 +391,19 @@ func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, baseRef
 // CreateMarkdown creates markdown based on capabilities
 func (ref *MarkdownReference) CreateMarkdown(ctx context.Context, caps []types.Capability, baseRefPath, referenceSourcePath string) error {
 	setDisplayFormat("markdown")
-	var capabilityType string
 	for i, c := range caps {
-		switch c.Type {
-		case types.TypeWorkload:
-			capabilityType = WorkloadTypePath
-		case types.TypeComponentDefinition:
-			capabilityType = ComponentDefinitionTypePath
-		case types.TypeTrait:
-			capabilityType = TraitPath
-		default:
+		if c.Type != types.TypeWorkload && c.Type !=types.TypeComponentDefinition && c.Type != types.TypeTrait {
 			return fmt.Errorf("the type of the capability is not right")
 		}
 
 		fileName := fmt.Sprintf("%s.md", c.Name)
-		filePath := filepath.Join(baseRefPath, capabilityType)
-		if _, err := os.Stat(filePath); err != nil && os.IsNotExist(err) {
-			if err := os.MkdirAll(filePath, 0750); err != nil {
+		if _, err := os.Stat(baseRefPath); err != nil && os.IsNotExist(err) {
+			if err := os.MkdirAll(baseRefPath, 0750); err != nil {
 				return err
 			}
 		}
 
-		markdownFile := filepath.Join(baseRefPath, capabilityType, fileName)
+		markdownFile := filepath.Join(baseRefPath, fileName)
 		f, err := os.OpenFile(filepath.Clean(markdownFile), os.O_WRONLY|os.O_CREATE, 0600)
 		if err != nil {
 			return fmt.Errorf("failed to open file %s: %w", markdownFile, err)

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -368,9 +368,8 @@ func setDisplayFormat(format string) {
 func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, c common.Args, baseRefPath string, namespace string) error {
 	var (
 		caps []types.Capability
-		err error
+		err  error
 	)
-
 
 	if ref.DefinitionName == "" {
 		caps, err = LoadAllInstalledCapability("default", c)
@@ -392,7 +391,7 @@ func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, c commo
 func (ref *MarkdownReference) CreateMarkdown(ctx context.Context, caps []types.Capability, baseRefPath, referenceSourcePath string) error {
 	setDisplayFormat("markdown")
 	for i, c := range caps {
-		if c.Type != types.TypeWorkload && c.Type !=types.TypeComponentDefinition && c.Type != types.TypeTrait {
+		if c.Type != types.TypeWorkload && c.Type != types.TypeComponentDefinition && c.Type != types.TypeTrait {
 			return fmt.Errorf("the type of the capability is not right")
 		}
 

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -375,12 +375,12 @@ func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, c commo
 	if ref.DefinitionName == "" {
 		caps, err = LoadAllInstalledCapability("default", c)
 		if err != nil {
-			return fmt.Errorf("failed to generate reference docs for all capabilities: %w", err)
+			return fmt.Errorf("failed to get all capabilityes: %w", err)
 		}
 	} else {
 		cap, err := GetCapabilityByName(ctx, c, ref.DefinitionName, namespace)
 		if err != nil {
-			return fmt.Errorf("failed to generate reference docs for capability %s: %w", ref.DefinitionName, err)
+			return fmt.Errorf("failed to get capability capability %s: %w", ref.DefinitionName, err)
 		}
 		caps = []types.Capability{*cap}
 	}

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -365,7 +365,7 @@ func setDisplayFormat(format string) {
 }
 
 // GenerateReferenceDocs generates reference docs
-func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, baseRefPath string) error {
+func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, baseRefPath string, namespace string) error {
 	var (
 		caps []types.Capability
 	)
@@ -380,7 +380,7 @@ func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, baseRef
 			return fmt.Errorf("failed to generate reference docs for all capabilities: %w", err)
 		}
 	} else {
-		cap, err := GetCapabilityByName(ctx, c, ref.DefinitionName, types.DefaultKubeVelaNS)
+		cap, err := GetCapabilityByName(ctx, c, ref.DefinitionName, namespace)
 		if err != nil {
 			return fmt.Errorf("failed to generate reference docs for capability %s: %w", ref.DefinitionName, err)
 		}

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -412,7 +412,7 @@ func (ref *MarkdownReference) CreateMarkdown(ctx context.Context, caps []types.C
 		}
 		capName := c.Name
 		refContent = ""
-		capNameInTitle := strings.Title(capName)
+		capNameInTitle := makeReadableTitle(capName)
 		switch c.Category {
 		case types.CUECategory:
 			cueValue, err := common.GetCUEParameterValue(c.CueTemplate)
@@ -469,6 +469,15 @@ func (ref *MarkdownReference) CreateMarkdown(ctx context.Context, caps []types.C
 		}
 	}
 	return nil
+}
+
+func makeReadableTitle(title string) string {
+	const alibabaCloud = "alibaba-"
+	if strings.HasPrefix(title, alibabaCloud) {
+		cloudResource := strings.Replace(title, alibabaCloud, "", 1)
+		return "Alibaba Cloud " + strings.ToUpper(cloudResource)
+	}
+	return strings.Title(title)
 }
 
 // prepareParameter prepares the table content for each property


### PR DESCRIPTION
Generated kubevela.io docs for Terraform typed ComponentDefinition
with `vela def gen-doc xxx` cli.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->