### PR TITLE
Feat: system information collection logic in apiserver

### DIFF
--- a/pkg/apiserver/model/system_info.go
+++ b/pkg/apiserver/model/system_info.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+func init() {
+	RegistModel(&SystemInfo{})
+}
+
+// SystemInfo systemInfo model
+type SystemInfo struct {
+	BaseModel
+	InstallID        string `json:"installID"`
+	EnableCollection bool   `json:"enableCollection"`
+}
+
+// TableName return custom table name
+func (u *SystemInfo) TableName() string {
+	return tableNamePrefix + "system_info"
+}
+
+// PrimaryKey return custom primary key
+func (u *SystemInfo) PrimaryKey() string {
+	return u.InstallID
+}
+
+// Index return custom index
+func (u *SystemInfo) Index() map[string]string {
+	index := make(map[string]string)
+	if u.InstallID != "" {
+		index["installID"] = u.InstallID
+	}
+	return index
+}

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -945,3 +945,13 @@ type ListRevisionsResponse struct {
 type DetailRevisionResponse struct {
 	model.ApplicationRevision
 }
+
+// SystemInfoResponse get SystemInfo
+type SystemInfoResponse struct {
+	model.SystemInfo
+}
+
+// SystemInfoRequest request by enable/disable SystemInfo
+type SystemInfoRequest struct {
+	InstallID string
+}

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -949,9 +949,16 @@ type DetailRevisionResponse struct {
 // SystemInfoResponse get SystemInfo
 type SystemInfoResponse struct {
 	model.SystemInfo
+	SystemVersion SystemVersion
 }
 
-// SystemInfoRequest request by enable/disable SystemInfo
+// SystemInfoRequest request by update SystemInfo
 type SystemInfoRequest struct {
-	InstallID string
+	EnableCollection bool
+}
+
+// SystemVersion contains KubeVela version
+type SystemVersion struct {
+	KubeVelaVersion string `json:"KubeVelaVersion"`
+	GitVersion      string `json:"gitVersion"`
 }

--- a/pkg/apiserver/rest/usecase/system_info.go
+++ b/pkg/apiserver/rest/usecase/system_info.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usecase
+
+import (
+	"context"
+
+	v1 "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/oam-dev/kubevela/pkg/apiserver/model"
+
+	"github.com/oam-dev/kubevela/pkg/apiserver/datastore"
+)
+
+// SystemInfoUsecase is usecase for systemInfoCollection
+type SystemInfoUsecase interface {
+	GetSystemInfo(ctx context.Context) (*v1.SystemInfoResponse, error)
+	EnableCollection(ctx context.Context) (*v1.SystemInfoResponse, error)
+	DisableCollection(ctx context.Context) (*v1.SystemInfoResponse, error)
+	DeleteSystemInfo(ctx context.Context) error
+}
+
+type systemInfoUsecaseImpl struct {
+	ds datastore.DataStore
+}
+
+// NewSystemInfoUsecase return a systemInfoCollectionUsecase
+func NewSystemInfoUsecase(ds datastore.DataStore) SystemInfoUsecase {
+	return &systemInfoUsecaseImpl{ds: ds}
+}
+
+func (u systemInfoUsecaseImpl) GetSystemInfo(ctx context.Context) (*v1.SystemInfoResponse, error) {
+	// first get request will init systemInfoCollection{installId: {random}, enableCollection: true}
+	info := &model.SystemInfo{}
+	entities, err := u.ds.List(ctx, info, &datastore.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if len(entities) != 0 {
+		info := entities[0].(*model.SystemInfo)
+		return &v1.SystemInfoResponse{SystemInfo: *info}, nil
+	}
+	installID := rand.String(16)
+	info.InstallID = installID
+	info.EnableCollection = true
+	err = u.ds.Add(ctx, info)
+	if err != nil {
+		return nil, err
+	}
+	return &v1.SystemInfoResponse{SystemInfo: *info}, nil
+}
+
+func (u systemInfoUsecaseImpl) EnableCollection(ctx context.Context) (*v1.SystemInfoResponse, error) {
+	info, err := u.GetSystemInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if info.EnableCollection {
+		return info, nil
+	}
+	modifiedInfo := model.SystemInfo{InstallID: info.InstallID, EnableCollection: true}
+	err = u.ds.Put(ctx, &modifiedInfo)
+	if err != nil {
+		return nil, err
+	}
+	return &v1.SystemInfoResponse{SystemInfo: modifiedInfo}, nil
+}
+
+func (u systemInfoUsecaseImpl) DisableCollection(ctx context.Context) (*v1.SystemInfoResponse, error) {
+	info, err := u.GetSystemInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !info.EnableCollection {
+		return info, nil
+	}
+	modifiedInfo := model.SystemInfo{InstallID: info.InstallID, EnableCollection: false}
+	err = u.ds.Put(ctx, &modifiedInfo)
+	if err != nil {
+		return nil, err
+	}
+	return &v1.SystemInfoResponse{SystemInfo: modifiedInfo}, nil
+}
+
+func (u systemInfoUsecaseImpl) DeleteSystemInfo(ctx context.Context) error {
+	info, err := u.GetSystemInfo(ctx)
+	if err != nil {
+		return err
+	}
+	err = u.ds.Delete(ctx, info)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/apiserver/rest/webservice/system_info.go
+++ b/pkg/apiserver/rest/webservice/system_info.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webservice
+
+import (
+	restfulspec "github.com/emicklei/go-restful-openapi/v2"
+	"github.com/emicklei/go-restful/v3"
+
+	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+	"github.com/oam-dev/kubevela/pkg/apiserver/rest/usecase"
+	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
+)
+
+type systemInfoWebService struct {
+	useCase usecase.SystemInfoUsecase
+}
+
+// NewSystemInfoWebService return systemInfo webservice
+func NewSystemInfoWebService(systemInfoUseCase usecase.SystemInfoUsecase) WebService {
+	return &systemInfoWebService{useCase: systemInfoUseCase}
+}
+
+// GetWebService return systemInfo webservice
+func (u systemInfoWebService) GetWebService() *restful.WebService {
+	ws := new(restful.WebService)
+	ws.Path(versionPrefix+"/system_info").Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML).
+		Doc("api for systemInfo management")
+
+	tags := []string{"systemInfo"}
+
+	// Get
+	ws.Route(ws.GET("/").To(u.getSystemInfo).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(200, "", apis.SystemInfoResponse{}).
+		Returns(400, "", bcode.Bcode{}).
+		Writes(apis.SystemInfoResponse{}))
+
+	// Get
+	ws.Route(ws.DELETE("/").To(u.deleteSystemInfo).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(200, "", apis.SystemInfoResponse{}).
+		Returns(400, "", bcode.Bcode{}).
+		Writes(apis.SystemInfoResponse{}))
+
+	// Get
+	ws.Route(ws.POST("/enable").To(u.enableSystemInfo).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Reads(apis.SystemInfoRequest{}).
+		Returns(200, "", apis.SystemInfoResponse{}).
+		Returns(400, "", bcode.Bcode{}).
+		Writes(apis.SystemInfoResponse{}))
+
+	// Get
+	ws.Route(ws.POST("/disable").To(u.disableSystemInfo).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Reads(apis.SystemInfoRequest{}).
+		Returns(200, "", apis.SystemInfoResponse{}).
+		Returns(400, "", bcode.Bcode{}).
+		Writes(apis.SystemInfoResponse{}))
+
+	return ws
+}
+
+func (u systemInfoWebService) getSystemInfo(req *restful.Request, res *restful.Response) {
+	info, err := u.useCase.GetSystemInfo(req.Request.Context())
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+	if err := res.WriteEntity(info); err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}
+
+func (u systemInfoWebService) enableSystemInfo(req *restful.Request, res *restful.Response) {
+	info, err := u.useCase.EnableCollection(req.Request.Context())
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+	if err := res.WriteEntity(info); err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}
+
+func (u systemInfoWebService) disableSystemInfo(req *restful.Request, res *restful.Response) {
+	info, err := u.useCase.DisableCollection(req.Request.Context())
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+	if err := res.WriteEntity(info); err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}
+
+func (u systemInfoWebService) deleteSystemInfo(req *restful.Request, res *restful.Response) {
+	err := u.useCase.DeleteSystemInfo(req.Request.Context())
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}

--- a/pkg/apiserver/rest/webservice/system_info.go
+++ b/pkg/apiserver/rest/webservice/system_info.go
@@ -50,23 +50,15 @@ func (u systemInfoWebService) GetWebService() *restful.WebService {
 		Returns(400, "", bcode.Bcode{}).
 		Writes(apis.SystemInfoResponse{}))
 
-	// Get
+	// Delete
 	ws.Route(ws.DELETE("/").To(u.deleteSystemInfo).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(200, "", apis.SystemInfoResponse{}).
 		Returns(400, "", bcode.Bcode{}).
 		Writes(apis.SystemInfoResponse{}))
 
-	// Get
-	ws.Route(ws.POST("/enable").To(u.enableSystemInfo).
-		Metadata(restfulspec.KeyOpenAPITags, tags).
-		Reads(apis.SystemInfoRequest{}).
-		Returns(200, "", apis.SystemInfoResponse{}).
-		Returns(400, "", bcode.Bcode{}).
-		Writes(apis.SystemInfoResponse{}))
-
-	// Get
-	ws.Route(ws.POST("/disable").To(u.disableSystemInfo).
+	// Post
+	ws.Route(ws.PUT("/").To(u.updateSystemInfo).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Reads(apis.SystemInfoRequest{}).
 		Returns(200, "", apis.SystemInfoResponse{}).
@@ -88,20 +80,23 @@ func (u systemInfoWebService) getSystemInfo(req *restful.Request, res *restful.R
 	}
 }
 
-func (u systemInfoWebService) enableSystemInfo(req *restful.Request, res *restful.Response) {
-	info, err := u.useCase.EnableCollection(req.Request.Context())
-	if err != nil {
-		bcode.ReturnError(req, res, err)
-		return
+func (u systemInfoWebService) updateSystemInfo(req *restful.Request, res *restful.Response) {
+	var systemInfoReq apis.SystemInfoRequest
+	var args []byte
+	_, err := req.Request.Body.Read(args)
+	if err == nil {
+		err := req.ReadEntity(&systemInfoReq)
+		if err != nil {
+			bcode.ReturnError(req, res, err)
+			return
+		}
+		if err = validate.Struct(&systemInfoReq); err != nil {
+			bcode.ReturnError(req, res, err)
+			return
+		}
 	}
-	if err := res.WriteEntity(info); err != nil {
-		bcode.ReturnError(req, res, err)
-		return
-	}
-}
 
-func (u systemInfoWebService) disableSystemInfo(req *restful.Request, res *restful.Response) {
-	info, err := u.useCase.DisableCollection(req.Request.Context())
+	info, err := u.useCase.UpdateSystemInfo(req.Request.Context(), systemInfoReq)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return

--- a/pkg/apiserver/rest/webservice/webservice.go
+++ b/pkg/apiserver/rest/webservice/webservice.go
@@ -71,6 +71,7 @@ func Init(ds datastore.DataStore, addonCacheTime time.Duration) {
 	envBindingUsecase := usecase.NewEnvBindingUsecase(ds, workflowUsecase, definitionUsecase, envUsecase)
 	applicationUsecase := usecase.NewApplicationUsecase(ds, workflowUsecase, envBindingUsecase, envUsecase, targetUsecase, definitionUsecase, projectUsecase)
 	webhookUsecase := usecase.NewWebhookUsecase(ds, applicationUsecase)
+	systemInfoUsecase := usecase.NewSystemInfoUsecase(ds)
 
 	// init for default values
 
@@ -93,4 +94,6 @@ func Init(ds datastore.DataStore, addonCacheTime time.Duration) {
 	RegisterWebService(NewTargetWebService(targetUsecase, applicationUsecase))
 	RegisterWebService(NewVelaQLWebService(velaQLUsecase))
 	RegisterWebService(NewWebhookWebService(webhookUsecase, applicationUsecase))
+
+	RegisterWebService(NewSystemInfoWebService(systemInfoUsecase))
 }

--- a/test/e2e-apiserver-test/system_info_test.go
+++ b/test/e2e-apiserver-test/system_info_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_apiserver_test
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apisv1 "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
+)
+
+var _ = Describe("Test system info  rest api", func() {
+	BeforeEach(func() {
+		req, err := http.NewRequest(http.MethodDelete, baseURL+"/api/v1/system_info/", nil)
+		Expect(err).Should(BeNil())
+		deleteRes, err := http.DefaultClient.Do(req)
+		Expect(err).Should(BeNil())
+		Expect(deleteRes).ShouldNot(BeNil())
+		Expect(deleteRes.StatusCode).Should(Equal(200))
+	})
+
+	It("Test get SystemInfo", func() {
+		response := get("/api/v1/system_info/")
+		Expect(response).ShouldNot(BeNil())
+		Expect(response.Body).ShouldNot(BeNil())
+		Expect(response.StatusCode).Should(Equal(200))
+
+		defer response.Body.Close()
+
+		var info apisv1.SystemInfoResponse
+		err := json.NewDecoder(response.Body).Decode(&info)
+		Expect(err).Should(BeNil())
+		Expect(len(info.InstallID)).ShouldNot(BeEquivalentTo(0))
+		Expect(info.EnableCollection).Should(BeEquivalentTo(true))
+		systemID := info.InstallID
+
+		// check several times the systemID should not change
+		for i := 0; i < 5; i++ {
+			check := get("/api/v1/system_info/")
+			Expect(check).ShouldNot(BeNil())
+			Expect(check.Body).ShouldNot(BeNil())
+			Expect(check.StatusCode).Should(Equal(200))
+
+			var checkInfo apisv1.SystemInfoResponse
+			err := json.NewDecoder(check.Body).Decode(&checkInfo)
+			Expect(err).Should(BeNil())
+			Expect(checkInfo.InstallID).Should(BeEquivalentTo(systemID))
+		}
+	})
+
+	It("Test disable/enable systemInfoCollection", func() {
+		response := get("/api/v1/system_info/")
+		Expect(response).ShouldNot(BeNil())
+		Expect(response.Body).ShouldNot(BeNil())
+		Expect(response.StatusCode).Should(Equal(200))
+
+		defer response.Body.Close()
+
+		var info apisv1.SystemInfoResponse
+		err := json.NewDecoder(response.Body).Decode(&info)
+		Expect(err).Should(BeNil())
+		Expect(len(info.InstallID)).ShouldNot(BeEquivalentTo(0))
+		Expect(info.EnableCollection).Should(BeEquivalentTo(true))
+		installID := info.InstallID
+
+		response = post("/api/v1/system_info/disable", apisv1.SystemInfoRequest{InstallID: installID})
+		Expect(response).ShouldNot(BeNil())
+		Expect(response.StatusCode).Should(Equal(200))
+
+		info = apisv1.SystemInfoResponse{}
+		err = json.NewDecoder(response.Body).Decode(&info)
+		Expect(err).Should(BeNil())
+		Expect(len(info.InstallID)).ShouldNot(BeEquivalentTo(0))
+		Expect(info.EnableCollection).Should(BeEquivalentTo(false))
+
+		getRes := get("/api/v1/system_info/")
+		Expect(getRes).ShouldNot(BeNil())
+		Expect(getRes.Body).ShouldNot(BeNil())
+		Expect(getRes.StatusCode).Should(Equal(200))
+
+		var checkInfo apisv1.SystemInfoResponse
+		err = json.NewDecoder(getRes.Body).Decode(&checkInfo)
+		Expect(err).Should(BeNil())
+		Expect(checkInfo.InstallID).Should(BeEquivalentTo(installID))
+		Expect(checkInfo.EnableCollection).Should(BeEquivalentTo(false))
+
+		response = post("/api/v1/system_info/enable", apisv1.SystemInfoRequest{InstallID: installID})
+		Expect(response).ShouldNot(BeNil())
+		Expect(response.StatusCode).Should(Equal(200))
+
+		var ebableInfo apisv1.SystemInfoResponse
+		err = json.NewDecoder(response.Body).Decode(&ebableInfo)
+		Expect(err).Should(BeNil())
+		Expect(len(ebableInfo.InstallID)).ShouldNot(BeEquivalentTo(0))
+		Expect(ebableInfo.EnableCollection).Should(BeEquivalentTo(true))
+		Expect(ebableInfo.InstallID).Should(BeEquivalentTo(installID))
+
+		getAgainRes := get("/api/v1/system_info/")
+		Expect(getRes).ShouldNot(BeNil())
+		Expect(getRes.Body).ShouldNot(BeNil())
+		Expect(getRes.StatusCode).Should(Equal(200))
+
+		var checkAgainInfo apisv1.SystemInfoResponse
+		err = json.NewDecoder(getAgainRes.Body).Decode(&checkAgainInfo)
+		Expect(err).Should(BeNil())
+		Expect(checkAgainInfo.InstallID).Should(BeEquivalentTo(installID))
+		Expect(checkAgainInfo.EnableCollection).Should(BeEquivalentTo(true))
+	})
+})


### PR DESCRIPTION
Signed-off-by: wangyike <wangyike_wyk@163.com>

1. `get` userInfoCollection will return

```json
{
    "userID": "n9qpmg2wtkcbj4cc",
    "enableCollection": true
}
```
 
first `get` request will generate a UserID by random

2. post request `enable/disable`  will enable or disable user-Info-collection
3. write e2e-test

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->