### PR TITLE
Fix: fix panic when user disable create apprevision

### DIFF
--- a/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/revision.go
@@ -370,7 +370,7 @@ func ComputeAppRevisionHash(appRevision *v1beta1.ApplicationRevision) (string, e
 // currentAppRevIsNew check application revision already exist or not
 func (h *AppHandler) currentAppRevIsNew(ctx context.Context) (bool, bool, error) {
 	// the last revision doesn't exist.
-	if h.app.Status.LatestRevision == nil {
+	if h.app.Status.LatestRevision == nil || DisableAllApplicationRevision {
 		return true, true, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: yangsoon <songyang.song@alibaba-inc.com>


### Description of your changes

Fix the bugs: when user open performance optimization options(DisableAllApplicationRevision), it will lead to panic

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->