### PR TITLE
Fix: add context parameters into the error message

### DIFF
--- a/pkg/appfile/validate.go
+++ b/pkg/appfile/validate.go
@@ -35,7 +35,7 @@ func (p *Parser) ValidateCUESchematicAppfile(a *Appfile) error {
 		}
 		pCtx, err := newValidationProcessContext(wl, a.Name, a.AppRevisionName, a.Namespace)
 		if err != nil {
-			return errors.WithMessage(err, "cannot create validationg process context")
+			return errors.WithMessagef(err, "cannot create the validation process context of app=%s in namespace=%s", a.Name, a.Namespace)
 		}
 		for _, tr := range wl.Traits {
 			if tr.CapabilityCategory != types.CUECategory {


### PR DESCRIPTION
### Description of your changes

1. fix the typo
2. add context parameters into the error message

Signed-off-by: zeed-w-beez <zeed.w.zhao@gmail.com>

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.
