### PR TITLE
Feat: support query endpoints in status command and speed up CLI resp…

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -48,6 +48,10 @@ const (
 	LabelDefinitionDeprecated = "custom.definition.oam.dev/deprecated"
 	// LabelDefinitionHidden is the label which describe whether the capability is hidden by UI
 	LabelDefinitionHidden = "custom.definition.oam.dev/ui-hidden"
+	// LabelNodeRoleGateway gateway role of node
+	LabelNodeRoleGateway = "node-role.kubernetes.io/gateway"
+	// LabelNodeRoleWorker worker role of node
+	LabelNodeRoleWorker = "node-role.kubernetes.io/worker"
 	// AnnoIngressControllerHTTPSPort define ingress controller listen port for https
 	AnnoIngressControllerHTTPSPort = "ingress.controller/https-port"
 	// AnnoIngressControllerHTTPPort define ingress controller listen port for http

--- a/charts/vela-core/templates/velaql/endpoints.yaml
+++ b/charts/vela-core/templates/velaql/endpoints.yaml
@@ -1,0 +1,38 @@
+apiVersion: "v1"
+kind:       "ConfigMap"
+metadata: 
+  name:      "service-endpoints-view"
+  namespace: "vela-system"
+data:
+  template: |
+      import (
+          "vela/ql"
+      )
+      parameter: {
+          appName:    string
+          appNs:      string
+          cluster?:   string
+          clusterNs?: string
+      }
+      resources: ql.#CollectServiceEndpoints & {
+          app: {
+              name:      parameter.appName
+              namespace: parameter.appNs
+              filter: {
+                  if parameter.cluster != _|_ {
+                      cluster: parameter.cluster
+                  }
+                  if parameter.clusterNs != _|_ {
+                      clusterNamespace: parameter.clusterNs
+                  }
+              }
+          }
+      }
+      if resources.err == _|_ {
+          endpoints: resources.list
+      }
+      if resources.err != _|_ {
+          status: {
+              error: resources.err
+          }
+      }

--- a/pkg/monitor/context/context.go
+++ b/pkg/monitor/context/context.go
@@ -87,7 +87,9 @@ func (t *traceContext) Commit(msg string) {
 	for _, export := range t.exporters {
 		export(t, duration.Microseconds())
 	}
-	klog.InfoSDepth(1, msg, t.getTagsWith("duration", duration.String())...)
+	if t.logLevel == 0 {
+		klog.InfoSDepth(1, msg, t.getTagsWith("duration", duration.String())...)
+	}
 }
 
 func (t *traceContext) getTagsWith(keysAndValues ...interface{}) []interface{} {

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -75,11 +75,11 @@
 	}
 	list?: [...{
 		endpoint: {
-			protocol:    string
-			appProtocol: string
-			host?:       string
-			port:        int
-			path?:       string
+			protocol:     string
+			appProtocol?: string
+			host?:        string
+			port:         int
+			path?:        string
 		}
 		ref: {...}
 	}]

--- a/pkg/stdlib/ql.cue
+++ b/pkg/stdlib/ql.cue
@@ -11,3 +11,5 @@
 #SearchEvents: query.#SearchEvents
 
 #CollectLogsInPod: query.#CollectLogsInPod
+
+#CollectServiceEndpoints: query.#CollectServiceEndpoints

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -47,7 +47,6 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/util/flowcontrol"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ocmclusterv1 "open-cluster-management.io/api/cluster/v1"
 	ocmclusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
@@ -100,18 +99,17 @@ func init() {
 
 // InitBaseRestConfig will return reset config for create controller runtime client
 func InitBaseRestConfig() (Args, error) {
-	restConf, err := config.GetConfig()
+	args := Args{
+		Schema: Scheme,
+	}
+	_, err := args.GetConfig()
 	if err != nil && os.Getenv("IGNORE_KUBE_CONFIG") != "true" {
 		fmt.Println("get kubeConfig err", err)
 		os.Exit(1)
 	} else if err != nil {
 		return Args{}, err
 	}
-	restConf.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(100, 200)
-	return Args{
-		Config: restConf,
-		Schema: Scheme,
-	}, nil
+	return args, nil
 }
 
 // globalClient will be a client for whole command lifecycle

--- a/pkg/velaql/providers/query/types/type.go
+++ b/pkg/velaql/providers/query/types/type.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// HTTPS https protocol name
+	HTTPS = "https"
+	// HTTP http protocol name
+	HTTP = "http"
+	// Mysql mysql protocol name
+	Mysql = "mysql"
+	// Redis redis protocol name
+	Redis = "redis"
+)
+
+// ServiceEndpoint record the access endpoints of the application services
+type ServiceEndpoint struct {
+	Endpoint Endpoint               `json:"endpoint"`
+	Ref      corev1.ObjectReference `json:"ref"`
+}
+
+// String return endpoint URL
+func (s *ServiceEndpoint) String() string {
+	protocol := strings.ToLower(string(s.Endpoint.Protocol))
+	if s.Endpoint.AppProtocol != nil && *s.Endpoint.AppProtocol != "" {
+		protocol = *s.Endpoint.AppProtocol
+	}
+	path := s.Endpoint.Path
+	if s.Endpoint.Path == "/" {
+		path = ""
+	}
+	if (protocol == HTTPS && s.Endpoint.Port == 443) || (protocol == HTTP && s.Endpoint.Port == 80) {
+		return fmt.Sprintf("%s://%s%s", protocol, s.Endpoint.Host, path)
+	}
+	return fmt.Sprintf("%s://%s:%d%s", protocol, s.Endpoint.Host, s.Endpoint.Port, path)
+}
+
+// Endpoint create by ingress or service
+type Endpoint struct {
+	// The protocol for this endpoint. Supports "TCP", "UDP", and "SCTP".
+	// Default is TCP.
+	// +default="TCP"
+	// +optional
+	Protocol corev1.Protocol `json:"protocol,omitempty"`
+
+	// The protocol for this endpoint.
+	// Un-prefixed names are reserved for IANA standard service names (as per
+	// RFC-6335 and http://www.iana.org/assignments/service-names).
+	// +optional
+	AppProtocol *string `json:"appProtocol,omitempty"`
+
+	// the host for the endpoint, it could be IP or domain
+	Host string `json:"host"`
+
+	// the port for the endpoint
+	// Default is 80.
+	Port int `json:"port"`
+
+	// the path for the endpoint
+	Path string `json:"path,omitempty"`
+}

