### PR TITLE
Fix: add NotUpdateRenderHashEqual option to statekeep apply

### DIFF
--- a/pkg/resourcekeeper/statekeep_suite.go
+++ b/pkg/resourcekeeper/statekeep_suite.go
@@ -53,7 +53,7 @@ func (h *resourceKeeper) StateKeep(ctx context.Context) error {
 					if err != nil {
 						return errors.Wrapf(err, "failed to decode resource %s from resourcetracker", mr.ResourceKey())
 					}
-					if err = h.applicator.Apply(multicluster.ContextWithClusterName(ctx, mr.Cluster), manifest, apply.MustBeControlledByApp(h.app)); err != nil {
+					if err = h.applicator.Apply(multicluster.ContextWithClusterName(ctx, mr.Cluster), manifest, apply.MustBeControlledByApp(h.app), apply.NotUpdateRenderHashEqual()); err != nil {
 						return errors.Wrapf(err, "failed to re-apply resource %s from resourcetracker %s", mr.ResourceKey(), rt.Name)
 					}
 				}


### PR DESCRIPTION
### Description of your changes

Statekeep should have same apply options with Dispatch to skip update when the render-hash doesn't change.

Fixes https://github.com/oam-dev/kubevela/issues/3123

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->