### PR TITLE
Feat: add seldon virtual service support in endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.6.1
+	istio.io/api v0.0.0-20210128181506-0c4b8e54850f
 	istio.io/client-go v0.0.0-20210128182905-ee2edd059e02
 	k8s.io/api v0.22.1
 	k8s.io/apiextensions-apiserver v0.22.1
@@ -261,7 +262,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	istio.io/api v0.0.0-20210128181506-0c4b8e54850f // indirect
 	istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a // indirect
 	k8s.io/apiserver v0.22.1 // indirect
 	k8s.io/component-base v0.22.1 // indirect

--- a/pkg/velaql/providers/query/handler.go
+++ b/pkg/velaql/providers/query/handler.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	istio "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkv1beta1 "k8s.io/api/networking/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -255,6 +256,55 @@ func (h *provider) GeneratorServiceEndpoints(wfctx wfContext.Context, v *value.V
 			for _, ing := range ingress {
 				serviceEndpoints = append(serviceEndpoints, generatorFromIngress(ing, cluster)...)
 			}
+		case "SeldonDeployment":
+			var vs istio.VirtualService
+			if err := findResource(&vs, resource.Name, resource.Namespace, resource.Cluster); err != nil {
+				klog.Error(err, fmt.Sprintf("find v1alpha3 VirtualService %s/%s from cluster %s failure", resource.Name, resource.Namespace, resource.Cluster))
+				continue
+			}
+			if vs.Spec.Http == nil || vs.Spec.Http[0].Match == nil {
+				klog.Error(fmt.Sprintf("find VirtualService %s/%s from cluster %s empty prefix", resource.Name, resource.Namespace, resource.Cluster))
+				continue
+			}
+			// get istio service from label here since the seldon's gateway is predefined
+			var istioService corev1.ServiceList
+			labels := &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"istio": "ingressgateway",
+				},
+			}
+			selector, err := v1.LabelSelectorAsSelector(labels)
+			if err != nil {
+				return err
+			}
+			if err := h.cli.List(ctx, &istioService, &client.ListOptions{
+				LabelSelector: selector,
+			}); err != nil || len(istioService.Items) == 0 {
+				klog.Error(err, fmt.Sprintf("find istio service from cluster %s failure", resource.Cluster))
+				continue
+			}
+			service := istioService.Items[0]
+			if service.Status.LoadBalancer.Ingress == nil {
+				klog.Error(fmt.Sprintf("find istio service from cluster %s empty ingress", resource.Cluster))
+				continue
+			}
+			serviceEndpoints = append(serviceEndpoints, querytypes.ServiceEndpoint{
+				Endpoint: querytypes.Endpoint{
+					Host:     service.Status.LoadBalancer.Ingress[0].IP,
+					Port:     80,
+					Path:     vs.Spec.Http[0].Match[0].Uri.GetPrefix(),
+					Protocol: corev1.ProtocolTCP,
+				},
+				Ref: corev1.ObjectReference{
+					Kind:            "VirtualService",
+					Namespace:       vs.ObjectMeta.Namespace,
+					Name:            vs.ObjectMeta.Name,
+					UID:             vs.UID,
+					APIVersion:      vs.APIVersion,
+					ResourceVersion: vs.ResourceVersion,
+				},
+				Cluster: cluster,
+			})
 		}
 	}
 	return v.FillObject(serviceEndpoints, "list")

