### PR TITLE
Fix: rollout workload namespace not aligned with rollout

### DIFF
--- a/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler.go
+++ b/pkg/controller/standard.oam.dev/v1alpha1/rollout/handler.go
@@ -221,10 +221,8 @@ func (h *handler) handleRolloutModified() {
 
 // setWorkloadBaseInfo set base workload base info, which is such as workload name and component revision label
 func (h *handler) setWorkloadBaseInfo() {
-	if len(h.targetWorkload.GetNamespace()) == 0 {
-		h.targetWorkload.SetNamespace(h.rollout.Namespace)
-	}
-	if h.sourceWorkload != nil && len(h.sourceWorkload.GetNamespace()) == 0 {
+	h.targetWorkload.SetNamespace(h.rollout.Namespace)
+	if h.sourceWorkload != nil {
 		h.sourceWorkload.SetNamespace(h.rollout.Namespace)
 	}
 


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fix rollout workload namespace not aligned with rollout. In EnvBinding, workload could be relocated at a namespace different from the initial one. Rollout controller should follow this redirection. 

Solve #3105 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->