### PR TITLE
Fix: cue template health check skipStandard workload and fix test diverge

### DIFF
--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -81,6 +81,7 @@ type Workload struct {
 	Ctx                process.Context
 	Patch              *value.Value
 	engine             definition.AbstractEngine
+	SkipApplyWorkload  bool
 }
 
 // EvalContext eval workload template and set result to context
@@ -90,12 +91,17 @@ func (wl *Workload) EvalContext(ctx process.Context) error {
 
 // EvalStatus eval workload status
 func (wl *Workload) EvalStatus(ctx process.Context, cli client.Client, ns string) (string, error) {
+	// if the  standard workload is managed by trait always return empty message
+	if wl.SkipApplyWorkload {
+		return "", nil
+	}
 	return wl.engine.Status(ctx, cli, ns, wl.FullTemplate.CustomStatus, wl.Params)
 }
 
 // EvalHealth eval workload health check
 func (wl *Workload) EvalHealth(ctx process.Context, client client.Client, namespace string) (bool, error) {
-	if wl.FullTemplate.Health == "" {
+	// if health of template is not set or standard workload is managed by trait always return true
+	if wl.FullTemplate.Health == "" || wl.SkipApplyWorkload {
 		return true, nil
 	}
 	return wl.engine.HealthCheck(ctx, client, namespace, wl.FullTemplate.Health)


### PR DESCRIPTION
Signed-off-by: wangyike <wangyike_wyk@163.com>

cue template health check skipStandard workload and fix rollout e2e-test diverge

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->