### PR TITLE
Fix: apply application failed

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -715,7 +715,7 @@ func (h *AppHandler) UpdateAppLatestRevisionStatus(ctx context.Context) error {
 		Revision:     int64(revNum),
 		RevisionHash: h.currentRevHash,
 	}
-	if err := h.r.patchStatus(ctx, h.app, common.ApplicationRendering); err != nil {
+	if err := h.r.patchStatus(ctx, nil, h.app, common.ApplicationRendering); err != nil {
 		klog.InfoS("Failed to update the latest appConfig revision to status", "application", klog.KObj(h.app),
 			"latest revision", revName, "err", err)
 		return err


### PR DESCRIPTION
Signed-off-by: Xiaoxi He <xxhe@alauda.io>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The application controller reconciler use `Merge` patch to update the status of application, and it will fail with conflict error if the application was updated during the reconcile loop.

The scenario is the `status.latestResourceTracker` may not be updated, and will cause the application always applied failed with error `cannot apply ApplyOption: existing object is not controlled by any of UID [\"a60fa607-c0eb-4f29-afa7-31ae37efd07e\"]`.

Use `MergeFrom` to replace the `Merge` to create the modified patch data, it will avoid the conflict error.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The existed test case could cover the changes.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->