--- a/pkg/velaql/view.go
+++ b/pkg/velaql/view.go
@@ -82,7 +82,7 @@ func (handler *ViewHandler) QueryView(ctx context.Context, qv QueryView) (*value
 		Outputs:    queryKey.Outputs,
 	}
 
-	taskDiscover := tasks.NewViewTaskDiscover(handler.pd, handler.cli, handler.cfg, handler.dispatch, handler.delete, handler.namespace)
+	taskDiscover := tasks.NewViewTaskDiscover(handler.pd, handler.cli, handler.cfg, handler.dispatch, handler.delete, handler.namespace, 3)
 	genTask, err := taskDiscover.GetTaskGenerator(ctx, handler.viewTask.Type)
 	if err != nil {
 		return nil, err

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -66,6 +66,7 @@ type TaskLoader struct {
 	pd                *packages.PackageDiscover
 	handlers          providers.Providers
 	runOptionsProcess func(*wfTypes.TaskRunOptions)
+	logLevel          int
 }
 
 // GetTaskGenerator get TaskGenerator by name.
@@ -156,6 +157,7 @@ func (t *TaskLoader) makeTaskGenerator(templ string) (wfTypes.TaskGenerator, err
 				}
 			}
 			tracer := options.GetTracer(exec.wfStatus.ID, wfStep).AddTag("step_name", wfStep.Name, "step_type", wfStep.Type)
+			tracer.V(t.logLevel)
 			defer func() {
 				tracer.Commit(string(exec.status().Phase))
 			}()
@@ -413,7 +415,7 @@ func getLabel(v *value.Value, label string) string {
 }
 
 // NewTaskLoader create a tasks loader.
-func NewTaskLoader(lt LoadTaskTemplate, pkgDiscover *packages.PackageDiscover, handlers providers.Providers) *TaskLoader {
+func NewTaskLoader(lt LoadTaskTemplate, pkgDiscover *packages.PackageDiscover, handlers providers.Providers, logLevel int) *TaskLoader {
 	return &TaskLoader{
 		loadTemplate: lt,
 		pd:           pkgDiscover,
@@ -422,5 +424,6 @@ func NewTaskLoader(lt LoadTaskTemplate, pkgDiscover *packages.PackageDiscover, h
 			options.PreStartHooks = append(options.PreStartHooks, hooks.Input)
 			options.PostStopHooks = append(options.PostStopHooks, hooks.Output)
 		},
+		logLevel: logLevel,
 	}
 }

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -75,7 +75,7 @@ myIP: value: "1.1.1.1"
 		},
 	})
 
-	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover)
+	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover, 0)
 
 	steps := []v1beta1.WorkflowStep{
 		{
@@ -178,7 +178,7 @@ close({
 			return errors.New("mock error")
 		},
 	})
-	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover)
+	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover, 0)
 
 	steps := []v1beta1.WorkflowStep{
 		{
@@ -413,7 +413,7 @@ func TestPendingInputCheck(t *testing.T) {
 			ParameterKey: "score",
 		}},
 	}
-	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover)
+	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover, 0)
 	gen, err := tasksLoader.GetTaskGenerator(context.Background(), step.Type)
 	r.NoError(err)
 	run, err := gen(step, &types.GeneratorOptions{})
@@ -442,7 +442,7 @@ func TestPendingDependsOnCheck(t *testing.T) {
 		Type:      "ok",
 		DependsOn: []string{"depend"},
 	}
-	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover)
+	tasksLoader := NewTaskLoader(mockLoadTemplate, nil, discover, 0)
 	gen, err := tasksLoader.GetTaskGenerator(context.Background(), step.Type)
 	r.NoError(err)
 	run, err := gen(step, &types.GeneratorOptions{})

--- a/pkg/workflow/tasks/discover.go
+++ b/pkg/workflow/tasks/discover.go
@@ -84,7 +84,7 @@ func NewTaskDiscover(providerHandlers providers.Providers, pd *packages.PackageD
 		builtins: map[string]types.TaskGenerator{
 			"suspend": suspend,
 		},
-		remoteTaskDiscover: custom.NewTaskLoader(templateLoader.LoadTaskTemplate, pd, providerHandlers),
+		remoteTaskDiscover: custom.NewTaskLoader(templateLoader.LoadTaskTemplate, pd, providerHandlers, 0),
 		templateLoader:     templateLoader,
 	}
 }
