### PR TITLE
Fix: add unit test for getting Terraform Configuration from remote git

### DIFF
--- a/pkg/controller/utils/capability_test.go
+++ b/pkg/controller/utils/capability_test.go
@@ -426,6 +426,34 @@ variable "aaa" {
 }`,
 			},
 		},
+		"configuration is remote with path": {
+			args: args{
+				name: "aws-subnet",
+				url:  "https://github.com/kubevela-contrib/terraform-modules.git",
+				path: "aws/subnet",
+				data: []byte(`
+variable "aaa" {
+	type = list(object({
+		type = string
+		sourceArn = string
+		config = string
+	}))
+	default = []
+}`),
+				variableFile: "variables.tf",
+			},
+			want: want{
+				config: `
+variable "aaa" {
+	type = list(object({
+		type = string
+		sourceArn = string
+		config = string
+	}))
+	default = []
+}`,
+			},
+		},
 		"working path exists": {
 			args: args{
 				variableFile:    "main.tf",
@@ -454,7 +482,12 @@ variable "aaa" {
 			}
 
 			patch := ApplyFunc(git.PlainCloneContext, func(ctx context.Context, path string, isBare bool, o *git.CloneOptions) (*git.Repository, error) {
-				tmpPath := filepath.Join("./tmp/terraform", tc.args.name)
+				var tmpPath string
+				if tc.args.path != "" {
+					tmpPath = filepath.Join("./tmp/terraform", tc.args.name, tc.args.path)
+				} else {
+					tmpPath = filepath.Join("./tmp/terraform", tc.args.name)
+				}
 				err := os.MkdirAll(tmpPath, os.ModePerm)
 				assert.NilError(t, err)
 				err = ioutil.WriteFile(filepath.Clean(filepath.Join(tmpPath, tc.args.variableFile)), tc.args.data, 0644)


### PR DESCRIPTION
Add another unit test when the configuration of Terraform locates
in a subpath of a git remote repository

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->