### PR TITLE
Fix: support generate Terraform ComponentDefinition from local HCL file

### DIFF
--- a/references/cli/common.go
+++ b/references/cli/common.go
@@ -44,6 +44,8 @@ const (
 	FlagProvider = "provider"
 	// FlagGit command flag to specify which git repository the configuration(HCL) is stored in
 	FlagGit = "git"
+	// FlagLocal command flag to specify the local path of Terraform module or resource HCL file
+	FlagLocal = "local"
 	// FlagPath command flag to specify which path the configuration(HCL) is stored in the Git repository
 	FlagPath = "path"
 	// FlagNamespace command flag to specify which namespace to use

--- a/references/cli/def_test.go
+++ b/references/cli/def_test.go
@@ -216,6 +216,10 @@ func TestNewDefinitionInitCommand4Terraform(t *testing.T) {
 			args: []string{"vswitch", "-t", "component", "--provider", "alibaba", "--desc", "xxx", "--git", "https://github.com/kubevela-contrib/terraform-modules.git", "--path", "alibaba/vswitch"},
 		},
 		{
+			name: "normal from local",
+			args: []string{"vswitch", "-t", "component", "--provider", "tencent", "--desc", "xxx", "--local", "test-data/redis.tf"},
+		},
+		{
 			name: "print in a file",
 			args: []string{"vswitch", "-t", "component", "--provider", "alibaba", "--desc", "xxx", "--git", "https://github.com/kubevela-contrib/terraform-modules.git", "--path", "alibaba/vswitch", "--output", defFileName},
 			want: `apiVersion: core.oam.dev/v1beta1
@@ -254,6 +258,16 @@ status: {}`,
 			name:   "git is not right",
 			args:   []string{"vswitch", "-t", "component", "--provider", "alibaba", "--desc", "test", "--git", "xxx"},
 			errMsg: "invalid git url",
+		},
+		{
+			name:   "git and local could be set at the same time",
+			args:   []string{"vswitch", "-t", "component", "--provider", "alibaba", "--desc", "test", "--git", "xxx", "--local", "yyy"},
+			errMsg: "only one of --git and --local can be set",
+		},
+		{
+			name:   "local file doesn't exist",
+			args:   []string{"vswitch", "-t", "component", "--provider", "tencent", "--desc", "xxx", "--local", "test-data/redis2.tf"},
+			errMsg: "failed to read Terraform configuration from file",
 		},
 	}
 

--- a/references/cli/test-data/redis.tf
+++ b/references/cli/test-data/redis.tf
@@ -1,0 +1,58 @@
+terraform {
+  required_providers {
+    tencentcloud = {
+      source = "tencentcloudstack/tencentcloud"
+    }
+  }
+}
+
+resource "tencentcloud_redis_instance" "main" {
+  type_id           = 8
+  availability_zone = var.availability_zone
+  name              = var.instance_name
+  password          = var.user_password
+  mem_size          = var.mem_size
+  port              = var.port
+}
+
+output "DB_IP" {
+  value = tencentcloud_redis_instance.main.ip
+}
+
+output "DB_PASSWORD" {
+  value = var.user_password
+}
+
+output "DB_PORT" {
+  value = var.port
+}
+
+variable "availability_zone" {
+  description = "The available zone ID of an instance to be created."
+  type        = string
+  default = "ap-chengdu-1"
+}
+
+variable "instance_name" {
+  description = "redis instance name"
+  type        = string
+  default     = "sample"
+}
+
+variable "user_password" {
+  description = "redis instance password"
+  type        = string
+  default     = "IEfewjf2342rfwfwYYfaked"
+}
+
+variable "mem_size" {
+  description = "redis instance memory size"
+  type        = number
+  default     = 1024
+}
+
+variable "port" {
+  description = "The port used to access a redis instance."
+  type        = number
+  default     = 6379
+}


### PR DESCRIPTION
Besides generating a Terraform ComponentDefinition from a remote git repo,
support generate one from local HCL file

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->