### PR TITLE
Fix: can not collector pod list with rollout trait

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-core/templates/defwithtemplate/rollout.yaml
@@ -5,8 +5,6 @@ kind: TraitDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Rollout the component.
-  labels:
-    custom.definition.oam.dev/ui-hidden: "true"
   name: rollout
   namespace: {{.Values.systemDefinitionNamespace}}
 spec:
@@ -22,8 +20,8 @@ spec:
         		namespace: context.namespace
         	}
         	spec: {
-        		targetRevisionName: parameter.targetRevision
-        		componentName:      context.name
+        		targetRevisionName?: parameter.targetRevision
+        		componentName:       context.name
         		rolloutPlan: {
         			rolloutStrategy: "IncreaseFirst"
         			if parameter.rolloutBatches != _|_ {

--- a/charts/vela-core/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-core/templates/defwithtemplate/rollout.yaml
@@ -20,8 +20,13 @@ spec:
         		namespace: context.namespace
         	}
         	spec: {
-        		targetRevisionName: parameter.targetRevision
-        		componentName:      context.name
+        		if parameter.targetRevision != _|_ {
+        			targetRevisionName: parameter.targetRevision
+        		}
+        		if parameter.targetRevision == _|_ {
+        			targetRevisionName: context.revision
+        		}
+        		componentName: context.name
         		rolloutPlan: {
         			rolloutStrategy: "IncreaseFirst"
         			if parameter.rolloutBatches != _|_ {
@@ -35,7 +40,7 @@ spec:
         	}
         }
         parameter: {
-        	targetRevision?: *context.revision | string
+        	targetRevision?: string
         	targetSize:      int
         	rolloutBatches?: [...rolloutBatch]
         	batchPartition?: int

--- a/charts/vela-core/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-core/templates/defwithtemplate/rollout.yaml
@@ -20,8 +20,8 @@ spec:
         		namespace: context.namespace
         	}
         	spec: {
-        		targetRevisionName?: parameter.targetRevision
-        		componentName:       context.name
+        		targetRevisionName: parameter.targetRevision
+        		componentName:      context.name
         		rolloutPlan: {
         			rolloutStrategy: "IncreaseFirst"
         			if parameter.rolloutBatches != _|_ {
@@ -35,8 +35,8 @@ spec:
         	}
         }
         parameter: {
-        	targetRevision: *context.revision | string
-        	targetSize:     int
+        	targetRevision?: *context.revision | string
+        	targetSize:      int
         	rolloutBatches?: [...rolloutBatch]
         	batchPartition?: int
         }

--- a/charts/vela-minimal/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/rollout.yaml
@@ -5,8 +5,6 @@ kind: TraitDefinition
 metadata:
   annotations:
     definition.oam.dev/description: Rollout the component.
-  labels:
-    custom.definition.oam.dev/ui-hidden: "true"
   name: rollout
   namespace: {{.Values.systemDefinitionNamespace}}
 spec:
@@ -22,8 +20,8 @@ spec:
         		namespace: context.namespace
         	}
         	spec: {
-        		targetRevisionName: parameter.targetRevision
-        		componentName:      context.name
+        		targetRevisionName?: parameter.targetRevision
+        		componentName:       context.name
         		rolloutPlan: {
         			rolloutStrategy: "IncreaseFirst"
         			if parameter.rolloutBatches != _|_ {

--- a/charts/vela-minimal/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/rollout.yaml
@@ -20,8 +20,13 @@ spec:
         		namespace: context.namespace
         	}
         	spec: {
-        		targetRevisionName: parameter.targetRevision
-        		componentName:      context.name
+        		if parameter.targetRevision != _|_ {
+        			targetRevisionName: parameter.targetRevision
+        		}
+        		if parameter.targetRevision == _|_ {
+        			targetRevisionName: context.revision
+        		}
+        		componentName: context.name
         		rolloutPlan: {
         			rolloutStrategy: "IncreaseFirst"
         			if parameter.rolloutBatches != _|_ {
@@ -35,7 +40,7 @@ spec:
         	}
         }
         parameter: {
-        	targetRevision?: *context.revision | string
+        	targetRevision?: string
         	targetSize:      int
         	rolloutBatches?: [...rolloutBatch]
         	batchPartition?: int

--- a/charts/vela-minimal/templates/defwithtemplate/rollout.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/rollout.yaml
@@ -20,8 +20,8 @@ spec:
         		namespace: context.namespace
         	}
         	spec: {
-        		targetRevisionName?: parameter.targetRevision
-        		componentName:       context.name
+        		targetRevisionName: parameter.targetRevision
+        		componentName:      context.name
         		rolloutPlan: {
         			rolloutStrategy: "IncreaseFirst"
         			if parameter.rolloutBatches != _|_ {
@@ -35,8 +35,8 @@ spec:
         	}
         }
         parameter: {
-        	targetRevision: *context.revision | string
-        	targetSize:     int
+        	targetRevision?: *context.revision | string
+        	targetSize:      int
         	rolloutBatches?: [...rolloutBatch]
         	batchPartition?: int
         }

--- a/vela-templates/definitions/internal/trait/rollout.cue
+++ b/vela-templates/definitions/internal/trait/rollout.cue
@@ -1,9 +1,6 @@
 rollout: {
 	type: "trait"
 	annotations: {}
-	labels: {
-		"ui-hidden": "true"
-	}
 	description: "Rollout the component."
 	attributes: {
 		manageWorkload: true
@@ -26,7 +23,7 @@ template: {
 			namespace: context.namespace
 		}
 		spec: {
-			targetRevisionName: parameter.targetRevision
+			targetRevisionName?: parameter.targetRevision
 			componentName:      context.name
 			rolloutPlan: {
 				rolloutStrategy: "IncreaseFirst"

--- a/vela-templates/definitions/internal/trait/rollout.cue
+++ b/vela-templates/definitions/internal/trait/rollout.cue
@@ -23,8 +23,13 @@ template: {
 			namespace: context.namespace
 		}
 		spec: {
-			targetRevisionName: parameter.targetRevision
-			componentName:      context.name
+			if parameter.targetRevision != _|_ {
+				targetRevisionName: parameter.targetRevision
+			}
+			if parameter.targetRevision == _|_ {
+				targetRevisionName: context.revision
+			}
+			componentName: context.name
 			rolloutPlan: {
 				rolloutStrategy: "IncreaseFirst"
 				if parameter.rolloutBatches != _|_ {
@@ -39,7 +44,7 @@ template: {
 	}
 
 	parameter: {
-		targetRevision?: *context.revision | string
+		targetRevision?: string
 		targetSize:      int
 		rolloutBatches?: [...rolloutBatch]
 		batchPartition?: int

--- a/vela-templates/definitions/internal/trait/rollout.cue
+++ b/vela-templates/definitions/internal/trait/rollout.cue
@@ -23,7 +23,7 @@ template: {
 			namespace: context.namespace
 		}
 		spec: {
-			targetRevisionName?: parameter.targetRevision
+			targetRevisionName: parameter.targetRevision
 			componentName:      context.name
 			rolloutPlan: {
 				rolloutStrategy: "IncreaseFirst"
@@ -39,8 +39,8 @@ template: {
 	}
 
 	parameter: {
-		targetRevision: *context.revision | string
-		targetSize:     int
+		targetRevision?: *context.revision | string
+		targetSize:      int
 		rolloutBatches?: [...rolloutBatch]
 		batchPartition?: int
 	}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

For component with rollout triat, the workload is Rollout. We will collector pod by label `app.oam.dev/component`.

It exists as a norm.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->