### PR TITLE
Fix: recover filtered event by re-sync

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller.go
@@ -393,6 +393,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// filter the changes in workflow status
 			// let workflow handle its reconcile
 			UpdateFunc: func(e ctrlEvent.UpdateEvent) bool {
+				// if completely equal, this update is triggered by re-sync and should not be filtered
+				if reflect.DeepEqual(e.ObjectNew, e.ObjectOld) {
+					return true
+				}
 				new, isNewApp := e.ObjectNew.DeepCopyObject().(*v1beta1.Application)
 				old, isOldApp := e.ObjectOld.DeepCopyObject().(*v1beta1.Application)
 				if !isNewApp || !isOldApp {


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Previous resync events are filtered by the equality check. Thus the logic will make StateKeep failed.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->