### PR TITLE
Fix: vela status api can not return customized arguments of addon

### DIFF
--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -204,10 +204,11 @@ func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*ap
 	if err != nil && !errors2.IsNotFound(err) {
 		return nil, bcode.ErrAddonSecretGet
 	} else if errors2.IsNotFound(err) {
-		res.Args = make(map[string]string, len(sec.Data))
-		for k, v := range sec.Data {
-			res.Args[k] = string(v)
-		}
+		return &res, nil
+	}
+	res.Args = make(map[string]string, len(sec.Data))
+	for k, v := range sec.Data {
+		res.Args[k] = string(v)
 	}
 
 	return &res, nil


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

Fixes #3274 
If addon argument secret exists, return the arguments.
 if not exist, return 404

Current logic is 
```
	if err != nil && !errors2.IsNotFound(err) {
		return nil, bcode.ErrAddonSecretGet
	} else if errors2.IsNotFound(err) {
		res.Args = make(map[string]string, len(sec.Data))
		for k, v := range sec.Data {
			res.Args[k] = string(v)
		}
	}
```
It does not return "res.Args",when secret exists.
So update it to be 
```
	if err != nil && !errors2.IsNotFound(err) {
		return nil, bcode.ErrAddonSecretGet
	} else if errors2.IsNotFound(err) {
		return nil, bcode.ErrAddonSecretNotExist
	} else {
		res.Args = make(map[string]string, len(sec.Data))
		for k, v := range sec.Data {
			res.Args[k] = string(v)
		}
	}
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->