### PR TITLE
Fix: vela addnon enable cannot support '='

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -234,11 +234,11 @@ func parseToMap(args []string) (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 	for _, pair := range args {
 		line := strings.Split(pair, "=")
-		if len(line) != 2 {
+		if len(line) < 2 {
 			return nil, fmt.Errorf("parameter format should be foo=bar, %s not match", pair)
 		}
 		k := strings.TrimSpace(line[0])
-		v := strings.TrimSpace(line[1])
+		v := strings.TrimSpace(strings.Join(line[1:], "="))
 		if k != "" && v != "" {
 			res[k] = v
 		}

--- a/references/cli/addon_test.go
+++ b/references/cli/addon_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestParseMap(t *testing.T) {
+	testcase := []struct {
+		args     []string
+		res      map[string]interface{}
+		nilError bool
+	}{
+		{
+			args: []string{"key1=value1"},
+			res: map[string]interface{}{
+				"key1": "value1",
+			},
+			nilError: true,
+		},
+		{
+			args: []string{"dbUrl=mongodb=mgset-58800212"},
+			res: map[string]interface{}{
+				"dbUrl": "mongodb=mgset-58800212",
+			},
+			nilError: true,
+		},
+		{
+			args:     []string{"errorparameter"},
+			res:      nil,
+			nilError: false,
+		},
+	}
+	for _, s := range testcase {
+		r, err := parseToMap(s.args)
+		assert.DeepEqual(t, s.res, r)
+		if s.nilError {
+			assert.NilError(t, err)
+		} else {
+			assert.Error(t, err, "parameter format should be foo=bar, errorparameter not match")
+		}
+	}
+}


### PR DESCRIPTION
fix vela addnon enable cannot support '='

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->