### PR TITLE
Fix: can not scale application in rollout traits

### DIFF
--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -181,5 +181,5 @@ const (
 	AnnotationWorkloadName = "trait.oam.dev/workload-name"
 
 	// AnnotationRolloutBatchesAutoComplete is used to enable rollout batches auto complete
-	AnnotationRolloutBatchesAutoComplete = "rollout.trait.oam.dev/rolloutBatchesAutoComplete"
+	AnnotationRolloutBatchesAutoComplete = "rollout.trait.oam.dev/rollout-batches-auto-complete"
 )

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -179,4 +179,7 @@ const (
 
 	// AnnotationWorkloadName indicates the managed workload's name by trait
 	AnnotationWorkloadName = "trait.oam.dev/workload-name"
+
+	// AnnotationRolloutBatchesAutoComplete is used to enable rollout batches auto complete
+	AnnotationRolloutBatchesAutoComplete = "rollout.trait.oam.dev/rolloutBatchesAutoComplete"
 )


### PR DESCRIPTION

Signed-off-by: Shuai Tian <tians1@xiaopeng.com>


### Description of your changes

Fix: can not scale application in rollout traits #3150

auto-complete rolloutBatches, enable by annotation


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->