### PR TITLE
Fix: Use systemDefinitionNamespace core Helm Chart

### DIFF
--- a/charts/vela-core/templates/addon_registry.yaml
+++ b/charts/vela-core/templates/addon_registry.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vela-addon-registry
-  namespace: vela-system
+  namespace: {{.Values.systemDefinitionNamespace}}
 data:
   registries: '{
   "KubeVela":{

--- a/charts/vela-core/templates/test/test-application.yaml
+++ b/charts/vela-core/templates/test/test-application.yaml
@@ -5,6 +5,7 @@ metadata:
     helm.sh/hook: test-success
     helm.sh/hook-delete-policy: hook-succeeded
   name: helm-test-vela-app
+  namespace: {{.Values.systemDefinitionNamespace}}
 spec:
   components:
     - name: helm-test-express-server
@@ -23,6 +24,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-application-test"
+  namespace: {{.Values.systemDefinitionNamespace}}
   annotations:
     "helm.sh/hook": test
     helm.sh/hook-delete-policy: hook-succeeded
@@ -42,16 +44,16 @@ spec:
           echo "Waiting application is ready..."
 
           echo "waiting for application being Ready"
-          kubectl -n vela-system wait --for=condition=Ready applications.core.oam.dev helm-test-vela-app --timeout=3m
+          kubectl -n {{.Values.systemDefinitionNamespace}} wait --for=condition=Ready applications.core.oam.dev helm-test-vela-app --timeout=3m
           echo "application is Ready"
 
           # wait for deploy being created
           echo "waiting for deployment being available"
-          kubectl -n vela-system wait --for=condition=available deployments helm-test-express-server --timeout 3m
+          kubectl -n {{.Values.systemDefinitionNamespace}} wait --for=condition=available deployments helm-test-express-server --timeout 3m
           echo "deployment being available"
 
           # wait for ingress being created
-          while ! [ `kubectl -n vela-system get ing helm-test-express-server | grep -v NAME | wc -l` = 1 ]; do
+          while ! [ `kubectl -n {{.Values.systemDefinitionNamespace}} get ing helm-test-express-server | grep -v NAME | wc -l` = 1 ]; do
             echo "waiting for ingress being created"
             sleep 1
           done


### PR DESCRIPTION
Use value in Addon Registry CM and the Test Application


### Description of your changes

Some vela-core helm chart templates did not use the value `systemDefinitionNamespace`. This leads to issues when using a different namespace than vela-system. I search all charts for those hardcoded references and make them configurable via the value.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I didn't create an Issue for this yet. Should I? Seems like a really minor change.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Did `helm template vela-test . --set=systemDefinitionNamespace=sys-kubevela | grep vela-system` see that no vela-system namespace is used anymore and a `helm lint`

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->