### PR TITLE
Fix: retrieve Terraform variables from variables.tf

### DIFF
--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -205,11 +205,14 @@ func GetTerraformConfigurationFromRemote(name, remoteURL, remotePath string) (st
 		return "", err
 	}
 
-	tfPath := filepath.Join(tmpPath, remotePath, "main.tf")
-	conf, err := ioutil.ReadFile(filepath.Clean(tfPath))
-	if err != nil {
-		return "", err
+	tfPath := filepath.Join(tmpPath, remotePath, "variables.tf")
+	if _, err := os.Stat(tfPath); err != nil {
+		tfPath = filepath.Join(tmpPath, remotePath, "main.tf")
+		if _, err := os.Stat(tfPath); err != nil {
+			return "", errors.Wrap(err, "failed to find main.tf or variables.tf in Terraform configurations of the remote repository")
+		}
 	}
+	conf, err := ioutil.ReadFile(filepath.Clean(tfPath))
 
 	if err := os.RemoveAll(tmpPath); err != nil {
 		return "", err

--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -213,7 +213,9 @@ func GetTerraformConfigurationFromRemote(name, remoteURL, remotePath string) (st
 		}
 	}
 	conf, err := ioutil.ReadFile(filepath.Clean(tfPath))
-
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read Terraform configuration")
+	}
 	if err := os.RemoveAll(tmpPath); err != nil {
 		return "", err
 	}

--- a/pkg/controller/utils/capability_test.go
+++ b/pkg/controller/utils/capability_test.go
@@ -465,7 +465,7 @@ variable "aaa" {
 
 			conf, err := GetTerraformConfigurationFromRemote(tc.args.name, tc.args.url, tc.args.path)
 			if tc.want.errMsg != "" {
-				if !strings.Contains(err.Error(), tc.want.errMsg) {
+				if err != nil && !strings.Contains(err.Error(), tc.want.errMsg) {
 					t.Errorf("\n%s\nGetTerraformConfigurationFromRemote(...): -want error %v, +got error:%s", name, err, tc.want.errMsg)
 				}
 			} else {

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -1038,7 +1038,7 @@ func (ref *ParseReference) parseTerraformCapabilityParameters(capability types.C
 		refParam.Name = v.Name
 		refParam.PrintableType = v.Type
 		refParam.Usage = v.Description
-		refParam.Required = true
+		refParam.Required = v.Required
 		refParameterList = append(refParameterList, refParam)
 	}
 	refParameterList = append(refParameterList, writeConnectionSecretToRefReferenceParameter)


### PR DESCRIPTION
If Terraform modules/resources are stored in remote git repos, get
variables from file `varialbes.tf`, or from `main.tf`.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->