### PR TITLE
Fix: add cue binary requirement in Development doc

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -9,6 +9,7 @@ This guide helps you get started developing KubeVela.
 3. ginkgo 1.14.0+ (just for [E2E test](./developer-guide.md#e2e-test))
 4. golangci-lint 1.38.0+, it will install automatically if you run `make`, you can [install it manually](https://golangci-lint.run/usage/install/#local-installation) if the installation is too slow.
 5. kubebuilder v3.1.0+ and you need to manually install the dependency tools for unit test.
+6. [Cue binary](https://github.com/cue-lang/cue/releases) v0.3.0+
 
 <details>
   <summary>Install Kubebuilder manually</summary>

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -9,7 +9,7 @@ This guide helps you get started developing KubeVela.
 3. ginkgo 1.14.0+ (just for [E2E test](./developer-guide.md#e2e-test))
 4. golangci-lint 1.38.0+, it will install automatically if you run `make`, you can [install it manually](https://golangci-lint.run/usage/install/#local-installation) if the installation is too slow.
 5. kubebuilder v3.1.0+ and you need to manually install the dependency tools for unit test.
-6. [Cue binary](https://github.com/cue-lang/cue/releases) v0.3.0+
+6. [CUE binary](https://github.com/cue-lang/cue/releases) v0.3.0+
 
 <details>
   <summary>Install Kubebuilder manually</summary>


### PR DESCRIPTION
If the version of cue binary is less than v0.3.0, like v0.2.0, `make reviewable`
will fail due to issue: "make: *** [fmt] Error 1". As `make reviewable` is a
required step for code contribution, add this prerequiste in the doc.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->