### PR TITLE
Fix: prioritize namespace flag for `vela up`

### DIFF
--- a/references/cli/up.go
+++ b/references/cli/up.go
@@ -68,6 +68,10 @@ func NewUpCommand(c common2.Args, order string, ioStream cmdutil.IOStreams) *cob
 			if err != nil {
 				return errors.Wrap(err, "File format is illegal, only support vela appfile format or OAM Application object yaml")
 			}
+			// override namespace if namespace flag is set
+			if namespace != "" {
+				app.SetNamespace(namespace)
+			}
 			err = common.ApplyApplication(app, ioStream, kubecli)
 			if err != nil {
 				return err

--- a/references/cli/up.go
+++ b/references/cli/up.go
@@ -68,8 +68,10 @@ func NewUpCommand(c common2.Args, order string, ioStream cmdutil.IOStreams) *cob
 			if err != nil {
 				return errors.Wrap(err, "File format is illegal, only support vela appfile format or OAM Application object yaml")
 			}
-			// override namespace if namespace flag is set
-			if namespace != "" {
+
+			// Override namespace if namespace flag is set. We should check if namespace is `default` or not
+			// since GetFlagNamespaceOrEnv returns default namespace when failed to get current env.
+			if namespace != "" && namespace != types.DefaultAppNamespace {
 				app.SetNamespace(namespace)
 			}
 			err = common.ApplyApplication(app, ioStream, kubecli)

--- a/references/cli/up_test.go
+++ b/references/cli/up_test.go
@@ -17,12 +17,21 @@ limitations under the License.
 package cli
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
 	"github.com/oam-dev/kubevela/references/common"
 )
 
@@ -33,4 +42,106 @@ func TestUp(t *testing.T) {
 	msg := common.Info(app)
 	assert.Contains(t, msg, "App has been deployed")
 	assert.Contains(t, msg, fmt.Sprintf("App status: vela status %s", app.Name))
+}
+
+func TestUpOverrideNamespace(t *testing.T) {
+	cases := map[string]struct {
+		application       string
+		applicationName   string
+		namespace         string
+		expectedNamespace string
+	}{
+		"use default namespace if not set": {
+			application: `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: first-vela-app
+spec:
+  components: []
+`,
+			applicationName:   "first-vela-app",
+			namespace:         "",
+			expectedNamespace: types.DefaultAppNamespace,
+		},
+		"override namespace": {
+			application: `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: first-vela-app
+spec:
+  components: []
+`,
+			applicationName:   "first-vela-app",
+			namespace:         "overridden-namespace",
+			expectedNamespace: "overridden-namespace",
+		},
+		"use application namespace": {
+			application: `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: first-vela-app
+  namespace: vela-apps
+spec:
+  components: []
+`,
+			applicationName:   "first-vela-app",
+			namespace:         "",
+			expectedNamespace: "vela-apps",
+		},
+		"override application namespace": {
+			application: `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: first-vela-app
+  namespace: vela-apps
+spec:
+  components: []
+`,
+			applicationName:   "first-vela-app",
+			namespace:         "overridden-namespace",
+			expectedNamespace: "overridden-namespace",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			args := initArgs()
+			kc, err := args.GetClient()
+			require.NoError(t, err)
+
+			af, err := os.CreateTemp(os.TempDir(), "up-override-namespace-*.yaml")
+			require.NoError(t, err)
+			defer func() {
+				_ = af.Close()
+				_ = os.Remove(af.Name())
+			}()
+			_, err = af.WriteString(c.application)
+			require.NoError(t, err)
+
+			// Ensure namespace
+			require.NoError(t, kc.Create(context.TODO(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: c.expectedNamespace},
+			}))
+
+			var buf bytes.Buffer
+			cmd := NewUpCommand(args, "", util.IOStreams{In: os.Stdin, Out: &buf, ErrOut: &buf})
+			if c.namespace != "" {
+				require.NoError(t, cmd.Flags().Set(FlagNamespace, c.namespace))
+			}
+			require.NoError(t, cmd.Flags().Set("file", af.Name()))
+			require.NoError(t, cmd.Execute())
+
+			var app v1beta1.Application
+			require.NoError(t, kc.Get(context.TODO(), client.ObjectKey{
+				Name:      c.applicationName,
+				Namespace: c.expectedNamespace,
+			}, &app))
+			require.Equal(t, c.expectedNamespace, app.Namespace)
+			require.Equal(t, c.applicationName, app.Name)
+		})
+	}
 }


### PR DESCRIPTION
### Description of your changes

Currently, CLI applies application to `default` namespace when there is no explicit namespace in application spec, even if the namespace flag is set.

This commit fixes issue by overriding the namespace if the namespace flag is set.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
  - ~Q. How can I add a `backport` label?~

### How has this code been tested

```sh
# Permanent link for vela.yaml in master branch as of 2022-01-20T08:30:42Z
export APP_SPEC_URL=https://raw.githubusercontent.com/oam-dev/kubevela/947455adb998426d56139f128b3a9cd7100e1d35/docs/examples/vela.yaml

# This will be applied to default namespace, since there is no explicit namespace in spec
vela up -f "${APP_SPEC_URL}"

# This will be applied to default namespace even if we override namespace to `some-other-namespace`
vela up -f "${APP_SPEC_URL}" -n some-other-namespace

# New binary should apply application to `some-other-namespace`
vela up -f "${APP_SPEC_URL}" -n some-other-namespace
```

### Special notes for your reviewer

I think overriding namespace in `NewUpCommand ` is better than extending `ApplyApplication` since it might be ambiguous  when taking it as a parameter. WDYT?