### PR TITLE
Fix: add providerRef in generated ComponentDefinition

### DIFF
--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -32,6 +32,7 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/encoding/gocode/gocodec"
+	crossplane "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -356,6 +357,12 @@ func generateTerraformTypedComponentDefinition(cmd *cobra.Command, name, kind, p
 					Terraform: terraform,
 				},
 			},
+		}
+		if provider != "alibaba" {
+			def.Spec.Schematic.Terraform.ProviderReference = &crossplane.Reference{
+				Name:      provider,
+				Namespace: "default",
+			}
 		}
 		var out bytes.Buffer
 		err = json.NewSerializerWithOptions(json.DefaultMetaFactory, nil, nil, json.SerializerOptions{Yaml: true}).Encode(&def, &out)


### PR DESCRIPTION
If the provider is not provider, append the providerRef section in
the generated ComponentDefinition

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->