### PR TITLE
Fix: Vela is crashed, when disabling addon, which needs namespace vela-system

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -467,6 +467,10 @@ func RenderApp(ctx context.Context, addon *InstallPackage, config *rest.Config, 
 	}
 	app.Labels = util.MergeMapOverrideWithDst(app.Labels, map[string]string{oam.LabelAddonName: addon.Name})
 	for _, namespace := range addon.NeedNamespace {
+		// vela-system must exist before rendering vela addon
+		if namespace == types.DefaultKubeVelaNS {
+			continue
+		}
 		comp := common2.ApplicationComponent{
 			Type:       "raw",
 			Name:       fmt.Sprintf("%s-namespace", namespace),

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -226,6 +226,17 @@ func TestRenderApp(t *testing.T) {
 	assert.Equal(t, len(app.Spec.Components), 2)
 }
 
+func TestRenderAppWithNeedNamespace(t *testing.T) {
+	addon := baseAddon
+	addon.NeedNamespace = append(addon.NeedNamespace, types.DefaultKubeVelaNS)
+	app, err := RenderApp(ctx, &addon, nil, nil, map[string]interface{}{})
+	assert.NoError(t, err, "render app fail")
+	assert.Equal(t, len(app.Spec.Components), 2)
+	for _, c := range app.Spec.Components {
+		assert.NotEqual(t, types.DefaultKubeVelaNS+"-namespace", c.Name, "namespace vela-system should not be rendered")
+	}
+}
+
 func TestRenderDeploy2RuntimeAddon(t *testing.T) {
 	addonDeployToRuntime := baseAddon
 	addonDeployToRuntime.Meta.DeployTo = &DeployTo{


### PR DESCRIPTION
…adata information

Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes
ignore vela-system, which is specified in needNamespace for addon metadata information.
Fixes #3108 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->