### PR TITLE
Feat: add DockerHub webhook trigger 

### DIFF
--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -430,10 +430,44 @@ type EventData struct {
 	Repository Repository  `json:"repository"`
 }
 
+// HandleApplicationTriggerACRRequest application trigger DockerHub webhook request
+type HandleApplicationTriggerDockerHubRequest struct {
+	CallbackUrl string              `json:"callback_url"`
+	PushData    DockerHubData       `json:"push_data"`
+	Repository  DockerHubRepository `json:"repository"`
+}
+
+// DockerHubData is the push data of dockerhub
+type DockerHubData struct {
+	Images   []string `json:"images"`
+	PushedAt int64    `json:"pushed_at"`
+	Pusher   string   `json:"pusher"`
+	Tag      string   `json:"tag"`
+}
+
+// DockerHubRepository is the repository of dockerhub
+type DockerHubRepository struct {
+	CommentCount    int    `json:"comment_count"`
+	DateCreated     int64  `json:"date_created"`
+	Description     string `json:"description"`
+	Dockerfile      string `json:"dockerfile"`
+	FullDescription string `json:"full_description"`
+	IsOfficial      bool   `json:"is_official"`
+	IsPrivate       bool   `json:"is_private"`
+	IsTrusted       bool   `json:"is_trusted"`
+	Name            string `json:"name"`
+	Namespace       string `json:"namespace"`
+	Owner           string `json:"owner"`
+	RepoName        string `json:"repo_name"`
+	RepoUrl         string `json:"repo_url"`
+	StartCount      int    `json:"star_count"`
+	Status          string `json:"status"`
+}
+
 // EnvBinding application env binding
 type EnvBinding struct {
 	Name string `json:"name" validate:"checkname"`
-	//TODO: support componentsPatch
+	// TODO: support componentsPatch
 }
 
 // EnvBindingTarget the target struct in the envbinding base struct
@@ -826,6 +860,14 @@ type ApplicationDeployRequest struct {
 // ApplicationDeployResponse application deploy response body
 type ApplicationDeployResponse struct {
 	ApplicationRevisionBase
+}
+
+// ApplicationDockerhubWebhookResponse dockerhub webhook response body
+type ApplicationDockerhubWebhookResponse struct {
+	State       string `json:"state,omitempty"`
+	Description string `json:"description,omitempty"`
+	Context     string `json:"context,omitempty"`
+	TargetUrl   string `json:"target_url,omitempty"`
 }
 
 // VelaQLViewResponse query response

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -430,9 +430,9 @@ type EventData struct {
 	Repository Repository  `json:"repository"`
 }
 
-// HandleApplicationTriggerACRRequest application trigger DockerHub webhook request
+// HandleApplicationTriggerDockerHubRequest application trigger DockerHub webhook request
 type HandleApplicationTriggerDockerHubRequest struct {
-	CallbackUrl string              `json:"callback_url"`
+	CallbackURL string              `json:"callback_url"`
 	PushData    DockerHubData       `json:"push_data"`
 	Repository  DockerHubRepository `json:"repository"`
 }
@@ -459,7 +459,7 @@ type DockerHubRepository struct {
 	Namespace       string `json:"namespace"`
 	Owner           string `json:"owner"`
 	RepoName        string `json:"repo_name"`
-	RepoUrl         string `json:"repo_url"`
+	RepoURL         string `json:"repo_url"`
 	StartCount      int    `json:"star_count"`
 	Status          string `json:"status"`
 }
@@ -867,7 +867,7 @@ type ApplicationDockerhubWebhookResponse struct {
 	State       string `json:"state,omitempty"`
 	Description string `json:"description,omitempty"`
 	Context     string `json:"context,omitempty"`
-	TargetUrl   string `json:"target_url,omitempty"`
+	TargetURL   string `json:"target_url,omitempty"`
 }
 
 // VelaQLViewResponse query response

--- a/pkg/apiserver/rest/usecase/webhook.go
+++ b/pkg/apiserver/rest/usecase/webhook.go
@@ -328,7 +328,7 @@ func (c dockerHubHandlerImpl) handle(ctx context.Context, trigger *model.Applica
 	}, nil
 }
 
-func (d dockerHubHandlerImpl) install() {
+func (c dockerHubHandlerImpl) install() {
 	WebhookHandlers = append(WebhookHandlers, model.PayloadTypeDockerhub)
 }
 
@@ -373,7 +373,7 @@ func (c *harborHandlerImpl) install() {
 	WebhookHandlers = append(WebhookHandlers, model.PayloadTypeHarbor)
 }
 
-func (c *harborHandlerImpl) handle(ctx context.Context, webhookTrigger *model.ApplicationTrigger, app *model.Application) (*apisv1.ApplicationDeployResponse, error) {
+func (c *harborHandlerImpl) handle(ctx context.Context, webhookTrigger *model.ApplicationTrigger, app *model.Application) (interface{}, error) {
 	resources := c.req.EventData.Resources
 	if len(resources) < 1 {
 		return nil, bcode.ErrInvalidWebhookPayloadBody

--- a/pkg/apiserver/rest/usecase/webhook.go
+++ b/pkg/apiserver/rest/usecase/webhook.go
@@ -60,6 +60,7 @@ func NewWebhookUsecase(ds datastore.DataStore,
 func registerHandlers() {
 	new(customHandlerImpl).install()
 	new(acrHandlerImpl).install()
+	new(dockerHubHandlerImpl).install()
 	new(harborHandlerImpl).install()
 }
 

--- a/pkg/apiserver/rest/usecase/webhook_test.go
+++ b/pkg/apiserver/rest/usecase/webhook_test.go
@@ -136,6 +136,7 @@ var _ = Describe("Test application usecase function", func() {
 		Expect(err).Should(BeNil())
 		res, err := webhookUsecase.HandleApplicationWebhook(context.TODO(), triggers[0].Token, restful.NewRequest(httpreq))
 		Expect(err).Should(BeNil())
+		appDeployRes := res.(*apisv1.ApplicationDeployResponse)
 		comp, err := appUsecase.GetApplicationComponent(context.TODO(), appModel, "component-name-webhook")
 		Expect(err).Should(BeNil())
 		Expect((*comp.Properties)["image"]).Should(Equal("test-image"))
@@ -145,7 +146,7 @@ var _ = Describe("Test application usecase function", func() {
 
 		revision := &model.ApplicationRevision{
 			AppPrimaryKey: "test-app-webhook",
-			Version:       res.Version,
+			Version:       appDeployRes.Version,
 		}
 		err = webhookUsecase.ds.Get(context.TODO(), revision)
 		Expect(err).Should(BeNil())


### PR DESCRIPTION
### Description of your changes
add DockerHub webhook trigger: #3029 

### Special notes for your reviewer
change webhook response data struct to interface{} because [dockerhub webhook](https://docs.docker.com/docker-hub/webhooks/#validate-a-webhook-callback) should response standard data structure to show webhook call status in dockerhub web, and continue dockerhub webhook chain