@@ -115,7 +115,7 @@ func (tr *suspendTaskRunner) Pending(ctx wfContext.Context) bool {
 }
 
 // NewViewTaskDiscover will create a client for load task generator.
-func NewViewTaskDiscover(pd *packages.PackageDiscover, cli client.Client, cfg *rest.Config, apply kube.Dispatcher, delete kube.Deleter, viewNs string) types.TaskDiscover {
+func NewViewTaskDiscover(pd *packages.PackageDiscover, cli client.Client, cfg *rest.Config, apply kube.Dispatcher, delete kube.Deleter, viewNs string, logLevel int) types.TaskDiscover {
 	handlerProviders := providers.NewProviders()
 
 	// install builtin provider
@@ -128,7 +128,7 @@ func NewViewTaskDiscover(pd *packages.PackageDiscover, cli client.Client, cfg *r
 
 	templateLoader := template.NewViewTemplateLoader(cli, viewNs)
 	return &taskDiscover{
-		remoteTaskDiscover: custom.NewTaskLoader(templateLoader.LoadTaskTemplate, pd, handlerProviders),
+		remoteTaskDiscover: custom.NewTaskLoader(templateLoader.LoadTaskTemplate, pd, handlerProviders, logLevel),
 		templateLoader:     templateLoader,
 	}
 }

--- a/pkg/workflow/tasks/discover_test.go
+++ b/pkg/workflow/tasks/discover_test.go
@@ -50,7 +50,7 @@ func TestDiscover(t *testing.T) {
 		builtins: map[string]types.TaskGenerator{
 			"suspend": suspend,
 		},
-		remoteTaskDiscover: custom.NewTaskLoader(loadTemplate, nil, nil),
+		remoteTaskDiscover: custom.NewTaskLoader(loadTemplate, nil, nil, 0),
 	}
 
 	_, err := discover.GetTaskGenerator(context.Background(), "suspend")

--- a/references/appfile/addon_test.go
+++ b/references/appfile/addon_test.go
@@ -42,7 +42,12 @@ var _ = It("Test ApplyTerraform", func() {
 		}},
 	}
 	ioStream := util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	_, err := ApplyTerraform(app, k8sClient, ioStream, addonNamespace, common.Args{Config: cfg})
+	arg := common.Args{
+		Schema: scheme,
+	}
+	err := arg.SetConfig(cfg)
+	Expect(err).Should(BeNil())
+	_, err = ApplyTerraform(app, k8sClient, ioStream, addonNamespace, arg)
 	Expect(err).Should(BeNil())
 })
 

--- a/references/cli/addon-registry.go
+++ b/references/cli/addon-registry.go
@@ -69,7 +69,7 @@ func NewAddAddonRegistryCommand(c common.Args, ioStreams cmdutil.IOStreams) *cob
 			if err != nil {
 				return err
 			}
-			if err := addAddonRegistry(context.Background(), *registry); err != nil {
+			if err := addAddonRegistry(context.Background(), c, *registry); err != nil {
 				return err
 			}
 			return nil
@@ -91,7 +91,7 @@ func NewGetAddonRegistryCommand(c common.Args, ioStreams cmdutil.IOStreams) *cob
 				return errors.New("must specify the registry name")
 			}
 			name := args[0]
-			err := getAddonRegistry(context.Background(), name)
+			err := getAddonRegistry(context.Background(), c, name)
 			if err != nil {
 				return err
 			}
@@ -108,7 +108,7 @@ func NewListAddonRegistryCommand(c common.Args, ioStreams cmdutil.IOStreams) *co
 		Long:    "List addon registries",
 		Example: "vela addon registry list",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := listAddonRegistry(context.Background()); err != nil {
+			if err := listAddonRegistry(context.Background(), c); err != nil {
 				return err
 			}
 			return nil
@@ -128,7 +128,7 @@ func NewUpdateAddonRegistryCommand(c common.Args, ioStreams cmdutil.IOStreams) *
 			if err != nil {
 				return err
 			}
-			if err := updateAddonRegistry(context.Background(), *registry); err != nil {
+			if err := updateAddonRegistry(context.Background(), c, *registry); err != nil {
 				return err
 			}
 			return nil
@@ -150,7 +150,7 @@ func NewDeleteAddonRegistryCommand(c common.Args, ioStreams cmdutil.IOStreams) *
 				return errors.New("must specify the registry name")
 			}
 			name := args[0]
-			err := deleteAddonRegistry(context.Background(), name)
+			err := deleteAddonRegistry(context.Background(), c, name)
 			if err != nil {
 				return err
 			}
@@ -159,8 +159,12 @@ func NewDeleteAddonRegistryCommand(c common.Args, ioStreams cmdutil.IOStreams) *
 	}
 }
 
