### PR TITLE
Fix:  file under the path of github addon registry is not ignored

### DIFF
--- a/pkg/addon/reader_github.go
+++ b/pkg/addon/reader_github.go
@@ -48,6 +48,9 @@ func (g *gitReader) ListAddonMeta() (map[string]SourceMeta, error) {
 	}
 	for _, item := range items {
 		// single addon
+		if item.GetType() != DirType {
+			continue
+		}
 		addonName := path.Base(item.GetPath())
 		addonMeta, err := g.listAddonMeta(g.RelativePath(item))
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

Fixes #3098 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->