### PR TITLE
Feat: extend gateway trait to set class in spec

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -67,7 +67,7 @@ spec:
         	// +usage=Specify the class of ingress to use
         	class: *"nginx" | string
 
-        	// +usage=Set ingress class to '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
+        	// +usage=Set ingress class in '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
         	classInSpec: *false | bool
         }
   status:

--- a/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -32,21 +32,30 @@ spec:
         	kind:       "Ingress"
         	metadata: {
         		name: context.name
-        		annotations: "kubernetes.io/ingress.class": parameter.class
+        		annotations: {
+        			if !parameter.classInSpec {
+        				"kubernetes.io/ingress.class": parameter.class
+        			}
+        		}
         	}
-        	spec: rules: [{
-        		host: parameter.domain
-        		http: paths: [
-        			for k, v in parameter.http {
-        				path:     k
-        				pathType: "ImplementationSpecific"
-        				backend: service: {
-        					name: context.name
-        					port: number: v
-        				}
-        			},
-        		]
-        	}]
+        	spec: {
+        		if parameter.classInSpec {
+        			ingressClassName: parameter.class
+        		}
+        		rules: [{
+        			host: parameter.domain
+        			http: paths: [
+        				for k, v in parameter.http {
+        					path:     k
+        					pathType: "ImplementationSpecific"
+        					backend: service: {
+        						name: context.name
+        						port: number: v
+        					}
+        				},
+        			]
+        		}]
+        	}
         }
         parameter: {
         	// +usage=Specify the domain you want to expose
@@ -57,6 +66,9 @@ spec:
 
         	// +usage=Specify the class of ingress to use
         	class: *"nginx" | string
+
+        	// +usage=Set ingress class to '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
+        	classInSpec: *false | bool
         }
   status:
     customStatus: |-

--- a/charts/vela-minimal/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/gateway.yaml
@@ -67,7 +67,7 @@ spec:
         	// +usage=Specify the class of ingress to use
         	class: *"nginx" | string
 
-        	// +usage=Set ingress class to '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
+        	// +usage=Set ingress class in '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
         	classInSpec: *false | bool
         }
   status:

--- a/charts/vela-minimal/templates/defwithtemplate/gateway.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/gateway.yaml
@@ -32,21 +32,30 @@ spec:
         	kind:       "Ingress"
         	metadata: {
         		name: context.name
-        		annotations: "kubernetes.io/ingress.class": parameter.class
+        		annotations: {
+        			if !parameter.classInSpec {
+        				"kubernetes.io/ingress.class": parameter.class
+        			}
+        		}
         	}
-        	spec: rules: [{
-        		host: parameter.domain
-        		http: paths: [
-        			for k, v in parameter.http {
-        				path:     k
-        				pathType: "ImplementationSpecific"
-        				backend: service: {
-        					name: context.name
-        					port: number: v
-        				}
-        			},
-        		]
-        	}]
+        	spec: {
+        		if parameter.classInSpec {
+        			ingressClassName: parameter.class
+        		}
+        		rules: [{
+        			host: parameter.domain
+        			http: paths: [
+        				for k, v in parameter.http {
+        					path:     k
+        					pathType: "ImplementationSpecific"
+        					backend: service: {
+        						name: context.name
+        						port: number: v
+        					}
+        				},
+        			]
+        		}]
+        	}
         }
         parameter: {
         	// +usage=Specify the domain you want to expose
@@ -57,6 +66,9 @@ spec:
 
         	// +usage=Specify the class of ingress to use
         	class: *"nginx" | string
+
+        	// +usage=Set ingress class to '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
+        	classInSpec: *false | bool
         }
   status:
     customStatus: |-

--- a/vela-templates/definitions/internal/trait/gateway.cue
+++ b/vela-templates/definitions/internal/trait/gateway.cue
@@ -1,4 +1,4 @@
-"gateway": {
+gateway: {
 	type: "trait"
 	annotations: {}
 	labels: {}
@@ -49,22 +49,29 @@ template: {
 		metadata: {
 			name: context.name
 			annotations: {
-				"kubernetes.io/ingress.class": parameter.class
+				if !parameter.classInSpec {
+					"kubernetes.io/ingress.class": parameter.class
+				}
 			}
 		}
-		spec: rules: [{
-			host: parameter.domain
-			http: paths: [
-				for k, v in parameter.http {
-					path:     k
-					pathType: "ImplementationSpecific"
-					backend: service: {
-						name: context.name
-						port: number: v
-					}
-				},
-			]
-		}]
+		spec: {
+			if parameter.classInSpec {
+				ingressClassName: parameter.class
+			}
+			rules: [{
+				host: parameter.domain
+				http: paths: [
+					for k, v in parameter.http {
+						path:     k
+						pathType: "ImplementationSpecific"
+						backend: service: {
+							name: context.name
+							port: number: v
+						}
+					},
+				]
+			}]
+		}
 	}
 
 	parameter: {
@@ -76,5 +83,8 @@ template: {
 
 		// +usage=Specify the class of ingress to use
 		class: *"nginx" | string
+
+		// +usage=Set ingress class to '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
+		classInSpec: *false | bool
 	}
 }

--- a/vela-templates/definitions/internal/trait/gateway.cue
+++ b/vela-templates/definitions/internal/trait/gateway.cue
@@ -84,7 +84,7 @@ template: {
 		// +usage=Specify the class of ingress to use
 		class: *"nginx" | string
 
-		// +usage=Set ingress class to '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
+		// +usage=Set ingress class in '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
 		classInSpec: *false | bool
 	}
 }


### PR DESCRIPTION
### Description of your changes

[`kubernetes.io/ingress.class` annotation is deprecated](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) in favor of `.spec.ingressClassName`. However, there is no way to set it through the gateway trait for now.

This commit extends the gateway trait by adding `classInSpec` to parameter. Forcing the use of `.spec.ingressClassName` makes sense, but some ingress controllers (including old versions) may not recognize this field. Therefore, set default value of `classInSpec` to `false` for backward compatibility.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
  - https://github.com/oam-dev/kubevela.io/pull/474
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: first-vela-app
spec:
  components:
    - name: express-server
      type: webservice
      properties:
        image: crccheck/hello-world
        port: 8000
      traits:
        - type: gateway
          properties:
            class: contour-private
            # set to `false` or remove for checking current behavior
            # or set to `true` to check ingress class is set to `.spec.ingressClassName`
            classInSpec: false
            domain: testsvc.example.com
            http:
              "/": 8000
```

### Special notes for your reviewer

None