-func listAddonRegistry(ctx context.Context) error {
-	ds := pkgaddon.NewRegistryDataStore(clt)
+func listAddonRegistry(ctx context.Context, c common.Args) error {
+	client, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	ds := pkgaddon.NewRegistryDataStore(client)
 	registries, err := ds.ListRegistries(ctx)
 	if err != nil {
 		return err
@@ -193,8 +197,12 @@ func listAddonRegistry(ctx context.Context) error {
 	return nil
 }
 
-func getAddonRegistry(ctx context.Context, name string) error {
-	ds := pkgaddon.NewRegistryDataStore(clt)
+func getAddonRegistry(ctx context.Context, c common.Args, name string) error {
+	client, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	ds := pkgaddon.NewRegistryDataStore(client)
 	registry, err := ds.GetRegistry(ctx, name)
 	if err != nil {
 		return err
@@ -211,8 +219,12 @@ func getAddonRegistry(ctx context.Context, name string) error {
 	return nil
 }
 
-func deleteAddonRegistry(ctx context.Context, name string) error {
-	ds := pkgaddon.NewRegistryDataStore(clt)
+func deleteAddonRegistry(ctx context.Context, c common.Args, name string) error {
+	client, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	ds := pkgaddon.NewRegistryDataStore(client)
 	if err := ds.DeleteRegistry(ctx, name); err != nil {
 		return err
 	}
@@ -220,8 +232,12 @@ func deleteAddonRegistry(ctx context.Context, name string) error {
 	return nil
 }
 
-func addAddonRegistry(ctx context.Context, registry pkgaddon.Registry) error {
-	ds := pkgaddon.NewRegistryDataStore(clt)
+func addAddonRegistry(ctx context.Context, c common.Args, registry pkgaddon.Registry) error {
+	client, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	ds := pkgaddon.NewRegistryDataStore(client)
 	if err := ds.AddRegistry(ctx, registry); err != nil {
 		return err
 	}
@@ -229,8 +245,12 @@ func addAddonRegistry(ctx context.Context, registry pkgaddon.Registry) error {
 	return nil
 }
 
-func updateAddonRegistry(ctx context.Context, registry pkgaddon.Registry) error {
-	ds := pkgaddon.NewRegistryDataStore(clt)
+func updateAddonRegistry(ctx context.Context, c common.Args, registry pkgaddon.Registry) error {
+	client, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	ds := pkgaddon.NewRegistryDataStore(client)
 	if err := ds.UpdateRegistry(ctx, registry); err != nil {
 		return err
 	}

--- a/references/cli/cli.go
+++ b/references/cli/cli.go
@@ -29,7 +29,6 @@ import (
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
-	"github.com/oam-dev/kubevela/references/a/preimport"
 	"github.com/oam-dev/kubevela/version"
 )
 
@@ -68,10 +67,6 @@ func NewCommand() *cobra.Command {
 		fmt.Println("InitDir err", err)
 		os.Exit(1)
 	}
-
-	preimport.SuppressLogging()
-	_, _ = commandArgs.GetClient()
-	preimport.ResumeLogging()
 
 	cmds.AddCommand(
 		// Getting Start

--- a/references/cli/components.go
+++ b/references/cli/components.go
@@ -45,9 +45,6 @@ func NewComponentsCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Co
 		Short:   "List/get components",
 		Long:    "List components & get components in registry",
 		Example: `vela comp`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// parse label filter
 			if label != "" {
@@ -76,7 +73,7 @@ func NewComponentsCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Co
 				}
 				return PrintComponentListFromRegistry(registry, ioStreams, filter)
 			}
-			return PrintInstalledCompDef(ioStreams, filter)
+			return PrintInstalledCompDef(c, ioStreams, filter)
 		},
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeExtension,
@@ -213,9 +210,13 @@ func InstallCompByNameFromRegistry(args common2.Args, ioStream cmdutil.IOStreams
 }
 
 // PrintInstalledCompDef will print all ComponentDefinition in cluster
-func PrintInstalledCompDef(io cmdutil.IOStreams, filter filterFunc) error {
+func PrintInstalledCompDef(c common2.Args, io cmdutil.IOStreams, filter filterFunc) error {
 	var list v1beta1.ComponentDefinitionList
-	err := clt.List(context.Background(), &list)
+	clt, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	err = clt.List(context.Background(), &list)
 	if err != nil {
 		return errors.Wrap(err, "get component definition list error")
 	}

--- a/references/cli/cue_packages.go
+++ b/references/cli/cue_packages.go
@@ -39,9 +39,6 @@ func NewCUEPackageCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Com
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeSystem,
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return printCUEPackageList(c, ioStreams)
 		},

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -45,9 +45,9 @@ const (
 )
 
 func initArgs() common2.Args {
-	return common2.Args{
-		Client: fake.NewClientBuilder().WithScheme(common2.Scheme).Build(),
-	}
+	arg := common2.Args{}
+	arg.SetClient(fake.NewClientBuilder().WithScheme(common2.Scheme).Build())
+	return arg
 }
 
 func initCommand(cmd *cobra.Command) {
@@ -66,7 +66,11 @@ func createTrait(c common2.Args, t *testing.T) string {
 
 func createNamespacedTrait(c common2.Args, name string, ns string, t *testing.T) {
 	traitName := fmt.Sprintf("my-trait-%d", time.Now().UnixNano())
-	if err := c.Client.Create(context.Background(), &v1beta1.TraitDefinition{
+	client, err := c.GetClient()
+	if err != nil {
+		t.Fatalf("failed to get client: %v", err)
+	}
+	if err := client.Create(context.Background(), &v1beta1.TraitDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
@@ -343,7 +347,11 @@ func TestNewDefinitionDelCommand(t *testing.T) {
 		t.Fatalf("unexpeced error when executing del command: %v", err)
 	}
 	obj := &v1beta1.TraitDefinition{}
-	if err := c.Client.Get(context.Background(), types.NamespacedName{
+	client, err := c.GetClient()
+	if err != nil {
+		t.Fatalf("failed to get client: %v", err)
+	}
+	if err := client.Get(context.Background(), types.NamespacedName{
 		Namespace: VelaTestNamespace,
 		Name:      traitName,
 	}, obj); !errors.IsNotFound(err) {

--- a/references/cli/delete.go
+++ b/references/cli/delete.go
@@ -35,9 +35,6 @@ func NewDeleteCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams)
 		DisableFlagsInUseLine: true,
 		Short:                 "Delete an application",
 		Long:                  "Delete an application",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
 			types.TagCommandType:  types.TypeApp,

--- a/references/cli/dryrun.go
+++ b/references/cli/dryrun.go
@@ -58,9 +58,6 @@ func NewDryRunCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeApp,
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
 			if err != nil {
@@ -101,8 +98,11 @@ func DryRunApplication(cmdOption *DryRunCmdOptions, c common.Args, namespace str
 	if err != nil {
 		return buff, err
 	}
-
-	dm, err := discoverymapper.New(c.Config)
+	config, err := c.GetConfig()
+	if err != nil {
+		return buff, err
+	}
+	dm, err := discoverymapper.New(config)
 	if err != nil {
 		return buff, err
 	}

--- a/references/cli/env.go
+++ b/references/cli/env.go
@@ -35,9 +35,6 @@ func NewEnvCommand(c common.Args, order string, ioStream cmdutil.IOStreams) *cob
 		DisableFlagsInUseLine: true,
 		Short:                 "Manage environments",
 		Long:                  "Manage environments",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		Annotations: map[string]string{
 			types.TagCommandOrder: order,
 			types.TagCommandType:  types.TypeStart,

--- a/references/cli/init.go
+++ b/references/cli/init.go
@@ -64,9 +64,6 @@ func NewInitCommand(c common2.Args, order string, ioStreams cmdutil.IOStreams) *
 		Short:                 "Create scaffold for an application",
 		Long:                  "Create scaffold for an application",
 		Example:               "vela init",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			o.Namespace, err = GetFlagNamespaceOrEnv(cmd, c)

--- a/references/cli/livediff.go
+++ b/references/cli/livediff.go
@@ -57,9 +57,6 @@ func NewLiveDiffCommand(c common.Args, order string, ioStreams cmdutil.IOStreams
 			types.TagCommandOrder: order,
 			types.TagCommandType:  types.TypeApp,
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
 			if err != nil {
@@ -102,8 +99,11 @@ func LiveDiffApplication(cmdOption *LiveDiffCmdOptions, c common.Args, namespace
 	if err != nil {
 		return buff, err
 	}
-
-	dm, err := discoverymapper.New(c.Config)
+	config, err := c.GetConfig()
+	if err != nil {
+		return buff, err
+	}
+	dm, err := discoverymapper.New(config)
 	if err != nil {
 		return buff, err
 	}

--- a/references/cli/logs.go
+++ b/references/cli/logs.go
@@ -49,11 +49,12 @@ func NewLogsCommand(c common.Args, order string, ioStreams util.IOStreams) *cobr
 		Long:  "Tail logs for application in multicluster",
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := c.SetConfig(); err != nil {
+			config, err := c.GetConfig()
+			if err != nil {
 				return err
 			}
 			largs.Args = c
-			largs.Args.Config.Wrap(multicluster.NewSecretModeMultiClusterRoundTripper)
+			config.Wrap(multicluster.NewSecretModeMultiClusterRoundTripper)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,7 +96,11 @@ type Args struct {
 func (l *Args) Run(ctx context.Context, ioStreams util.IOStreams) error {
 	// TODO(wonderflow): we could get labels from service to narrow the pods scope selected
 	labelSelector := labels.Everything()
-	clientSet, err := kubernetes.NewForConfig(l.Args.Config)
+	config, err := l.Args.GetConfig()
+	if err != nil {
+		return err
+	}
+	clientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err
 	}

--- a/references/cli/ls.go
+++ b/references/cli/ls.go
@@ -40,9 +40,6 @@ func NewListCommand(c common.Args, order string, ioStreams cmdutil.IOStreams) *c
 		Short:                 "List applications",
 		Long:                  "List all applications in cluster",
 		Example:               `vela ls`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newClient, err := c.GetClient()
 			if err != nil {

--- a/references/cli/show.go
+++ b/references/cli/show.go
@@ -65,9 +65,6 @@ func NewCapabilityShowCommand(c common.Args, ioStreams cmdutil.IOStreams) *cobra
 		Short:   "Show the reference doc for a component type or trait",
 		Long:    "Show the reference doc for a component type or trait",
 		Example: `show webservice`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("please specify a component type or trait")

--- a/references/cli/traits.go
+++ b/references/cli/traits.go
@@ -53,9 +53,6 @@ func NewTraitCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 		Short:   "List/get traits",
 		Long:    "List traits & get trait in registry",
 		Example: `vela trait`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// parse label filter
 			if label != "" {
@@ -85,7 +82,7 @@ func NewTraitCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Command
 				return PrintTraitListFromRegistry(registry, ioStreams, filter)
 
 			}
-			return PrintInstalledTraitDef(ioStreams, filter)
+			return PrintInstalledTraitDef(c, ioStreams, filter)
 		},
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeExtension,
@@ -214,9 +211,13 @@ func InstallTraitByNameFromRegistry(args common2.Args, ioStream cmdutil.IOStream
 }
 
 // PrintInstalledTraitDef will print all TraitDefinition in cluster
-func PrintInstalledTraitDef(io cmdutil.IOStreams, filter filterFunc) error {
+func PrintInstalledTraitDef(c common2.Args, io cmdutil.IOStreams, filter filterFunc) error {
 	var list v1beta1.TraitDefinitionList
-	err := clt.List(context.Background(), &list)
+	clt, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+	err = clt.List(context.Background(), &list)
 	if err != nil {
 		return errors.Wrap(err, "get trait definition list error")
 	}

--- a/references/cli/traits_test.go
+++ b/references/cli/traits_test.go
@@ -17,25 +17,13 @@ limitations under the License.
 package cli
 
 import (
-	"os"
 	"testing"
 
-	"github.com/oam-dev/kubevela/apis/types"
-
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
-	common2 "github.com/oam-dev/kubevela/pkg/utils/common"
-	cmdutil "github.com/oam-dev/kubevela/pkg/utils/util"
+	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/references/common"
 )
-
-func TestNewTraitsCommandPersistentPreRunE(t *testing.T) {
-	io := cmdutil.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	fakeC := common2.Args{}
-	cmd := NewTraitCommand(fakeC, io)
-	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
-}
 
 func TestTraitsAppliedToAllWorkloads(t *testing.T) {
 	trait := types.Capability{

--- a/references/cli/uischema.go
+++ b/references/cli/uischema.go
@@ -60,12 +60,9 @@ func NewUISchemaCommand(c common.Args, order string, ioStreams util.IOStreams) *
 		Annotations: map[string]string{
 			types.TagCommandType: types.TypeExtension,
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.New("please provider the uischema file or dir path")
+				return errors.New("please provider the ui schema file or dir path")
 			}
 			allUISchemaFiles, err := loadUISchemaFiles(args[0])
 			if err != nil {

--- a/references/cli/up.go
+++ b/references/cli/up.go
@@ -43,9 +43,6 @@ func NewUpCommand(c common2.Args, order string, ioStream cmdutil.IOStreams) *cob
 			types.TagCommandOrder: order,
 			types.TagCommandType:  types.TypeStart,
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
 			if err != nil {

--- a/references/cli/up_test.go
+++ b/references/cli/up_test.go
@@ -21,11 +21,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	common2 "github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
 	"github.com/oam-dev/kubevela/references/common"
 )
@@ -42,11 +40,4 @@ func TestUp(t *testing.T) {
 	msg := o.Info(app)
 	assert.Contains(t, msg, "App has been deployed")
 	assert.Contains(t, msg, fmt.Sprintf("App status: vela status %s", app.Name))
-}
-
-func TestNewUpCommandPersistentPreRunE(t *testing.T) {
-	io := util.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	fakeC := common2.Args{}
-	cmd := NewUpCommand(fakeC, "", io)
-	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }

--- a/references/cli/velaql.go
+++ b/references/cli/velaql.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/kubevela/pkg/velaql"
+	querytypes "github.com/oam-dev/kubevela/pkg/velaql/providers/query/types"
+)
+
+// GetServiceEndpoints get service endpoints by velaQL
+func GetServiceEndpoints(ctx context.Context, client client.Client, appName string, namespace string, velaC common.Args) ([]querytypes.ServiceEndpoint, error) {
+	dm, err := velaC.GetDiscoveryMapper()
+	if err != nil {
+		return nil, err
+	}
+	pd, err := velaC.GetPackageDiscover()
+	if err != nil {
+		return nil, err
+	}
+	queryView, err := velaql.ParseVelaQL(fmt.Sprintf("service-endpoints-view{appName=%s,appNs=%s}.endpoints", appName, namespace))
+	if err != nil {
+		return nil, err
+	}
+	config, err := velaC.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	queryValue, err := velaql.NewViewHandler(client, config, dm, pd).QueryView(ctx, queryView)
+	if err != nil {
+		return nil, err
+	}
+	var endpoints []querytypes.ServiceEndpoint
+	if err := queryValue.CueValue().Decode(&endpoints); err != nil {
+		return nil, err
+	}
+	return endpoints, nil
+}

--- a/references/cli/workflow.go
+++ b/references/cli/workflow.go
@@ -76,12 +76,11 @@ func NewWorkflowSuspendCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra
 			if app.Status.Workflow == nil {
 				return fmt.Errorf("the workflow in application is not running")
 			}
-			kubecli, err := c.GetClient()
+			client, err := c.GetClient()
 			if err != nil {
 				return err
 			}
-
-			err = suspendWorkflow(kubecli, app)
+			err = suspendWorkflow(client, app)
 			if err != nil {
 				return err
 			}
@@ -124,12 +123,12 @@ func NewWorkflowResumeCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.
 				}
 				return nil
 			}
-			kubecli, err := c.GetClient()
+			client, err := c.GetClient()
 			if err != nil {
 				return err
 			}
 
-			err = resumeWorkflow(kubecli, app)
+			err = resumeWorkflow(client, app)
 			if err != nil {
 				return err
 			}
@@ -165,12 +164,11 @@ func NewWorkflowTerminateCommand(c common.Args, ioStream cmdutil.IOStreams) *cob
 			if app.Status.Workflow == nil {
 				return fmt.Errorf("the workflow in application is not running")
 			}
-			kubecli, err := c.GetClient()
+			client, err := c.GetClient()
 			if err != nil {
 				return err
 			}
-
-			err = terminateWorkflow(kubecli, app)
+			err = terminateWorkflow(client, app)
 			if err != nil {
 				return err
 			}
@@ -206,12 +204,12 @@ func NewWorkflowRestartCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra
 			if app.Status.Workflow == nil {
 				return fmt.Errorf("the workflow in application is not running")
 			}
-			kubecli, err := c.GetClient()
+			client, err := c.GetClient()
 			if err != nil {
 				return err
 			}
 
-			err = restartWorkflow(kubecli, app)
+			err = restartWorkflow(client, app)
 			if err != nil {
 				return err
 			}
@@ -247,12 +245,12 @@ func NewWorkflowRollbackCommand(c common.Args, ioStream cmdutil.IOStreams) *cobr
 			if app.Status.Workflow != nil && !app.Status.Workflow.Terminated && !app.Status.Workflow.Suspend && !app.Status.Workflow.Finished {
 				return fmt.Errorf("can not rollback a running workflow")
 			}
-			kubecli, err := c.GetClient()
+			client, err := c.GetClient()
 			if err != nil {
 				return err
 			}
 
-			err = rollbackWorkflow(kubecli, app)
+			err = rollbackWorkflow(client, app)
 			if err != nil {
 				return err
 			}

--- a/references/cli/workflow_test.go
+++ b/references/cli/workflow_test.go
@@ -103,12 +103,14 @@ func TestWorkflowSuspend(t *testing.T) {
 			initCommand(cmd)
 			// clean up the arguments before start
 			cmd.SetArgs([]string{})
+			client, err := c.GetClient()
+			r.NoError(err)
 			if tc.app != nil {
-				err := c.Client.Create(ctx, tc.app)
+				err := client.Create(ctx, tc.app)
 				r.NoError(err)
 
 				if tc.app.Namespace != corev1.NamespaceDefault {
-					err := c.Client.Create(ctx, &corev1.Namespace{
+					err := client.Create(ctx, &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: tc.app.Namespace,
 						},
@@ -119,7 +121,7 @@ func TestWorkflowSuspend(t *testing.T) {
 					cmd.SetArgs([]string{tc.app.Name})
 				}
 			}
-			err := cmd.Execute()
+			err = cmd.Execute()
 			if tc.expectedErr != nil {
 				r.Equal(tc.expectedErr, err)
 				return
@@ -127,7 +129,7 @@ func TestWorkflowSuspend(t *testing.T) {
 			r.NoError(err)
 
 			wf := &v1beta1.Application{}
-			err = c.Client.Get(ctx, types.NamespacedName{
+			err = client.Get(ctx, types.NamespacedName{
 				Namespace: tc.app.Namespace,
 				Name:      tc.app.Name,
 			}, wf)
@@ -210,13 +212,14 @@ func TestWorkflowResume(t *testing.T) {
 			r := require.New(t)
 			cmd := NewWorkflowResumeCommand(c, ioStream)
 			initCommand(cmd)
-
+			client, err := c.GetClient()
+			r.NoError(err)
 			if tc.app != nil {
-				err := c.Client.Create(ctx, tc.app)
+				err := client.Create(ctx, tc.app)
 				r.NoError(err)
 
 				if tc.app.Namespace != corev1.NamespaceDefault {
-					err := c.Client.Create(ctx, &corev1.Namespace{
+					err := client.Create(ctx, &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: tc.app.Namespace,
 						},
@@ -227,7 +230,7 @@ func TestWorkflowResume(t *testing.T) {
 					cmd.SetArgs([]string{tc.app.Name})
 				}
 			}
-			err := cmd.Execute()
+			err = cmd.Execute()
 			if tc.expectedErr != nil {
 				r.Equal(tc.expectedErr, err)
 				return
@@ -235,7 +238,7 @@ func TestWorkflowResume(t *testing.T) {
 			r.NoError(err)
 
 			wf := &v1beta1.Application{}
-			err = c.Client.Get(ctx, types.NamespacedName{
+			err = client.Get(ctx, types.NamespacedName{
 				Namespace: tc.app.Namespace,
 				Name:      tc.app.Name,
 			}, wf)
@@ -298,13 +301,14 @@ func TestWorkflowTerminate(t *testing.T) {
 			r := require.New(t)
 			cmd := NewWorkflowTerminateCommand(c, ioStream)
 			initCommand(cmd)
-
+			client, err := c.GetClient()
+			r.NoError(err)
 			if tc.app != nil {
-				err := c.Client.Create(ctx, tc.app)
+				err := client.Create(ctx, tc.app)
 				r.NoError(err)
 
 				if tc.app.Namespace != corev1.NamespaceDefault {
-					err := c.Client.Create(ctx, &corev1.Namespace{
+					err := client.Create(ctx, &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: tc.app.Namespace,
 						},
@@ -315,7 +319,7 @@ func TestWorkflowTerminate(t *testing.T) {
 					cmd.SetArgs([]string{tc.app.Name})
 				}
 			}
-			err := cmd.Execute()
+			err = cmd.Execute()
 			if tc.expectedErr != nil {
 				r.Equal(tc.expectedErr, err)
 				return
@@ -323,7 +327,7 @@ func TestWorkflowTerminate(t *testing.T) {
 			r.NoError(err)
 
 			wf := &v1beta1.Application{}
-			err = c.Client.Get(ctx, types.NamespacedName{
+			err = client.Get(ctx, types.NamespacedName{
 				Namespace: tc.app.Namespace,
 				Name:      tc.app.Name,
 			}, wf)
@@ -386,13 +390,14 @@ func TestWorkflowRestart(t *testing.T) {
 			r := require.New(t)
 			cmd := NewWorkflowRestartCommand(c, ioStream)
 			initCommand(cmd)
-
+			client, err := c.GetClient()
+			r.NoError(err)
 			if tc.app != nil {
-				err := c.Client.Create(ctx, tc.app)
+				err := client.Create(ctx, tc.app)
 				r.NoError(err)
 
 				if tc.app.Namespace != corev1.NamespaceDefault {
-					err := c.Client.Create(ctx, &corev1.Namespace{
+					err := client.Create(ctx, &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: tc.app.Namespace,
 						},
@@ -403,7 +408,7 @@ func TestWorkflowRestart(t *testing.T) {
 					cmd.SetArgs([]string{tc.app.Name})
 				}
 			}
-			err := cmd.Execute()
+			err = cmd.Execute()
 			if tc.expectedErr != nil {
 				r.Equal(tc.expectedErr, err)
 				return
@@ -411,7 +416,7 @@ func TestWorkflowRestart(t *testing.T) {
 			r.NoError(err)
 
 			wf := &v1beta1.Application{}
-			err = c.Client.Get(ctx, types.NamespacedName{
+			err = client.Get(ctx, types.NamespacedName{
 				Namespace: tc.app.Namespace,
 				Name:      tc.app.Name,
 			}, wf)
@@ -517,13 +522,14 @@ func TestWorkflowRollback(t *testing.T) {
 			r := require.New(t)
 			cmd := NewWorkflowRollbackCommand(c, ioStream)
 			initCommand(cmd)
-
+			client, err := c.GetClient()
+			r.NoError(err)
 			if tc.app != nil {
-				err := c.Client.Create(ctx, tc.app)
+				err := client.Create(ctx, tc.app)
 				r.NoError(err)
 
 				if tc.app.Namespace != corev1.NamespaceDefault {
-					err := c.Client.Create(ctx, &corev1.Namespace{
+					err := client.Create(ctx, &corev1.Namespace{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: tc.app.Namespace,
 						},
@@ -535,10 +541,10 @@ func TestWorkflowRollback(t *testing.T) {
 				}
 			}
 			if tc.revision != nil {
-				err := c.Client.Create(ctx, tc.revision)
+				err := client.Create(ctx, tc.revision)
 				r.NoError(err)
 			}
-			err := cmd.Execute()
+			err = cmd.Execute()
 			if tc.expectedErr != nil {
 				r.Equal(tc.expectedErr, err)
 				return
@@ -546,7 +552,7 @@ func TestWorkflowRollback(t *testing.T) {
 			r.NoError(err)
 
 			wf := &v1beta1.Application{}
-			err = c.Client.Get(ctx, types.NamespacedName{
+			err = client.Get(ctx, types.NamespacedName{
 				Namespace: tc.app.Namespace,
 				Name:      tc.app.Name,
 			}, wf)

--- a/references/cli/workloads.go
+++ b/references/cli/workloads.go
@@ -34,9 +34,6 @@ func NewWorkloadsCommand(c common2.Args, ioStreams cmdutil.IOStreams) *cobra.Com
 		Long:                  "List workloads",
 		Example:               `vela workloads`,
 		Hidden:                true,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return c.SetConfig()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, err := GetFlagNamespaceOrEnv(cmd, c)
 			if err != nil {

--- a/references/plugins/cluster.go
+++ b/references/plugins/cluster.go
@@ -150,7 +150,11 @@ func GetTraitsFromClusterWithValidateOption(ctx context.Context, namespace strin
 	if err != nil {
 		return nil, nil, err
 	}
-	dm, err := discoverymapper.New(c.Config)
+	config, err := c.GetConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	dm, err := discoverymapper.New(config)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/references/plugins/suit_test.go
+++ b/references/plugins/suit_test.go
@@ -49,7 +49,6 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var cfg *rest.Config
-var scheme *runtime.Scheme
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var definitionDir string
@@ -81,7 +80,7 @@ var _ = BeforeSuite(func(done Done) {
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
-	scheme = runtime.NewScheme()
+	scheme := runtime.NewScheme()
 	Expect(coreoam.AddToScheme(scheme)).NotTo(HaveOccurred())
 	Expect(clientgoscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
 	Expect(v1beta1.AddToScheme(scheme)).NotTo(HaveOccurred())


### PR DESCRIPTION
…onse

Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

![image](https://user-images.githubusercontent.com/18493394/148380985-117250ea-fe09-4d07-bd09-6128e812d830.png)

* Support show application endpoints in the `vela status` command.
* Support show application endpoints after addon enabled
* Adjust the CLI code structure to speed up CLI response. `vela --help` 3s => ms

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.