### PR TITLE
Fix: properties table of cloud resource doc is broken

### DIFF
--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -1047,8 +1047,8 @@ func (ref *ParseReference) parseTerraformCapabilityParameters(capability types.C
 	for _, v := range variables {
 		var refParam ReferenceParameter
 		refParam.Name = v.Name
-		refParam.PrintableType = v.Type
-		refParam.Usage = v.Description
+		refParam.PrintableType = strings.ReplaceAll(v.Type, "\n", `\n`)
+		refParam.Usage = strings.ReplaceAll(v.Description, "\n", `\n`)
 		refParam.Required = v.Required
 		refParameterList = append(refParameterList, refParam)
 	}


### PR DESCRIPTION
If one column of a table contianers multiple line of a json
struct, it will break the table.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->