--- a/pkg/velaql/providers/query/suite_test.go
+++ b/pkg/velaql/providers/query/suite_test.go
@@ -44,7 +44,7 @@ var _ = BeforeSuite(func(done Done) {
 		ControlPlaneStartTimeout: time.Minute * 3,
 		ControlPlaneStopTimeout:  time.Minute,
 		UseExistingCluster:       pointer.BoolPtr(false),
-		CRDDirectoryPaths:        []string{"../../../../charts/vela-core/crds"},
+		CRDDirectoryPaths:        []string{"../../../../charts/vela-core/crds", "./testdata/virtual_service.yaml"},
 	}
 
 	By("start kube test env")

--- a/pkg/velaql/providers/query/testdata/virtual_service.yaml
+++ b/pkg/velaql/providers/query/testdata/virtual_service.yaml
@@ -1,0 +1,1654 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
+  name: virtualservices.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: VirtualService
+    listKind: VirtualServiceList
+    plural: virtualservices
+    shortNames:
+    - vs
+    singular: virtualservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The names of gateways and sidecars that should apply these routes
+      jsonPath: .spec.gateways
+      name: Gateways
+      type: string
+    - description: The destination hosts to which traffic is being sent
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting label/content routing, sni routing,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this virtual service is
+                  exported.
+                items:
+                  type: string
+                type: array
+              gateways:
+                description: The names of gateways and sidecars that should apply
+                  these routes.
+                items:
+                  type: string
+                type: array
+              hosts:
+                description: The destination hosts to which traffic is being sent.
+                items:
+                  type: string
+                type: array
+              http:
+                description: An ordered list of route rules for HTTP traffic.
+                items:
+                  properties:
+                    corsPolicy:
+                      description: Cross-Origin Resource Sharing policy (CORS).
+                      properties:
+                        allowCredentials:
+                          nullable: true
+                          type: boolean
+                        allowHeaders:
+                          items:
+                            type: string
+                          type: array
+                        allowMethods:
+                          description: List of HTTP methods allowed to access the
+                            resource.
+                          items:
+                            type: string
+                          type: array
+                        allowOrigin:
+                          description: The list of origins that are allowed to perform
+                            CORS requests.
+                          items:
+                            type: string
+                          type: array
+                        allowOrigins:
+                          description: String patterns that match allowed origins.
+                          items:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          type: array
+                        exposeHeaders:
+                          items:
+                            type: string
+                          type: array
+                        maxAge:
+                          type: string
+                      type: object
+                    delegate:
+                      properties:
+                        name:
+                          description: Name specifies the name of the delegate VirtualService.
+                          type: string
+                        namespace:
+                          description: Namespace specifies the namespace where the
+                            delegate VirtualService resides.
+                          type: string
+                      type: object
+                    fault:
+                      description: Fault injection policy to apply on HTTP traffic
+                        at the client side.
+                      properties:
+                        abort:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpStatus
+                              - required:
+                                - grpcStatus
+                              - required:
+                                - http2Error
+                          - required:
+                            - httpStatus
+                          - required:
+                            - grpcStatus
+                          - required:
+                            - http2Error
+                          properties:
+                            grpcStatus:
+                              type: string
+                            http2Error:
+                              type: string
+                            httpStatus:
+                              description: HTTP status code to use to abort the Http
+                                request.
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests to be aborted with
+                                the error code provided.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        delay:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - fixedDelay
+                              - required:
+                                - exponentialDelay
+                          - required:
+                            - fixedDelay
+                          - required:
+                            - exponentialDelay
+                          properties:
+                            exponentialDelay:
+                              type: string
+                            fixedDelay:
+                              description: Add a fixed delay before forwarding the
+                                request.
+                              type: string
+                            percent:
+                              description: Percentage of requests on which the delay
+                                will be injected (0-100).
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests on which the delay
+                                will be injected.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                      type: object
+                    headers:
+                      properties:
+                        request:
+                          properties:
+                            add:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        response:
+                          properties:
+                            add:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    match:
+                      items:
+                        properties:
+                          authority:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            type: object
+                          ignoreUriCase:
+                            description: Flag to specify whether the URI matching
+                              should be case-insensitive.
+                            type: boolean
+                          method:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being
+                              addressed.
+                            type: integer
+                          queryParams:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            type: string
+                          uri:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          withoutHeaders:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            description: withoutHeader has the same syntax with the
+                              header, but has opposite meaning.
+                            type: object
+                        type: object
+                      type: array
+                    mirror:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          type: string
+                      type: object
+                    mirror_percent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercentage:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      properties:
+                        value:
+                          format: double
+                          type: number
+                      type: object
+                    name:
+                      description: The name assigned to the route for debugging purposes.
+                      type: string
+                    redirect:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      oneOf:
+                      - not:
+                          anyOf:
+                          - required:
+                            - port
+                          - required:
+                            - derivePort
+                      - required:
+                        - port
+                      - required:
+                        - derivePort
+                      properties:
+                        authority:
+                          type: string
+                        derivePort:
+                          enum:
+                          - FROM_PROTOCOL_DEFAULT
+                          - FROM_REQUEST_PORT
+                          type: string
+                        port:
+                          description: On a redirect, overwrite the port portion of
+                            the URL with this value.
+                          type: integer
+                        redirectCode:
+                          type: integer
+                        scheme:
+                          description: On a redirect, overwrite the scheme portion
+                            of the URL with this value.
+                          type: string
+                        uri:
+                          type: string
+                      type: object
+                    retries:
+                      description: Retry policy for HTTP requests.
+                      properties:
+                        attempts:
+                          description: Number of retries to be allowed for a given
+                            request.
+                          format: int32
+                          type: integer
+                        perTryTimeout:
+                          description: Timeout per attempt for a given request, including
+                            the initial call and any retries.
+                          type: string
+                        retryOn:
+                          description: Specifies the conditions under which retry
+                            takes place.
+                          type: string
+                        retryRemoteLocalities:
+                          description: Flag to specify whether the retries should
+                            retry to other localities.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    rewrite:
+                      description: Rewrite HTTP URIs and Authority headers.
+                      properties:
+                        authority:
+                          description: rewrite the Authority/Host header with this
+                            value.
+                          type: string
+                        uri:
+                          type: string
+                      type: object
+                    route:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            type: object
+                          headers:
+                            properties:
+                              request:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              response:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                    timeout:
+                      description: Timeout for HTTP requests, default is disabled.
+                      type: string
+                  type: object
+                type: array
+              tcp:
+                description: An ordered list of route rules for opaque TCP traffic.
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sourceLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            type: string
+                          sourceSubnet:
+                            description: IPv4 or IPv6 ip address of source with optional
+                              subnet.
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            type: object
+                          weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sniHosts:
+                            description: SNI (server name indicator) to match on.
+                            items:
+                              type: string
+                            type: array
+                          sourceLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            type: object
+                          weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The names of gateways and sidecars that should apply these routes
+      jsonPath: .spec.gateways
+      name: Gateways
+      type: string
+    - description: The destination hosts to which traffic is being sent
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting label/content routing, sni routing,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this virtual service is
+                  exported.
+                items:
+                  type: string
+                type: array
+              gateways:
+                description: The names of gateways and sidecars that should apply
+                  these routes.
+                items:
+                  type: string
+                type: array
+              hosts:
+                description: The destination hosts to which traffic is being sent.
+                items:
+                  type: string
+                type: array
+              http:
+                description: An ordered list of route rules for HTTP traffic.
+                items:
+                  properties:
+                    corsPolicy:
+                      description: Cross-Origin Resource Sharing policy (CORS).
+                      properties:
+                        allowCredentials:
+                          nullable: true
+                          type: boolean
+                        allowHeaders:
+                          items:
+                            type: string
+                          type: array
+                        allowMethods:
+                          description: List of HTTP methods allowed to access the
+                            resource.
+                          items:
+                            type: string
+                          type: array
+                        allowOrigin:
+                          description: The list of origins that are allowed to perform
+                            CORS requests.
+                          items:
+                            type: string
+                          type: array
+                        allowOrigins:
+                          description: String patterns that match allowed origins.
+                          items:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          type: array
+                        exposeHeaders:
+                          items:
+                            type: string
+                          type: array
+                        maxAge:
+                          type: string
+                      type: object
+                    delegate:
+                      properties:
+                        name:
+                          description: Name specifies the name of the delegate VirtualService.
+                          type: string
+                        namespace:
+                          description: Namespace specifies the namespace where the
+                            delegate VirtualService resides.
+                          type: string
+                      type: object
+                    fault:
+                      description: Fault injection policy to apply on HTTP traffic
+                        at the client side.
+                      properties:
+                        abort:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpStatus
+                              - required:
+                                - grpcStatus
+                              - required:
+                                - http2Error
+                          - required:
+                            - httpStatus
+                          - required:
+                            - grpcStatus
+                          - required:
+                            - http2Error
+                          properties:
+                            grpcStatus:
+                              type: string
+                            http2Error:
+                              type: string
+                            httpStatus:
+                              description: HTTP status code to use to abort the Http
+                                request.
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests to be aborted with
+                                the error code provided.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        delay:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - fixedDelay
+                              - required:
+                                - exponentialDelay
+                          - required:
+                            - fixedDelay
+                          - required:
+                            - exponentialDelay
+                          properties:
+                            exponentialDelay:
+                              type: string
+                            fixedDelay:
+                              description: Add a fixed delay before forwarding the
+                                request.
+                              type: string
+                            percent:
+                              description: Percentage of requests on which the delay
+                                will be injected (0-100).
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests on which the delay
+                                will be injected.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                      type: object
+                    headers:
+                      properties:
+                        request:
+                          properties:
+                            add:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        response:
+                          properties:
+                            add:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    match:
+                      items:
+                        properties:
+                          authority:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            type: object
+                          ignoreUriCase:
+                            description: Flag to specify whether the URI matching
+                              should be case-insensitive.
+                            type: boolean
+                          method:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being
+                              addressed.
+                            type: integer
+                          queryParams:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            type: string
+                          uri:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                            type: object
+                          withoutHeaders:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  type: string
+                              type: object
+                            description: withoutHeader has the same syntax with the
+                              header, but has opposite meaning.
+                            type: object
+                        type: object
+                      type: array
+                    mirror:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          type: string
+                      type: object
+                    mirror_percent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercentage:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      properties:
+                        value:
+                          format: double
+                          type: number
+                      type: object
+                    name:
+                      description: The name assigned to the route for debugging purposes.
+                      type: string
+                    redirect:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      oneOf:
+                      - not:
+                          anyOf:
+                          - required:
+                            - port
+                          - required:
+                            - derivePort
+                      - required:
+                        - port
+                      - required:
+                        - derivePort
+                      properties:
+                        authority:
+                          type: string
+                        derivePort:
+                          enum:
+                          - FROM_PROTOCOL_DEFAULT
+                          - FROM_REQUEST_PORT
+                          type: string
+                        port:
+                          description: On a redirect, overwrite the port portion of
+                            the URL with this value.
+                          type: integer
+                        redirectCode:
+                          type: integer
+                        scheme:
+                          description: On a redirect, overwrite the scheme portion
+                            of the URL with this value.
+                          type: string
+                        uri:
+                          type: string
+                      type: object
+                    retries:
+                      description: Retry policy for HTTP requests.
+                      properties:
+                        attempts:
+                          description: Number of retries to be allowed for a given
+                            request.
+                          format: int32
+                          type: integer
+                        perTryTimeout:
+                          description: Timeout per attempt for a given request, including
+                            the initial call and any retries.
+                          type: string
+                        retryOn:
+                          description: Specifies the conditions under which retry
+                            takes place.
+                          type: string
+                        retryRemoteLocalities:
+                          description: Flag to specify whether the retries should
+                            retry to other localities.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    rewrite:
+                      description: Rewrite HTTP URIs and Authority headers.
+                      properties:
+                        authority:
+                          description: rewrite the Authority/Host header with this
+                            value.
+                          type: string
+                        uri:
+                          type: string
+                      type: object
+                    route:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            type: object
+                          headers:
+                            properties:
+                              request:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              response:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                    timeout:
+                      description: Timeout for HTTP requests, default is disabled.
+                      type: string
+                  type: object
+                type: array
+              tcp:
+                description: An ordered list of route rules for opaque TCP traffic.
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sourceLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            type: string
+                          sourceSubnet:
+                            description: IPv4 or IPv6 ip address of source with optional
+                              subnet.
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            type: object
+                          weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sniHosts:
+                            description: SNI (server name indicator) to match on.
+                            items:
+                              type: string
+                            type: array
+                          sourceLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                type: string
+                            type: object
+                          weight:
+                            description: Weight specifies the relative proportion
+                              of traffic to be forwarded to the destination.
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
+  name: workloadentries.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: WorkloadEntry
+    listKind: WorkloadEntryList
+    plural: workloadentries
+    shortNames:
+    - we
+    singular: workloadentry
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Address associated with the network endpoint.
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting VMs onboarded into the mesh. See
+              more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+            properties:
+              address:
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: One or more labels associated with the endpoint.
+                type: object
+              locality:
+                description: The locality associated with the endpoint.
+                type: string
+              network:
+                type: string
+              ports:
+                additionalProperties:
+                  type: integer
+                description: Set of ports associated with the endpoint.
+                type: object
+              serviceAccount:
+                type: string
+              weight:
+                description: The load balancing weight associated with the endpoint.
+                type: integer
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Address associated with the network endpoint.
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting VMs onboarded into the mesh. See
+              more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+            properties:
+              address:
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: One or more labels associated with the endpoint.
+                type: object
+              locality:
+                description: The locality associated with the endpoint.
+                type: string
+              network:
+                type: string
+              ports:
+                additionalProperties:
+                  type: integer
+                description: Set of ports associated with the endpoint.
+                type: object
+              serviceAccount:
+                type: string
+              weight:
+                description: The load balancing weight associated with the endpoint.
+                type: integer
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

add seldon virtual service support in endpoints

```bash
vela status simple-example --endpoint

+---------+-------------------------------------+---------------------------------------------------+
| CLUSTER |      REF(KIND/NAMESPACE/NAME)       |                     ENDPOINT                      |
+---------+-------------------------------------+---------------------------------------------------+
|         | VirtualService/default/demo-serving | tcp://1.1.1.1:80/seldon/default/demo-serving/ |
|         | Service/default/jupyter             | tcp://1.1.1.1:8888                           |
+---------+-------------------------------------+---------------------------------------------------+
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->