### PR TITLE
Fix: add cli support for provider gcp and baidu

### DIFF
--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -295,7 +295,7 @@ func generateTerraformTypedComponentDefinition(cmd *cobra.Command, name, kind, p
 	}
 
 	switch provider {
-	case "aws", "azure", "alibaba", "tencent":
+	case "aws", "azure", "alibaba", "tencent", "gcp", "baidu":
 		var terraform *commontype.Terraform
 
 		git, err := cmd.Flags().GetString(FlagGit)


### PR DESCRIPTION
### Description of your changes

Add cli support for provider baidu and gcp.

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

### Special notes for your reviewer