### PR TITLE
Fix: registry don't have enough info to build a reader

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -951,6 +951,26 @@ func (h *Installer) installDependency(addon *InstallPackage) error {
 	return nil
 }
 
+// checkDependency checks if addon's dependency
+func (h *Installer) checkDependency(addon *InstallPackage) ([]string, error) {
+	var app v1beta1.Application
+	var needEnable []string
+	for _, dep := range addon.Dependencies {
+		err := h.cli.Get(h.ctx, client.ObjectKey{
+			Namespace: types.DefaultKubeVelaNS,
+			Name:      Convert2AppName(dep.Name),
+		}, &app)
+		if err == nil {
+			continue
+		}
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		needEnable = append(needEnable, dep.Name)
+	}
+	return needEnable, nil
+}
+
 func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 	app, err := RenderApp(h.ctx, addon, h.config, h.cli, h.args)
 	if err != nil {

--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -92,6 +92,14 @@ func EnableAddonByLocalDir(ctx context.Context, name string, dir string, cli cli
 		return err
 	}
 	h := NewAddonInstaller(ctx, cli, applicator, config, &Registry{Name: LocalAddonRegistryName}, args, nil)
+	needEnableAddonNames, err := h.checkDependency(pkg)
+	if err != nil {
+		return err
+	}
+	if len(needEnableAddonNames) > 0 {
+		return fmt.Errorf("you must first enable dependencies: %v", needEnableAddonNames)
+	}
+
 	err = h.enableAddon(pkg)
 	if err != nil {
 		return err

--- a/pkg/addon/source.go
+++ b/pkg/addon/source.go
@@ -169,7 +169,6 @@ func (r *Registry) BuildReader() (AsyncReader, error) {
 		return NewAsyncReader(g.URL, "", g.Path, g.Token, gitType)
 	}
 	return nil, errors.New("registry don't have enough info to build a reader")
-
 }
 
 // GetUIData get UIData of an addon

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -138,7 +138,7 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 				if !file.IsDir() {
 					return fmt.Errorf("%s is not addon dir", addonOrDir)
 				}
-				ioStream.Infof("enable addon by local dir: %s", addonOrDir)
+				ioStream.Infof("enable addon by local dir: %s \n", addonOrDir)
 				// args[0] is a local path install with local dir, use base dir name as addonName
 				name = filepath.Base(addonOrDir)
 				err = enableAddonByLocal(ctx, name, addonOrDir, k8sClient, config, addonArgs)
@@ -208,7 +208,7 @@ func NewAddonUpgradeCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Co
 				if !file.IsDir() {
 					return fmt.Errorf("%s is not addon dir", addonOrDir)
 				}
-				ioStream.Infof("enable addon by local dir: %s", addonOrDir)
+				ioStream.Infof("enable addon by local dir: %s \n", addonOrDir)
 				// args[0] is a local path install with local dir
 				name := filepath.Base(addonOrDir)
 				_, err = pkgaddon.FetchAddonRelatedApp(context.Background(), k8sClient, name)


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

If the addon has dependencies, enable is from local dir can not be successful and users are confused.

before:
```
vela addon enable ./experimental/addons/rollout

enable addon by local dir: ./experimental/addons/rolloutError: fail to get addon meta: registry don't have enough info to build a reader
```

after
```
vela addon enable ./experimental/addons/rollout

enable addon by local dir: ./experimental/addons/rollout 
Error: you must first enable dependencies: [fluxcd]
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.