### PR TITLE
Fix: the definition namespace is empty

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -559,6 +559,9 @@ func RenderApp(ctx context.Context, addon *InstallPackage, config *rest.Config, 
 			if err != nil {
 				return nil, errors.Wrapf(err, "fail to render definition: %s in cue's format", cueDef.Name)
 			}
+			if def.Unstructured.GetNamespace() == "" {
+				def.Unstructured.SetNamespace(types.DefaultKubeVelaNS)
+			}
 			app.Spec.Components = append(app.Spec.Components, common2.ApplicationComponent{
 				Name:       cueDef.Name,
 				Type:       "raw",
@@ -604,6 +607,9 @@ func RenderDefinitions(addon *InstallPackage, config *rest.Config) ([]*unstructu
 			err := def.FromCUEString(cueDef.Data, config)
 			if err != nil {
 				return nil, errors.Wrapf(err, "fail to render definition: %s in cue's format", cueDef.Name)
+			}
+			if def.GetNamespace() == "" {
+				def.SetNamespace(types.DefaultKubeVelaNS)
 			}
 			defObjs = append(defObjs, &def.Unstructured)
 		}

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -134,7 +134,11 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 			}
 			addonOrDir := args[0]
 			var name = addonOrDir
-			if _, err := os.Stat(addonOrDir); err == nil {
+			if file, err := os.Stat(addonOrDir); err == nil {
+				if !file.IsDir() {
+					return fmt.Errorf("%s is not addon dir", addonOrDir)
+				}
+				ioStream.Infof("enable addon by local dir: %s", addonOrDir)
 				// args[0] is a local path install with local dir, use base dir name as addonName
 				name = filepath.Base(addonOrDir)
 				err = enableAddonByLocal(ctx, name, addonOrDir, k8sClient, config, addonArgs)
@@ -200,7 +204,11 @@ func NewAddonUpgradeCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Co
 			}
 			addonOrDir := args[0]
 			var name string
-			if _, err := os.Stat(addonOrDir); err == nil {
+			if file, err := os.Stat(addonOrDir); err == nil {
+				if !file.IsDir() {
+					return fmt.Errorf("%s is not addon dir", addonOrDir)
+				}
+				ioStream.Infof("enable addon by local dir: %s", addonOrDir)
 				// args[0] is a local path install with local dir
 				name := filepath.Base(addonOrDir)
 				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, name)


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

A definition defined by CUE cannot be created because the namespace is empty.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.