### PR TITLE
Fix: fixed required items for a Terraform ComponentDefinition

### DIFF
--- a/pkg/controller/utils/capability.go
+++ b/pkg/controller/utils/capability.go
@@ -194,7 +194,9 @@ func GetOpenAPISchemaFromTerraformComponentDefinition(configuration string) ([]b
 			}
 		}
 		schema.Title = k
-		required = append(required, k)
+		if v.Required {
+			required = append(required, k)
+		}
 		if v.Default != nil {
 			schema.Default = v.Default
 		}

--- a/pkg/controller/utils/capability_test.go
+++ b/pkg/controller/utils/capability_test.go
@@ -317,7 +317,7 @@ variable "mapVar" {
   type = "map"
 }`,
 			want: want{
-				subStr: "account_name",
+				subStr: `"required":["intVar","boolVar","listVar","mapVar"]`,
 				err:    nil,
 			},
 		},


### PR DESCRIPTION
If a Terraform variable is required, the item in OpenAPI schema
is required.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->