### PR TITLE
Feat: vela can set default namespace and user can  enable fluxcd addon by default

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -19,8 +19,6 @@ package types
 import "github.com/oam-dev/kubevela/pkg/oam"
 
 const (
-	// DefaultKubeVelaNS defines the default KubeVela namespace in Kubernetes
-	DefaultKubeVelaNS = "vela-system"
 	// DefaultKubeVelaReleaseName defines the default name of KubeVela Release
 	DefaultKubeVelaReleaseName = "kubevela"
 	// DefaultKubeVelaChartName defines the default chart name of KubeVela, this variable MUST align to the chart name of this repo
@@ -34,6 +32,9 @@ const (
 	// AutoDetectWorkloadDefinition defines the default workload type for ComponentDefinition which doesn't specify a workload
 	AutoDetectWorkloadDefinition = "autodetects.core.oam.dev"
 )
+
+// DefaultKubeVelaNS defines the default KubeVela namespace in Kubernetes
+var DefaultKubeVelaNS = "vela-system"
 
 const (
 	// AnnoDefinitionDescription is the annotation which describe what is the capability used for in a WorkloadDefinition/TraitDefinition Object

--- a/charts/vela-core/templates/addon/fluxcd-def.yaml
+++ b/charts/vela-core/templates/addon/fluxcd-def.yaml
@@ -1,0 +1,268 @@
+{{- if .Values.enableFluxcdAddon -}}
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  labels:
+    addons.oam.dev/name: fluxcd-def
+  name: addon-fluxcd-def
+  namespace: {{ .Release.Namespace }}
+spec:
+  components:
+    - name: fluxc-def-resources
+      properties:
+        objects:
+          - apiVersion: core.oam.dev/v1beta1
+            kind: ComponentDefinition
+            metadata:
+              annotations:
+                definition.oam.dev/description: helm release is a group of K8s resources
+                  from either git repository or helm repo
+              name: helm
+              namespace: {{.Values.systemDefinitionNamespace}}
+            spec:
+              schematic:
+                cue:
+                  template: "output: {\n\tapiVersion: \"source.toolkit.fluxcd.io/v1beta1\"\n\tmetadata:
+                {\n\t\tname: context.name\n\t}\n\tif parameter.repoType == \"git\"
+                {\n\t\tkind: \"GitRepository\"\n\t\tspec: {\n\t\t\turl: parameter.url\n\t\t\tif
+                parameter.git.branch != _|_ {\n\t\t\t\tref: branch: parameter.git.branch\n\t\t\t}\n\t\t\t_secret\n\t\t\t_sourceCommonArgs\n\t\t}\n\t}\n\tif
+                parameter.repoType == \"oss\" {\n\t\tkind: \"Bucket\"\n\t\tspec: {\n\t\t\tendpoint:
+                \  parameter.url\n\t\t\tbucketName: parameter.oss.bucketName\n\t\t\tprovider:
+                \  parameter.oss.provider\n\t\t\tif parameter.oss.region != _|_ {\n\t\t\t\tregion:
+                parameter.oss.region\n\t\t\t}\n\t\t\t_secret\n\t\t\t_sourceCommonArgs\n\t\t}\n\t}\n\tif
+                parameter.repoType == \"helm\" {\n\t\tkind: \"HelmRepository\"\n\t\tspec:
+                {\n\t\t\turl: parameter.url\n\t\t\t_secret\n\t\t\t_sourceCommonArgs\n\t\t}\n\t}\n}\n\noutputs:
+                release: {\n\tapiVersion: \"helm.toolkit.fluxcd.io/v2beta1\"\n\tkind:
+                \      \"HelmRelease\"\n\tmetadata: {\n\t\tname: context.name\n\t}\n\tspec:
+                {\n\t\ttimeout: parameter.installTimeout\n\t\tinterval: parameter.interval\n\t\tchart:
+                {\n\t\t\tspec: {\n\t\t\t\tchart:   parameter.chart\n\t\t\t\tversion:
+                parameter.version\n\t\t\t\tsourceRef: {\n\t\t\t\t\tif parameter.repoType
+                == \"git\" {\n\t\t\t\t\t\tkind: \"GitRepository\"\n\t\t\t\t\t}\n\t\t\t\t\tif
+                parameter.repoType == \"helm\" {\n\t\t\t\t\t\tkind: \"HelmRepository\"\n\t\t\t\t\t}\n\t\t\t\t\tif
+                parameter.repoType == \"oss\" {\n\t\t\t\t\t\tkind: \"Bucket\"\n\t\t\t\t\t}\n\t\t\t\t\tname:
+                \     context.name\n\t\t\t\t}\n\t\t\t\tinterval: parameter.interval\n\t\t\t}\n\t\t}\n\t\tif
+                parameter.targetNamespace != _|_ {\n\t\t\ttargetNamespace: parameter.targetNamespace\n\t\t}\n\t\tif
+                parameter.releaseName != _|_ {\n\t\t\treleaseName: parameter.releaseName\n\t\t}\n\t\tif
+                parameter.values != _|_ {\n\t\t\tvalues: parameter.values\n\t\t}\n\t}\n}\n\n_secret:
+                {\n\tif parameter.secretRef != _|_ {\n\t\tsecretRef: {\n\t\t\tname:
+                parameter.secretRef\n\t\t}\n\t}\n}\n\n_sourceCommonArgs: {\n\tinterval:
+                parameter.pullInterval\n\tif parameter.timeout != _|_ {\n\t\ttimeout:
+                parameter.timeout\n\t}\n}\n\nparameter: {\n\trepoType: *\"helm\" |
+                \"git\" | \"oss\"\n\t// +usage=The interval at which to check for
+                repository/bucket and relese updates, default to 5m\n\tpullInterval:
+                *\"5m\" | string\n        // +usage=The  Interval at which to reconcile
+                the Helm release, default to 30s\n        interval: *\"30s\" | string\n\t//
+                +usage=The Git or Helm repository URL, OSS endpoint, accept HTTP/S
+                or SSH address as git url,\n\turl: string\n\t// +usage=The name of
+                the secret containing authentication credentials\n\tsecretRef?: string\n\t//
+                +usage=The timeout for operations like download index/clone repository,
+                optional\n\ttimeout?: string\n\t// +usage=The timeout for operation
+                `helm install`, optional\n\tinstallTimeout: *\"10m\" | string\n\n\tgit?:
+                {\n\t\t// +usage=The Git reference to checkout and monitor for changes,
+                defaults to master branch\n\t\tbranch: string\n\t}\n\toss?: {\n\t\t//
+                +usage=The bucket's name, required if repoType is oss\n\t\tbucketName:
+                string\n\t\t// +usage=\"generic\" for Minio, Amazon S3, Google Cloud
+                Storage, Alibaba Cloud OSS, \"aws\" for retrieve credentials from
+                the EC2 service when credentials not specified, default \"generic\"\n\t\tprovider:
+                *\"generic\" | \"aws\"\n\t\t// +usage=The bucket region, optional\n\t\tregion?:
+                string\n\t}\n\n\t// +usage=1.The relative path to helm chart for git/oss
+                source. 2. chart name for helm resource 3. relative path for chart
+                package(e.g. ./charts/podinfo-1.2.3.tgz)\n\tchart: string\n\t// +usage=Chart
+                version\n\tversion: *\"*\" | string\n\t// +usage=The namespace for
+                helm chart, optional\n\ttargetNamespace?: string\n\t// +usage=The
+                release name\n\treleaseName?: string\n\t// +usage=Chart values\n\tvalues?:
+                #nestedmap\n}\n\n#nestedmap: {\n\t...\n}\n"
+              status:
+                customStatus: "repoMessage:    string\nreleaseMessage: string\nif context.output.status
+              == _|_ {\n\trepoMessage:    \"Fetching repository\"\n\treleaseMessage:
+              \"Wating repository ready\"\n}\nif context.output.status != _|_ {\n\trepoStatus:
+              context.output.status\n\tif repoStatus.conditions[0][\"type\"] != \"Ready\"
+              {\n\t\trepoMessage: \"Fetch repository fail\"\n\t}\n\tif repoStatus.conditions[0][\"type\"]
+              == \"Ready\" {\n\t\trepoMessage: \"Fetch repository successfully\"\n\t}\n\n\tif
+              context.outputs.release.status == _|_ {\n\t\treleaseMessage: \"Creating
+              helm release\"\n\t}\n\tif context.outputs.release.status != _|_ {\n\t\tif
+              context.outputs.release.status.conditions[0][\"message\"] == \"Release
+              reconciliation succeeded\" {\n\t\t\treleaseMessage: \"Create helm release
+              successfully\"\n\t\t}\n\t\tif context.outputs.release.status.conditions[0][\"message\"]
+              != \"Release reconciliation succeeded\" {\n\t\t\treleaseBasicMessage:
+              \"Delivery helm release in progress, message: \" + context.outputs.release.status.conditions[0][\"message\"]\n\t\t\tif
+              len(context.outputs.release.status.conditions) == 1 {\n\t\t\t\treleaseMessage:
+              releaseBasicMessage\n\t\t\t}\n\t\t\tif len(context.outputs.release.status.conditions)
+              > 1 {\n\t\t\t\treleaseMessage: releaseBasicMessage + \", \" + context.outputs.release.status.conditions[1][\"message\"]\n\t\t\t}\n\t\t}\n\t}\n\n}\nmessage:
+              repoMessage + \", \" + releaseMessage"
+                healthPolicy: 'isHealth: len(context.outputs.release.status.conditions)
+              != 0 && context.outputs.release.status.conditions[0]["status"]=="True"'
+              workload:
+                type: autodetects.core.oam.dev
+          - apiVersion: core.oam.dev/v1beta1
+            kind: TraitDefinition
+            metadata:
+              annotations:
+                definition.oam.dev/description: A list of JSON6902 patch to selected target
+              name: kustomize-json-patch
+              namespace: {{.Values.systemDefinitionNamespace}}
+            spec:
+              schematic:
+                cue:
+                  template: "patch: {\n\tspec: {\n\t\tpatchesJson6902: parameter.patchesJson\n\t}\n}\n\nparameter:
+                {\n\t// +usage=A list of JSON6902 patch.\n\tpatchesJson: [...#jsonPatchItem]\n}\n\n//
+                +usage=Contains a JSON6902 patch\n#jsonPatchItem: {\n\ttarget: #selector\n\tpatch:
+                [...{\n\t\t// +usage=operation to perform\n\t\top: string | \"add\"
+                | \"remove\" | \"replace\" | \"move\" | \"copy\" | \"test\"\n\t\t//
+                +usage=operate path e.g. /foo/bar\n\t\tpath: string\n\t\t// +usage=specify
+                source path when op is copy/move\n\t\tfrom?:  string\n\t\t// +usage=specify
+                opraation value when op is test/add/replace\n\t\tvalue?: string\n\t}]\n}\n\n//
+                +usage=Selector specifies a set of resources\n#selector: {\n\tgroup?:
+                \             string\n\tversion?:            string\n\tkind?:               string\n\tnamespace?:
+                \         string\n\tname?:               string\n\tannotationSelector?:
+                string\n\tlabelSelector?:      string\n}\n"
+          - apiVersion: core.oam.dev/v1beta1
+            kind: TraitDefinition
+            metadata:
+              annotations:
+                definition.oam.dev/description: A list of StrategicMerge or JSON6902 patch
+                  to selected target
+              name: kustomize-patch
+              namespace: {{.Values.systemDefinitionNamespace}}
+            spec:
+              schematic:
+                cue:
+                  template: "patch: {\n\tspec: {\n\t\tpatches: parameter.patches\n\t}\n}\nparameter:
+                {\n\t// +usage=a list of StrategicMerge or JSON6902 patch to selected
+                target\n\tpatches: [...#patchItem]\n}\n\n// +usage=Contains a strategicMerge
+                or JSON6902 patch\n#patchItem: {\n\t// +usage=Inline patch string,
+                in yaml style\n\tpatch: string\n\t// +usage=Specify the target the
+                patch should be applied to\n\ttarget: #selector\n}\n\n// +usage=Selector
+                specifies a set of resources\n#selector: {\n\tgroup?:              string\n\tversion?:
+                \           string\n\tkind?:               string\n\tnamespace?:          string\n\tname?:
+                \              string\n\tannotationSelector?: string\n\tlabelSelector?:
+                \     string\n}\n"
+          - apiVersion: core.oam.dev/v1beta1
+            kind: ComponentDefinition
+            metadata:
+              annotations:
+                definition.oam.dev/description: kustomize can fetching, building, updating
+                  and applying Kustomize manifests from git repo.
+              name: kustomize
+              namespace: {{.Values.systemDefinitionNamespace}}
+            spec:
+              schematic:
+                cue:
+                  template: "output: {\n\tapiVersion: \"kustomize.toolkit.fluxcd.io/v1beta1\"\n\tkind:
+                \      \"Kustomization\"\n\tmetadata: {\n\t\tname: context.name\n
+                \   namespace: context.namespace\n\t}\n\tspec: {\n\t\tinterval: parameter.pullInterval\n\t\tsourceRef:
+                {\n\t\t\tif parameter.repoType == \"git\" {\n\t\t\t\tkind: \"GitRepository\"\n\t\t\t}\n\t\t\tif
+                parameter.repoType == \"oss\" {\n\t\t\t\tkind: \"Bucket\"\n\t\t\t}\n\t\t\tname:
+                \     context.name\n\t\t\tnamespace: context.namespace\n\t\t}\n\t\tpath:
+                \      parameter.path\n\t\tprune:      true\n\t\tvalidation: \"client\"\n\t}\n}\n\noutputs:
+                {\n  repo: {\n\t  apiVersion: \"source.toolkit.fluxcd.io/v1beta1\"\n\t
+                \ metadata: {\n\t\t  name: context.name\n      namespace: context.namespace\n\t
+                \ }\n\t  if parameter.repoType == \"git\" {\n\t\t  kind: \"GitRepository\"\n\t\t
+                \ spec: {\n\t\t\t  url: parameter.url\n\t\t\t  if parameter.git.branch
+                != _|_ {\n\t\t\t\t  ref: branch: parameter.git.branch\n\t\t\t  }\n
+                \       if parameter.git.provider != _|_ {\n          if parameter.git.provider
+                == \"GitHub\" {\n            gitImplementation: \"go-git\"\n          }\n
+                \         if parameter.git.provider == \"AzureDevOps\" {\n            gitImplementation:
+                \"libgit2\"\n          }\n        }\n\t\t\t  _secret\n\t\t\t  _sourceCommonArgs\n\t\t
+                \ }\n\t  }\n\t  if parameter.repoType == \"oss\" {\n\t\t  kind: \"Bucket\"\n\t\t
+                \ spec: {\n\t\t\t  endpoint:   parameter.url\n\t\t\t  bucketName:
+                parameter.oss.bucketName\n\t\t\t  provider:   parameter.oss.provider\n\t\t\t
+                \ if parameter.oss.region != _|_ {\n\t\t\t\t  region: parameter.oss.region\n\t\t\t
+                \ }\n\t\t\t  _secret\n\t\t\t  _sourceCommonArgs\n\t\t  }\n\t  }\n
+                \ }\n\n  if parameter.imageRepository != _|_ {\n    imageRepo: {\n
+                \     apiVersion: \"image.toolkit.fluxcd.io/v1beta1\"\n      kind:
+                \"ImageRepository\"\n\t    metadata: {\n\t\t    name: context.name\n
+                \       namespace: context.namespace\n\t    }\n      spec: {\n        image:
+                parameter.imageRepository.image\n        interval: parameter.pullInterval\n
+                \       if parameter.imageRepository.secretRef != _|_ {\n          secretRef:
+                name: parameter.imageRepository.secretRef\n        }\n      }\n    }\n\n
+                \   imagePolicy: {\n      apiVersion: \"image.toolkit.fluxcd.io/v1beta1\"\n
+                \     kind: \"ImagePolicy\"\n\t    metadata: {\n\t\t    name: context.name\n
+                \       namespace: context.namespace\n\t    }\n      spec: {\n        imageRepositoryRef:
+                name: context.name\n        policy: parameter.imageRepository.policy\n
+                \       if parameter.imageRepository.filterTags != _|_ {\n          filterTags:
+                parameter.imageRepository.filterTags\n        }\n      }\n    }\n\n
+                \   imageUpdate: {\n      apiVersion: \"image.toolkit.fluxcd.io/v1beta1\"\n
+                \     kind: \"ImageUpdateAutomation\"\n\t    metadata: {\n\t\t    name:
+                context.name\n        namespace: context.namespace\n\t    }\n      spec:
+                {\n        interval: parameter.pullInterval\n        sourceRef: {\n
+                \         kind: \"GitRepository\"\n          name: context.name\n
+                \       }\n        git: {\n          checkout: ref: branch: parameter.git.branch\n
+                \         commit: {\n            author: {\n              email: \"kubevelabot@users.noreply.github.com\"\n
+                \             name: \"kubevelabot\"\n            }\n            if
+                parameter.imageRepository.commitMessage != _|_ {\n              messageTemplate:
+                \"Update image automatically.\\n\" + parameter.imageRepository.commitMessage\n
+                \           }\n            if parameter.imageRepository.commitMessage
+                == _|_ {\n              messageTemplate: \"Update image automatically.\"\n
+                \           }\n          }\n          push: branch: parameter.git.branch\n
+                \       }\n        update: {\n          path:\tparameter.path\n          strategy:
+                \"Setters\"\n        }\n      }\n    }\n  }\n}\n\n_secret: {\n\tif
+                parameter.secretRef != _|_ {\n\t\tsecretRef: {\n\t\t\tname: parameter.secretRef\n\t\t}\n\t}\n}\n\n_sourceCommonArgs:
+                {\n\tinterval: parameter.pullInterval\n\tif parameter.timeout != _|_
+                {\n\t\ttimeout: parameter.timeout\n\t}\n}\n\nparameter: {\n\trepoType:
+                *\"git\" | \"oss\"\n  // +usage=The image repository for automatically
+                update image to git\n  imageRepository?: {\n    // +usage=The image
+                url\n    image: string\n    // +usage=The name of the secret containing
+                authentication credentials\n    secretRef?: string\n    // +usage=Policy
+                gives the particulars of the policy to be followed in selecting the
+                most recent image.\n    policy: {\n      // +usage=Alphabetical set
+                of rules to use for alphabetical ordering of the tags.\n      alphabetical?:
+                {\n        // +usage=Order specifies the sorting order of the tags.\n
+                \       // +usage=Given the letters of the alphabet as tags, ascending
+                order would select Z, and descending order would select A.\n        order?:
+                \"asc\" | \"desc\"\n      }\n      // +usage=Numerical set of rules
+                to use for numerical ordering of the tags.\n      numerical?: {\n
+                \       // +usage=Order specifies the sorting order of the tags.\n
+                \       // +usage=Given the integer values from 0 to 9 as tags, ascending
+                order would select 9, and descending order would select 0.\n        order:
+                \"asc\" | \"desc\"\n      }\n      // +usage=SemVer gives a semantic
+                version range to check against the tags available.\n      semver?:
+                {\n        // +usage=Range gives a semver range for the image tag;
+                the highest version within the range that's a tag yields the latest
+                image.\n        range: string\n      }\n    }\n    // +usage=FilterTags
+                enables filtering for only a subset of tags based on a set of rules.
+                If no rules are provided, all the tags from the repository will be
+                ordered and compared.\n    filterTags?: {\n      // +usage=Extract
+                allows a capture group to be extracted from the specified regular
+                expression pattern, useful before tag evaluation.\n      extract?:
+                string\n      // +usage=Pattern specifies a regular expression pattern
+                used to filter for image tags.\n      pattern?: string\n    }\n    //
+                +usage=The image url\n    commitMessage?: string\n  }\n\t// +usage=The
+                interval at which to check for repository/bucket and release updates,
+                default to 5m\n\tpullInterval: *\"5m\" | string\n\t// +usage=The Git
+                or Helm repository URL, OSS endpoint, accept HTTP/S or SSH address
+                as git url,\n\turl: string\n\t// +usage=The name of the secret containing
+                authentication credentials\n\tsecretRef?: string\n\t// +usage=The
+                timeout for operations like download index/clone repository, optional\n\ttimeout?:
+                string\n\tgit?: {\n\t\t// +usage=The Git reference to checkout and
+                monitor for changes, defaults to master branch\n\t\tbranch: string\n
+                \   // +usage=Determines which git client library to use. Defaults
+                to GitHub, it will pick go-git. AzureDevOps will pick libgit2.\n    provider?:
+                *\"GitHub\" | \"AzureDevOps\"\n\t}\n\toss?: {\n\t\t// +usage=The bucket's
+                name, required if repoType is oss\n\t\tbucketName: string\n\t\t//
+                +usage=\"generic\" for Minio, Amazon S3, Google Cloud Storage, Alibaba
+                Cloud OSS, \"aws\" for retrieve credentials from the EC2 service when
+                credentials not specified, default \"generic\"\n\t\tprovider: *\"generic\"
+                | \"aws\"\n\t\t// +usage=The bucket region, optional\n\t\tregion?:
+                string\n\t}\n\t//+usage=Path to the directory containing the kustomization.yaml
+                file, or the set of plain YAMLs a kustomization.yaml should be generated
+                for.\n\tpath: string\n}"
+              workload:
+                type: autodetects.core.oam.dev
+          - apiVersion: core.oam.dev/v1beta1
+            kind: TraitDefinition
+            metadata:
+              annotations:
+                definition.oam.dev/description: A list of strategic merge to kustomize
+                  config
+              name: kustomize-strategy-merge
+              namespace: {{.Values.systemDefinitionNamespace}}
+            spec:
+              schematic:
+                cue:
+                  template: "patch: {\n\tspec: {\n\t\tpatchesStrategicMerge: parameter.patchesStrategicMerge\n\t}\n}\n\nparameter:
+                {\n\t// +usage=a list of strategicmerge, defined as inline yaml objects.\n\tpatchesStrategicMerge:
+                [...#nestedmap]\n}\n\n#nestedmap: {\n\t...\n}\n"
+      type: k8s-objects
+
+  {{- end }}

--- a/charts/vela-core/templates/addon/fluxcd.yaml
+++ b/charts/vela-core/templates/addon/fluxcd.yaml
@@ -1,0 +1,4986 @@
+{{- if .Values.enableFluxcdAddon -}}
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  labels:
+    addons.oam.dev/name: fluxcd
+    addons.oam.dev/registry: KubeVela
+  name: addon-fluxcd
+  namespace: {{ .Release.Namespace }}
+spec:
+  components:
+    - name: flux-system-namespace
+      properties:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: flux-system
+      type: raw
+    - name: fluxcd-resources
+      properties:
+        objects:
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: buckets.source.toolkit.fluxcd.io
+            spec:
+              group: source.toolkit.fluxcd.io
+              names:
+                kind: Bucket
+                listKind: BucketList
+                plural: buckets
+                singular: bucket
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .spec.url
+                      name: URL
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+                      name: Ready
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+                      name: Status
+                      type: string
+                    - jsonPath: .metadata.creationTimestamp
+                      name: Age
+                      type: date
+                  name: v1beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: Bucket is the Schema for the buckets API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: BucketSpec defines the desired state of an S3 compatible
+                            bucket
+                          properties:
+                            bucketName:
+                              description: The bucket name.
+                              type: string
+                            endpoint:
+                              description: The bucket endpoint address.
+                              type: string
+                            ignore:
+                              description: Ignore overrides the set of excluded patterns
+                                in the .sourceignore format (which is the same as .gitignore).
+                                If not provided, a default will be used, consult the documentation
+                                for your version to find out what those are.
+                              type: string
+                            insecure:
+                              description: Insecure allows connecting to a non-TLS S3 HTTP
+                                endpoint.
+                              type: boolean
+                            interval:
+                              description: The interval at which to check for bucket updates.
+                              type: string
+                            provider:
+                              default: generic
+                              description: The S3 compatible storage provider name, default
+                                ('generic').
+                              enum:
+                                - generic
+                                - aws
+                              type: string
+                            region:
+                              description: The bucket region.
+                              type: string
+                            secretRef:
+                              description: The name of the secret containing authentication
+                                credentials for the Bucket.
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            suspend:
+                              description: This flag tells the controller to suspend the
+                                reconciliation of this source.
+                              type: boolean
+                            timeout:
+                              default: 20s
+                              description: The timeout for download operations, defaults
+                                to 20s.
+                              type: string
+                          required:
+                            - bucketName
+                            - endpoint
+                            - interval
+                          type: object
+                        status:
+                          description: BucketStatus defines the observed state of a bucket
+                          properties:
+                            artifact:
+                              description: Artifact represents the output of the last successful
+                                Bucket sync.
+                              properties:
+                                checksum:
+                                  description: Checksum is the SHA1 checksum of the artifact.
+                                  type: string
+                                lastUpdateTime:
+                                  description: LastUpdateTime is the timestamp corresponding
+                                    to the last update of this artifact.
+                                  format: date-time
+                                  type: string
+                                path:
+                                  description: Path is the relative file path of this artifact.
+                                  type: string
+                                revision:
+                                  description: Revision is a human readable identifier traceable
+                                    in the origin source system. It can be a Git commit
+                                    SHA, Git tag, a Helm index timestamp, a Helm chart version,
+                                    etc.
+                                  type: string
+                                url:
+                                  description: URL is the HTTP address of this artifact.
+                                  type: string
+                              required:
+                                - path
+                                - url
+                              type: object
+                            conditions:
+                              description: Conditions holds the conditions for the Bucket.
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            observedGeneration:
+                              description: ObservedGeneration is the last observed generation.
+                              format: int64
+                              type: integer
+                            url:
+                              description: URL is the download link for the artifact output
+                                of the last Bucket sync.
+                              type: string
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: gitrepositories.source.toolkit.fluxcd.io
+            spec:
+              group: source.toolkit.fluxcd.io
+              names:
+                kind: GitRepository
+                listKind: GitRepositoryList
+                plural: gitrepositories
+                shortNames:
+                  - gitrepo
+                singular: gitrepository
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .spec.url
+                      name: URL
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+                      name: Ready
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+                      name: Status
+                      type: string
+                    - jsonPath: .metadata.creationTimestamp
+                      name: Age
+                      type: date
+                  name: v1beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: GitRepository is the Schema for the gitrepositories API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: GitRepositorySpec defines the desired state of a
+                            Git repository.
+                          properties:
+                            gitImplementation:
+                              default: go-git
+                              description: Determines which git client library to use. Defaults
+                                to go-git, valid values are ('go-git', 'libgit2').
+                              enum:
+                                - go-git
+                                - libgit2
+                              type: string
+                            ignore:
+                              description: Ignore overrides the set of excluded patterns
+                                in the .sourceignore format (which is the same as .gitignore).
+                                If not provided, a default will be used, consult the documentation
+                                for your version to find out what those are.
+                              type: string
+                            include:
+                              description: Extra git repositories to map into the repository
+                              items:
+                                description: GitRepositoryInclude defines a source with
+                                  a from and to path.
+                                properties:
+                                  fromPath:
+                                    description: The path to copy contents from, defaults
+                                      to the root directory.
+                                    type: string
+                                  repository:
+                                    description: Reference to a GitRepository to include.
+                                    properties:
+                                      name:
+                                        description: Name of the referent
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  toPath:
+                                    description: The path to copy contents to, defaults
+                                      to the name of the source ref.
+                                    type: string
+                                required:
+                                  - repository
+                                type: object
+                              type: array
+                            interval:
+                              description: The interval at which to check for repository
+                                updates.
+                              type: string
+                            recurseSubmodules:
+                              description: When enabled, after the clone is created, initializes
+                                all submodules within, using their default settings. This
+                                option is available only when using the 'go-git' GitImplementation.
+                              type: boolean
+                            ref:
+                              description: The Git reference to checkout and monitor for
+                                changes, defaults to master branch.
+                              properties:
+                                branch:
+                                  default: master
+                                  description: The Git branch to checkout, defaults to master.
+                                  type: string
+                                commit:
+                                  description: The Git commit SHA to checkout, if specified
+                                    Tag filters will be ignored.
+                                  type: string
+                                semver:
+                                  description: The Git tag semver expression, takes precedence
+                                    over Tag.
+                                  type: string
+                                tag:
+                                  description: The Git tag to checkout, takes precedence
+                                    over Branch.
+                                  type: string
+                              type: object
+                            secretRef:
+                              description: The secret name containing the Git credentials.
+                                For HTTPS repositories the secret must contain username
+                                and password fields. For SSH repositories the secret must
+                                contain identity, identity.pub and known_hosts fields.
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            suspend:
+                              description: This flag tells the controller to suspend the
+                                reconciliation of this source.
+                              type: boolean
+                            timeout:
+                              default: 20s
+                              description: The timeout for remote Git operations like cloning,
+                                defaults to 20s.
+                              type: string
+                            url:
+                              description: The repository URL, can be a HTTP/S or SSH address.
+                              pattern: ^(http|https|ssh)://
+                              type: string
+                            verify:
+                              description: Verify OpenPGP signature for the Git commit HEAD
+                                points to.
+                              properties:
+                                mode:
+                                  description: Mode describes what git object should be
+                                    verified, currently ('head').
+                                  enum:
+                                    - head
+                                  type: string
+                                secretRef:
+                                  description: The secret name containing the public keys
+                                    of all trusted Git authors.
+                                  properties:
+                                    name:
+                                      description: Name of the referent
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mode
+                              type: object
+                          required:
+                            - interval
+                            - url
+                          type: object
+                        status:
+                          description: GitRepositoryStatus defines the observed state of
+                            a Git repository.
+                          properties:
+                            artifact:
+                              description: Artifact represents the output of the last successful
+                                repository sync.
+                              properties:
+                                checksum:
+                                  description: Checksum is the SHA1 checksum of the artifact.
+                                  type: string
+                                lastUpdateTime:
+                                  description: LastUpdateTime is the timestamp corresponding
+                                    to the last update of this artifact.
+                                  format: date-time
+                                  type: string
+                                path:
+                                  description: Path is the relative file path of this artifact.
+                                  type: string
+                                revision:
+                                  description: Revision is a human readable identifier traceable
+                                    in the origin source system. It can be a Git commit
+                                    SHA, Git tag, a Helm index timestamp, a Helm chart version,
+                                    etc.
+                                  type: string
+                                url:
+                                  description: URL is the HTTP address of this artifact.
+                                  type: string
+                              required:
+                                - path
+                                - url
+                              type: object
+                            conditions:
+                              description: Conditions holds the conditions for the GitRepository.
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            includedArtifacts:
+                              description: IncludedArtifacts represents the included artifacts
+                                from the last successful repository sync.
+                              items:
+                                description: Artifact represents the output of a source
+                                  synchronisation.
+                                properties:
+                                  checksum:
+                                    description: Checksum is the SHA1 checksum of the artifact.
+                                    type: string
+                                  lastUpdateTime:
+                                    description: LastUpdateTime is the timestamp corresponding
+                                      to the last update of this artifact.
+                                    format: date-time
+                                    type: string
+                                  path:
+                                    description: Path is the relative file path of this
+                                      artifact.
+                                    type: string
+                                  revision:
+                                    description: Revision is a human readable identifier
+                                      traceable in the origin source system. It can be a
+                                      Git commit SHA, Git tag, a Helm index timestamp, a
+                                      Helm chart version, etc.
+                                    type: string
+                                  url:
+                                    description: URL is the HTTP address of this artifact.
+                                    type: string
+                                required:
+                                  - path
+                                  - url
+                                type: object
+                              type: array
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            observedGeneration:
+                              description: ObservedGeneration is the last observed generation.
+                              format: int64
+                              type: integer
+                            url:
+                              description: URL is the download link for the artifact output
+                                of the last repository sync.
+                              type: string
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: helmcharts.source.toolkit.fluxcd.io
+            spec:
+              group: source.toolkit.fluxcd.io
+              names:
+                kind: HelmChart
+                listKind: HelmChartList
+                plural: helmcharts
+                shortNames:
+                  - hc
+                singular: helmchart
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .spec.chart
+                      name: Chart
+                      type: string
+                    - jsonPath: .spec.version
+                      name: Version
+                      type: string
+                    - jsonPath: .spec.sourceRef.kind
+                      name: Source Kind
+                      type: string
+                    - jsonPath: .spec.sourceRef.name
+                      name: Source Name
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+                      name: Ready
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+                      name: Status
+                      type: string
+                    - jsonPath: .metadata.creationTimestamp
+                      name: Age
+                      type: date
+                  name: v1beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: HelmChart is the Schema for the helmcharts API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: HelmChartSpec defines the desired state of a Helm
+                            chart.
+                          properties:
+                            chart:
+                              description: The name or path the Helm chart is available
+                                at in the SourceRef.
+                              type: string
+                            interval:
+                              description: The interval at which to check the Source for
+                                updates.
+                              type: string
+                            sourceRef:
+                              description: The reference to the Source the chart is available
+                                at.
+                              properties:
+                                apiVersion:
+                                  description: APIVersion of the referent.
+                                  type: string
+                                kind:
+                                  description: Kind of the referent, valid values are ('HelmRepository',
+                                    'GitRepository', 'Bucket').
+                                  enum:
+                                    - HelmRepository
+                                    - GitRepository
+                                    - Bucket
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            suspend:
+                              description: This flag tells the controller to suspend the
+                                reconciliation of this source.
+                              type: boolean
+                            valuesFile:
+                              description: Alternative values file to use as the default
+                                chart values, expected to be a relative path in the SourceRef.
+                                Deprecated in favor of ValuesFiles, for backwards compatibility
+                                the file defined here is merged before the ValuesFiles items.
+                                Ignored when omitted.
+                              type: string
+                            valuesFiles:
+                              description: Alternative list of values files to use as the
+                                chart values (values.yaml is not included by default), expected
+                                to be a relative path in the SourceRef. Values files are
+                                merged in the order of this list with the last file overriding
+                                the first. Ignored when omitted.
+                              items:
+                                type: string
+                              type: array
+                            version:
+                              default: '*'
+                              description: The chart version semver expression, ignored
+                                for charts from GitRepository and Bucket sources. Defaults
+                                to latest when omitted.
+                              type: string
+                          required:
+                            - chart
+                            - interval
+                            - sourceRef
+                          type: object
+                        status:
+                          description: HelmChartStatus defines the observed state of the
+                            HelmChart.
+                          properties:
+                            artifact:
+                              description: Artifact represents the output of the last successful
+                                chart sync.
+                              properties:
+                                checksum:
+                                  description: Checksum is the SHA1 checksum of the artifact.
+                                  type: string
+                                lastUpdateTime:
+                                  description: LastUpdateTime is the timestamp corresponding
+                                    to the last update of this artifact.
+                                  format: date-time
+                                  type: string
+                                path:
+                                  description: Path is the relative file path of this artifact.
+                                  type: string
+                                revision:
+                                  description: Revision is a human readable identifier traceable
+                                    in the origin source system. It can be a Git commit
+                                    SHA, Git tag, a Helm index timestamp, a Helm chart version,
+                                    etc.
+                                  type: string
+                                url:
+                                  description: URL is the HTTP address of this artifact.
+                                  type: string
+                              required:
+                                - path
+                                - url
+                              type: object
+                            conditions:
+                              description: Conditions holds the conditions for the HelmChart.
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            observedGeneration:
+                              description: ObservedGeneration is the last observed generation.
+                              format: int64
+                              type: integer
+                            url:
+                              description: URL is the download link for the last chart pulled.
+                              type: string
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: helmreleases.helm.toolkit.fluxcd.io
+            spec:
+              group: helm.toolkit.fluxcd.io
+              names:
+                kind: HelmRelease
+                listKind: HelmReleaseList
+                plural: helmreleases
+                shortNames:
+                  - hr
+                singular: helmrelease
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+                      name: Ready
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+                      name: Status
+                      type: string
+                    - jsonPath: .metadata.creationTimestamp
+                      name: Age
+                      type: date
+                  name: v2beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: HelmRelease is the Schema for the helmreleases API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: HelmReleaseSpec defines the desired state of a Helm
+                            release.
+                          properties:
+                            chart:
+                              description: Chart defines the template of the v1beta1.HelmChart
+                                that should be created for this HelmRelease.
+                              properties:
+                                spec:
+                                  description: Spec holds the template for the v1beta1.HelmChartSpec
+                                    for this HelmRelease.
+                                  properties:
+                                    chart:
+                                      description: The name or path the Helm chart is available
+                                        at in the SourceRef.
+                                      type: string
+                                    interval:
+                                      description: Interval at which to check the v1beta1.Source
+                                        for updates. Defaults to 'HelmReleaseSpec.Interval'.
+                                      type: string
+                                    sourceRef:
+                                      description: The name and namespace of the v1beta1.Source
+                                        the chart is available at.
+                                      properties:
+                                        apiVersion:
+                                          description: APIVersion of the referent.
+                                          type: string
+                                        kind:
+                                          description: Kind of the referent.
+                                          enum:
+                                            - HelmRepository
+                                            - GitRepository
+                                            - Bucket
+                                          type: string
+                                        name:
+                                          description: Name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    valuesFile:
+                                      description: Alternative values file to use as the
+                                        default chart values, expected to be a relative
+                                        path in the SourceRef. Deprecated in favor of ValuesFiles,
+                                        for backwards compatibility the file defined here
+                                        is merged before the ValuesFiles items. Ignored
+                                        when omitted.
+                                      type: string
+                                    valuesFiles:
+                                      description: Alternative list of values files to use
+                                        as the chart values (values.yaml is not included
+                                        by default), expected to be a relative path in the
+                                        SourceRef. Values files are merged in the order
+                                        of this list with the last file overriding the first.
+                                        Ignored when omitted.
+                                      items:
+                                        type: string
+                                      type: array
+                                    version:
+                                      default: '*'
+                                      description: Version semver expression, ignored for
+                                        charts from v1beta1.GitRepository and v1beta1.Bucket
+                                        sources. Defaults to latest when omitted.
+                                      type: string
+                                  required:
+                                    - chart
+                                    - sourceRef
+                                  type: object
+                              required:
+                                - spec
+                              type: object
+                            dependsOn:
+                              description: DependsOn may contain a dependency.CrossNamespaceDependencyReference
+                                slice with references to HelmRelease resources that must
+                                be ready before this HelmRelease can be reconciled.
+                              items:
+                                description: CrossNamespaceDependencyReference holds the
+                                  reference to a dependency.
+                                properties:
+                                  name:
+                                    description: Name holds the name reference of a dependency.
+                                    type: string
+                                  namespace:
+                                    description: Namespace holds the namespace reference
+                                      of a dependency.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            install:
+                              description: Install holds the configuration for Helm install
+                                actions for this HelmRelease.
+                              properties:
+                                crds:
+                                  description: "CRDs upgrade CRDs from the Helm Chart's
+                              crds directory according to the CRD upgrade policy provided
+                              here. Valid values are `Skip`, `Create` or `CreateReplace`.
+                              Default is `Create` and if omitted CRDs are installed
+                              but not updated. \n Skip: do neither install nor replace
+                              (update) any CRDs. \n Create: new CRDs are created,
+                              existing CRDs are neither updated nor deleted. \n CreateReplace:
+                              new CRDs are created, existing CRDs are updated (replaced)
+                              but not deleted. \n By default, CRDs are applied (installed)
+                              during Helm install action. With this option users can
+                              opt-in to CRD replace existing CRDs on Helm install
+                              actions, which is not (yet) natively supported by Helm.
+                              https://helm.sh/docs/chart_best_practices/custom_resource_definitions."
+                                  enum:
+                                    - Skip
+                                    - Create
+                                    - CreateReplace
+                                  type: string
+                                createNamespace:
+                                  description: CreateNamespace tells the Helm install action
+                                    to create the HelmReleaseSpec.TargetNamespace if it
+                                    does not exist yet. On uninstall, the namespace will
+                                    not be garbage collected.
+                                  type: boolean
+                                disableHooks:
+                                  description: DisableHooks prevents hooks from running
+                                    during the Helm install action.
+                                  type: boolean
+                                disableOpenAPIValidation:
+                                  description: DisableOpenAPIValidation prevents the Helm
+                                    install action from validating rendered templates against
+                                    the Kubernetes OpenAPI Schema.
+                                  type: boolean
+                                disableWait:
+                                  description: DisableWait disables the waiting for resources
+                                    to be ready after a Helm install has been performed.
+                                  type: boolean
+                                disableWaitForJobs:
+                                  description: DisableWaitForJobs disables waiting for jobs
+                                    to complete after a Helm install has been performed.
+                                  type: boolean
+                                remediation:
+                                  description: Remediation holds the remediation configuration
+                                    for when the Helm install action for the HelmRelease
+                                    fails. The default is to not perform any action.
+                                  properties:
+                                    ignoreTestFailures:
+                                      description: IgnoreTestFailures tells the controller
+                                        to skip remediation when the Helm tests are run
+                                        after an install action but fail. Defaults to 'Test.IgnoreFailures'.
+                                      type: boolean
+                                    remediateLastFailure:
+                                      description: RemediateLastFailure tells the controller
+                                        to remediate the last failure, when no retries remain.
+                                        Defaults to 'false'.
+                                      type: boolean
+                                    retries:
+                                      description: Retries is the number of retries that
+                                        should be attempted on failures before bailing.
+                                        Remediation, using an uninstall, is performed between
+                                        each attempt. Defaults to '0', a negative integer
+                                        equals to unlimited retries.
+                                      type: integer
+                                  type: object
+                                replace:
+                                  description: Replace tells the Helm install action to
+                                    re-use the 'ReleaseName', but only if that name is a
+                                    deleted release which remains in the history.
+                                  type: boolean
+                                skipCRDs:
+                                  description: "SkipCRDs tells the Helm install action to
+                              not install any CRDs. By default, CRDs are installed
+                              if not already present. \n Deprecated use CRD policy
+                              (`crds`) attribute with value `Skip` instead."
+                                  type: boolean
+                                timeout:
+                                  description: Timeout is the time to wait for any individual
+                                    Kubernetes operation (like Jobs for hooks) during the
+                                    performance of a Helm install action. Defaults to 'HelmReleaseSpec.Timeout'.
+                                  type: string
+                              type: object
+                            interval:
+                              description: Interval at which to reconcile the Helm release.
+                              type: string
+                            kubeConfig:
+                              description: KubeConfig for reconciling the HelmRelease on
+                                a remote cluster. When specified, KubeConfig takes precedence
+                                over ServiceAccountName.
+                              properties:
+                                secretRef:
+                                  description: SecretRef holds the name to a secret that
+                                    contains a 'value' key with the kubeconfig file as the
+                                    value. It must be in the same namespace as the HelmRelease.
+                                    It is recommended that the kubeconfig is self-contained,
+                                    and the secret is regularly updated if credentials such
+                                    as a cloud-access-token expire. Cloud specific `cmd-path`
+                                    auth helpers will not function without adding binaries
+                                    and credentials to the Pod that is responsible for reconciling
+                                    the HelmRelease.
+                                  properties:
+                                    name:
+                                      description: Name of the referent
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            maxHistory:
+                              description: MaxHistory is the number of revisions saved by
+                                Helm for this HelmRelease. Use '0' for an unlimited number
+                                of revisions; defaults to '10'.
+                              type: integer
+                            postRenderers:
+                              description: PostRenderers holds an array of Helm PostRenderers,
+                                which will be applied in order of their definition.
+                              items:
+                                description: PostRenderer contains a Helm PostRenderer specification.
+                                properties:
+                                  kustomize:
+                                    description: Kustomization to apply as PostRenderer.
+                                    properties:
+                                      images:
+                                        description: Images is a list of (image name, new
+                                          name, new tag or digest) for changing image names,
+                                          tags or digests. This can also be achieved with
+                                          a patch, but this operator is simpler to specify.
+                                        items:
+                                          description: Image contains an image name, a new
+                                            name, a new tag or digest, which will replace
+                                            the original name and tag.
+                                          properties:
+                                            digest:
+                                              description: Digest is the value used to replace
+                                                the original image tag. If digest is present
+                                                NewTag value is ignored.
+                                              type: string
+                                            name:
+                                              description: Name is a tag-less image name.
+                                              type: string
+                                            newName:
+                                              description: NewName is the value used to
+                                                replace the original name.
+                                              type: string
+                                            newTag:
+                                              description: NewTag is the value used to replace
+                                                the original tag.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                      patchesJson6902:
+                                        description: JSON 6902 patches, defined as inline
+                                          YAML objects.
+                                        items:
+                                          description: JSON6902Patch contains a JSON6902
+                                            patch and the target the patch should be applied
+                                            to.
+                                          properties:
+                                            patch:
+                                              description: Patch contains the JSON6902 patch
+                                                document with an array of operation objects.
+                                              items:
+                                                description: JSON6902 is a JSON6902 operation
+                                                  object. https://tools.ietf.org/html/rfc6902#section-4
+                                                properties:
+                                                  from:
+                                                    type: string
+                                                  op:
+                                                    enum:
+                                                      - test
+                                                      - remove
+                                                      - add
+                                                      - replace
+                                                      - move
+                                                      - copy
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  value:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                required:
+                                                  - op
+                                                  - path
+                                                type: object
+                                              type: array
+                                            target:
+                                              description: Target points to the resources
+                                                that the patch document should be applied
+                                                to.
+                                              properties:
+                                                annotationSelector:
+                                                  description: AnnotationSelector is a string
+                                                    that follows the label selection expression
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                                    It matches with the resource annotations.
+                                                  type: string
+                                                group:
+                                                  description: Group is the API group to
+                                                    select resources from. Together with
+                                                    Version and Kind it is capable of unambiguously
+                                                    identifying and/or selecting resources.
+                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                                  type: string
+                                                kind:
+                                                  description: Kind of the API Group to
+                                                    select resources from. Together with
+                                                    Group and Version it is capable of unambiguously
+                                                    identifying and/or selecting resources.
+                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                                  type: string
+                                                labelSelector:
+                                                  description: LabelSelector is a string
+                                                    that follows the label selection expression
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                                    It matches with the resource labels.
+                                                  type: string
+                                                name:
+                                                  description: Name to match resources with.
+                                                  type: string
+                                                namespace:
+                                                  description: Namespace to select resources
+                                                    from.
+                                                  type: string
+                                                version:
+                                                  description: Version of the API Group
+                                                    to select resources from. Together with
+                                                    Group and Kind it is capable of unambiguously
+                                                    identifying and/or selecting resources.
+                                                    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                                  type: string
+                                              type: object
+                                          required:
+                                            - patch
+                                            - target
+                                          type: object
+                                        type: array
+                                      patchesStrategicMerge:
+                                        description: Strategic merge patches, defined as
+                                          inline YAML objects.
+                                        items:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        type: array
+                                    type: object
+                                type: object
+                              type: array
+                            releaseName:
+                              description: ReleaseName used for the Helm release. Defaults
+                                to a composition of '[TargetNamespace-]Name'.
+                              maxLength: 53
+                              minLength: 1
+                              type: string
+                            rollback:
+                              description: Rollback holds the configuration for Helm rollback
+                                actions for this HelmRelease.
+                              properties:
+                                cleanupOnFail:
+                                  description: CleanupOnFail allows deletion of new resources
+                                    created during the Helm rollback action when it fails.
+                                  type: boolean
+                                disableHooks:
+                                  description: DisableHooks prevents hooks from running
+                                    during the Helm rollback action.
+                                  type: boolean
+                                disableWait:
+                                  description: DisableWait disables the waiting for resources
+                                    to be ready after a Helm rollback has been performed.
+                                  type: boolean
+                                disableWaitForJobs:
+                                  description: DisableWaitForJobs disables waiting for jobs
+                                    to complete after a Helm rollback has been performed.
+                                  type: boolean
+                                force:
+                                  description: Force forces resource updates through a replacement
+                                    strategy.
+                                  type: boolean
+                                recreate:
+                                  description: Recreate performs pod restarts for the resource
+                                    if applicable.
+                                  type: boolean
+                                timeout:
+                                  description: Timeout is the time to wait for any individual
+                                    Kubernetes operation (like Jobs for hooks) during the
+                                    performance of a Helm rollback action. Defaults to 'HelmReleaseSpec.Timeout'.
+                                  type: string
+                              type: object
+                            serviceAccountName:
+                              description: The name of the Kubernetes service account to
+                                impersonate when reconciling this HelmRelease.
+                              type: string
+                            storageNamespace:
+                              description: StorageNamespace used for the Helm storage. Defaults
+                                to the namespace of the HelmRelease.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                            suspend:
+                              description: Suspend tells the controller to suspend reconciliation
+                                for this HelmRelease, it does not apply to already started
+                                reconciliations. Defaults to false.
+                              type: boolean
+                            targetNamespace:
+                              description: TargetNamespace to target when performing operations
+                                for the HelmRelease. Defaults to the namespace of the HelmRelease.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                            test:
+                              description: Test holds the configuration for Helm test actions
+                                for this HelmRelease.
+                              properties:
+                                enable:
+                                  description: Enable enables Helm test actions for this
+                                    HelmRelease after an Helm install or upgrade action
+                                    has been performed.
+                                  type: boolean
+                                ignoreFailures:
+                                  description: IgnoreFailures tells the controller to skip
+                                    remediation when the Helm tests are run but fail. Can
+                                    be overwritten for tests run after install or upgrade
+                                    actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                                  type: boolean
+                                timeout:
+                                  description: Timeout is the time to wait for any individual
+                                    Kubernetes operation during the performance of a Helm
+                                    test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                                  type: string
+                              type: object
+                            timeout:
+                              description: Timeout is the time to wait for any individual
+                                Kubernetes operation (like Jobs for hooks) during the performance
+                                of a Helm action. Defaults to '5m0s'.
+                              type: string
+                            uninstall:
+                              description: Uninstall holds the configuration for Helm uninstall
+                                actions for this HelmRelease.
+                              properties:
+                                disableHooks:
+                                  description: DisableHooks prevents hooks from running
+                                    during the Helm rollback action.
+                                  type: boolean
+                                keepHistory:
+                                  description: KeepHistory tells Helm to remove all associated
+                                    resources and mark the release as deleted, but retain
+                                    the release history.
+                                  type: boolean
+                                timeout:
+                                  description: Timeout is the time to wait for any individual
+                                    Kubernetes operation (like Jobs for hooks) during the
+                                    performance of a Helm uninstall action. Defaults to
+                                    'HelmReleaseSpec.Timeout'.
+                                  type: string
+                              type: object
+                            upgrade:
+                              description: Upgrade holds the configuration for Helm upgrade
+                                actions for this HelmRelease.
+                              properties:
+                                cleanupOnFail:
+                                  description: CleanupOnFail allows deletion of new resources
+                                    created during the Helm upgrade action when it fails.
+                                  type: boolean
+                                crds:
+                                  description: "CRDs upgrade CRDs from the Helm Chart's
+                              crds directory according to the CRD upgrade policy provided
+                              here. Valid values are `Skip`, `Create` or `CreateReplace`.
+                              Default is `Skip` and if omitted CRDs are neither installed
+                              nor upgraded. \n Skip: do neither install nor replace
+                              (update) any CRDs. \n Create: new CRDs are created,
+                              existing CRDs are neither updated nor deleted. \n CreateReplace:
+                              new CRDs are created, existing CRDs are updated (replaced)
+                              but not deleted. \n By default, CRDs are not applied
+                              during Helm upgrade action. With this option users can
+                              opt-in to CRD upgrade, which is not (yet) natively supported
+                              by Helm. https://helm.sh/docs/chart_best_practices/custom_resource_definitions."
+                                  enum:
+                                    - Skip
+                                    - Create
+                                    - CreateReplace
+                                  type: string
+                                disableHooks:
+                                  description: DisableHooks prevents hooks from running
+                                    during the Helm upgrade action.
+                                  type: boolean
+                                disableOpenAPIValidation:
+                                  description: DisableOpenAPIValidation prevents the Helm
+                                    upgrade action from validating rendered templates against
+                                    the Kubernetes OpenAPI Schema.
+                                  type: boolean
+                                disableWait:
+                                  description: DisableWait disables the waiting for resources
+                                    to be ready after a Helm upgrade has been performed.
+                                  type: boolean
+                                disableWaitForJobs:
+                                  description: DisableWaitForJobs disables waiting for jobs
+                                    to complete after a Helm upgrade has been performed.
+                                  type: boolean
+                                force:
+                                  description: Force forces resource updates through a replacement
+                                    strategy.
+                                  type: boolean
+                                preserveValues:
+                                  description: PreserveValues will make Helm reuse the last
+                                    release's values and merge in overrides from 'Values'.
+                                    Setting this flag makes the HelmRelease non-declarative.
+                                  type: boolean
+                                remediation:
+                                  description: Remediation holds the remediation configuration
+                                    for when the Helm upgrade action for the HelmRelease
+                                    fails. The default is to not perform any action.
+                                  properties:
+                                    ignoreTestFailures:
+                                      description: IgnoreTestFailures tells the controller
+                                        to skip remediation when the Helm tests are run
+                                        after an upgrade action but fail. Defaults to 'Test.IgnoreFailures'.
+                                      type: boolean
+                                    remediateLastFailure:
+                                      description: RemediateLastFailure tells the controller
+                                        to remediate the last failure, when no retries remain.
+                                        Defaults to 'false' unless 'Retries' is greater
+                                        than 0.
+                                      type: boolean
+                                    retries:
+                                      description: Retries is the number of retries that
+                                        should be attempted on failures before bailing.
+                                        Remediation, using 'Strategy', is performed between
+                                        each attempt. Defaults to '0', a negative integer
+                                        equals to unlimited retries.
+                                      type: integer
+                                    strategy:
+                                      description: Strategy to use for failure remediation.
+                                        Defaults to 'rollback'.
+                                      enum:
+                                        - rollback
+                                        - uninstall
+                                      type: string
+                                  type: object
+                                timeout:
+                                  description: Timeout is the time to wait for any individual
+                                    Kubernetes operation (like Jobs for hooks) during the
+                                    performance of a Helm upgrade action. Defaults to 'HelmReleaseSpec.Timeout'.
+                                  type: string
+                              type: object
+                            values:
+                              description: Values holds the values for this Helm release.
+                              x-kubernetes-preserve-unknown-fields: true
+                            valuesFrom:
+                              description: ValuesFrom holds references to resources containing
+                                Helm values for this HelmRelease, and information about
+                                how they should be merged.
+                              items:
+                                description: ValuesReference contains a reference to a resource
+                                  containing Helm values, and optionally the key they can
+                                  be found at.
+                                properties:
+                                  kind:
+                                    description: Kind of the values referent, valid values
+                                      are ('Secret', 'ConfigMap').
+                                    enum:
+                                      - Secret
+                                      - ConfigMap
+                                    type: string
+                                  name:
+                                    description: Name of the values referent. Should reside
+                                      in the same namespace as the referring resource.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  optional:
+                                    description: Optional marks this ValuesReference as
+                                      optional. When set, a not found error for the values
+                                      reference is ignored, but any ValuesKey, TargetPath
+                                      or transient error will still result in a reconciliation
+                                      failure.
+                                    type: boolean
+                                  targetPath:
+                                    description: TargetPath is the YAML dot notation path
+                                      the value should be merged at. When set, the ValuesKey
+                                      is expected to be a single flat value. Defaults to
+                                      'None', which results in the values getting merged
+                                      at the root.
+                                    type: string
+                                  valuesKey:
+                                    description: ValuesKey is the data key where the values.yaml
+                                      or a specific value can be found at. Defaults to 'values.yaml'.
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              type: array
+                          required:
+                            - chart
+                            - interval
+                          type: object
+                        status:
+                          description: HelmReleaseStatus defines the observed state of a
+                            HelmRelease.
+                          properties:
+                            conditions:
+                              description: Conditions holds the conditions for the HelmRelease.
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            failures:
+                              description: Failures is the reconciliation failure count
+                                against the latest desired state. It is reset after a successful
+                                reconciliation.
+                              format: int64
+                              type: integer
+                            helmChart:
+                              description: HelmChart is the namespaced name of the HelmChart
+                                resource created by the controller for the HelmRelease.
+                              type: string
+                            installFailures:
+                              description: InstallFailures is the install failure count
+                                against the latest desired state. It is reset after a successful
+                                reconciliation.
+                              format: int64
+                              type: integer
+                            lastAppliedRevision:
+                              description: LastAppliedRevision is the revision of the last
+                                successfully applied source.
+                              type: string
+                            lastAttemptedRevision:
+                              description: LastAttemptedRevision is the revision of the
+                                last reconciliation attempt.
+                              type: string
+                            lastAttemptedValuesChecksum:
+                              description: LastAttemptedValuesChecksum is the SHA1 checksum
+                                of the values of the last reconciliation attempt.
+                              type: string
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            lastReleaseRevision:
+                              description: LastReleaseRevision is the revision of the last
+                                successful Helm release.
+                              type: integer
+                            observedGeneration:
+                              description: ObservedGeneration is the last observed generation.
+                              format: int64
+                              type: integer
+                            upgradeFailures:
+                              description: UpgradeFailures is the upgrade failure count
+                                against the latest desired state. It is reset after a successful
+                                reconciliation.
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: helmrepositories.source.toolkit.fluxcd.io
+            spec:
+              group: source.toolkit.fluxcd.io
+              names:
+                kind: HelmRepository
+                listKind: HelmRepositoryList
+                plural: helmrepositories
+                shortNames:
+                  - helmrepo
+                singular: helmrepository
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .spec.url
+                      name: URL
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+                      name: Ready
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+                      name: Status
+                      type: string
+                    - jsonPath: .metadata.creationTimestamp
+                      name: Age
+                      type: date
+                  name: v1beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: HelmRepository is the Schema for the helmrepositories
+                        API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: HelmRepositorySpec defines the reference to a Helm
+                            repository.
+                          properties:
+                            interval:
+                              description: The interval at which to check the upstream for
+                                updates.
+                              type: string
+                            passCredentials:
+                              description: PassCredentials allows the credentials from the
+                                SecretRef to be passed on to a host that does not match
+                                the host as defined in URL. This may be required if the
+                                host of the advertised chart URLs in the index differ from
+                                the defined URL. Enabling this should be done with caution,
+                                as it can potentially result in credentials getting stolen
+                                in a MITM-attack.
+                              type: boolean
+                            secretRef:
+                              description: The name of the secret containing authentication
+                                credentials for the Helm repository. For HTTP/S basic auth
+                                the secret must contain username and password fields. For
+                                TLS the secret must contain a certFile and keyFile, and/or
+                                caCert fields.
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            suspend:
+                              description: This flag tells the controller to suspend the
+                                reconciliation of this source.
+                              type: boolean
+                            timeout:
+                              default: 60s
+                              description: The timeout of index downloading, defaults to
+                                60s.
+                              type: string
+                            url:
+                              description: The Helm repository URL, a valid URL contains
+                                at least a protocol and host.
+                              type: string
+                          required:
+                            - interval
+                            - url
+                          type: object
+                        status:
+                          description: HelmRepositoryStatus defines the observed state of
+                            the HelmRepository.
+                          properties:
+                            artifact:
+                              description: Artifact represents the output of the last successful
+                                repository sync.
+                              properties:
+                                checksum:
+                                  description: Checksum is the SHA1 checksum of the artifact.
+                                  type: string
+                                lastUpdateTime:
+                                  description: LastUpdateTime is the timestamp corresponding
+                                    to the last update of this artifact.
+                                  format: date-time
+                                  type: string
+                                path:
+                                  description: Path is the relative file path of this artifact.
+                                  type: string
+                                revision:
+                                  description: Revision is a human readable identifier traceable
+                                    in the origin source system. It can be a Git commit
+                                    SHA, Git tag, a Helm index timestamp, a Helm chart version,
+                                    etc.
+                                  type: string
+                                url:
+                                  description: URL is the HTTP address of this artifact.
+                                  type: string
+                              required:
+                                - path
+                                - url
+                              type: object
+                            conditions:
+                              description: Conditions holds the conditions for the HelmRepository.
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            observedGeneration:
+                              description: ObservedGeneration is the last observed generation.
+                              format: int64
+                              type: integer
+                            url:
+                              description: URL is the download link for the last index fetched.
+                              type: string
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: imagepolicies.image.toolkit.fluxcd.io
+            spec:
+              group: image.toolkit.fluxcd.io
+              names:
+                kind: ImagePolicy
+                listKind: ImagePolicyList
+                plural: imagepolicies
+                singular: imagepolicy
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .status.latestImage
+                      name: LatestImage
+                      type: string
+                  name: v1alpha1
+                  schema:
+                    openAPIV3Schema:
+                      description: ImagePolicy is the Schema for the imagepolicies API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImagePolicySpec defines the parameters for calculating
+                            the ImagePolicy
+                          properties:
+                            filterTags:
+                              description: FilterTags enables filtering for only a subset
+                                of tags based on a set of rules. If no rules are provided,
+                                all the tags from the repository will be ordered and compared.
+                              properties:
+                                extract:
+                                  description: Extract allows a capture group to be extracted
+                                    from the specified regular expression pattern, useful
+                                    before tag evaluation.
+                                  type: string
+                                pattern:
+                                  description: Pattern specifies a regular expression pattern
+                                    used to filter for image tags.
+                                  type: string
+                              type: object
+                            imageRepositoryRef:
+                              description: ImageRepositoryRef points at the object specifying
+                                the image being scanned
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            policy:
+                              description: Policy gives the particulars of the policy to
+                                be followed in selecting the most recent image
+                              properties:
+                                alphabetical:
+                                  description: Alphabetical set of rules to use for alphabetical
+                                    ordering of the tags.
+                                  properties:
+                                    order:
+                                      default: asc
+                                      description: Order specifies the sorting order of
+                                        the tags. Given the letters of the alphabet as tags,
+                                        ascending order would select Z, and descending order
+                                        would select A.
+                                      enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                  type: object
+                                numerical:
+                                  description: Numerical set of rules to use for numerical
+                                    ordering of the tags.
+                                  properties:
+                                    order:
+                                      default: asc
+                                      description: Order specifies the sorting order of
+                                        the tags. Given the integer values from 0 to 9 as
+                                        tags, ascending order would select 9, and descending
+                                        order would select 0.
+                                      enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                  type: object
+                                semver:
+                                  description: SemVer gives a semantic version range to
+                                    check against the tags available.
+                                  properties:
+                                    range:
+                                      description: Range gives a semver range for the image
+                                        tag; the highest version within the range that's
+                                        a tag yields the latest image.
+                                      type: string
+                                  required:
+                                    - range
+                                  type: object
+                              type: object
+                          required:
+                            - imageRepositoryRef
+                            - policy
+                          type: object
+                        status:
+                          description: ImagePolicyStatus defines the observed state of ImagePolicy
+                          properties:
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            latestImage:
+                              description: LatestImage gives the first in the list of images
+                                scanned by the image repository, when filtered and ordered
+                                according to the policy.
+                              type: string
+                            observedGeneration:
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: false
+                  subresources:
+                    status: {}
+                - additionalPrinterColumns:
+                    - jsonPath: .status.latestImage
+                      name: LatestImage
+                      type: string
+                  name: v1alpha2
+                  schema:
+                    openAPIV3Schema:
+                      description: ImagePolicy is the Schema for the imagepolicies API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImagePolicySpec defines the parameters for calculating
+                            the ImagePolicy
+                          properties:
+                            filterTags:
+                              description: FilterTags enables filtering for only a subset
+                                of tags based on a set of rules. If no rules are provided,
+                                all the tags from the repository will be ordered and compared.
+                              properties:
+                                extract:
+                                  description: Extract allows a capture group to be extracted
+                                    from the specified regular expression pattern, useful
+                                    before tag evaluation.
+                                  type: string
+                                pattern:
+                                  description: Pattern specifies a regular expression pattern
+                                    used to filter for image tags.
+                                  type: string
+                              type: object
+                            imageRepositoryRef:
+                              description: ImageRepositoryRef points at the object specifying
+                                the image being scanned
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            policy:
+                              description: Policy gives the particulars of the policy to
+                                be followed in selecting the most recent image
+                              properties:
+                                alphabetical:
+                                  description: Alphabetical set of rules to use for alphabetical
+                                    ordering of the tags.
+                                  properties:
+                                    order:
+                                      default: asc
+                                      description: Order specifies the sorting order of
+                                        the tags. Given the letters of the alphabet as tags,
+                                        ascending order would select Z, and descending order
+                                        would select A.
+                                      enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                  type: object
+                                numerical:
+                                  description: Numerical set of rules to use for numerical
+                                    ordering of the tags.
+                                  properties:
+                                    order:
+                                      default: asc
+                                      description: Order specifies the sorting order of
+                                        the tags. Given the integer values from 0 to 9 as
+                                        tags, ascending order would select 9, and descending
+                                        order would select 0.
+                                      enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                  type: object
+                                semver:
+                                  description: SemVer gives a semantic version range to
+                                    check against the tags available.
+                                  properties:
+                                    range:
+                                      description: Range gives a semver range for the image
+                                        tag; the highest version within the range that's
+                                        a tag yields the latest image.
+                                      type: string
+                                  required:
+                                    - range
+                                  type: object
+                              type: object
+                          required:
+                            - imageRepositoryRef
+                            - policy
+                          type: object
+                        status:
+                          description: ImagePolicyStatus defines the observed state of ImagePolicy
+                          properties:
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            latestImage:
+                              description: LatestImage gives the first in the list of images
+                                scanned by the image repository, when filtered and ordered
+                                according to the policy.
+                              type: string
+                            observedGeneration:
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: false
+                  subresources:
+                    status: {}
+                - additionalPrinterColumns:
+                    - jsonPath: .status.latestImage
+                      name: LatestImage
+                      type: string
+                  name: v1beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: ImagePolicy is the Schema for the imagepolicies API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImagePolicySpec defines the parameters for calculating
+                            the ImagePolicy
+                          properties:
+                            filterTags:
+                              description: FilterTags enables filtering for only a subset
+                                of tags based on a set of rules. If no rules are provided,
+                                all the tags from the repository will be ordered and compared.
+                              properties:
+                                extract:
+                                  description: Extract allows a capture group to be extracted
+                                    from the specified regular expression pattern, useful
+                                    before tag evaluation.
+                                  type: string
+                                pattern:
+                                  description: Pattern specifies a regular expression pattern
+                                    used to filter for image tags.
+                                  type: string
+                              type: object
+                            imageRepositoryRef:
+                              description: ImageRepositoryRef points at the object specifying
+                                the image being scanned
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            policy:
+                              description: Policy gives the particulars of the policy to
+                                be followed in selecting the most recent image
+                              properties:
+                                alphabetical:
+                                  description: Alphabetical set of rules to use for alphabetical
+                                    ordering of the tags.
+                                  properties:
+                                    order:
+                                      default: asc
+                                      description: Order specifies the sorting order of
+                                        the tags. Given the letters of the alphabet as tags,
+                                        ascending order would select Z, and descending order
+                                        would select A.
+                                      enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                  type: object
+                                numerical:
+                                  description: Numerical set of rules to use for numerical
+                                    ordering of the tags.
+                                  properties:
+                                    order:
+                                      default: asc
+                                      description: Order specifies the sorting order of
+                                        the tags. Given the integer values from 0 to 9 as
+                                        tags, ascending order would select 9, and descending
+                                        order would select 0.
+                                      enum:
+                                        - asc
+                                        - desc
+                                      type: string
+                                  type: object
+                                semver:
+                                  description: SemVer gives a semantic version range to
+                                    check against the tags available.
+                                  properties:
+                                    range:
+                                      description: Range gives a semver range for the image
+                                        tag; the highest version within the range that's
+                                        a tag yields the latest image.
+                                      type: string
+                                  required:
+                                    - range
+                                  type: object
+                              type: object
+                          required:
+                            - imageRepositoryRef
+                            - policy
+                          type: object
+                        status:
+                          description: ImagePolicyStatus defines the observed state of ImagePolicy
+                          properties:
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            latestImage:
+                              description: LatestImage gives the first in the list of images
+                                scanned by the image repository, when filtered and ordered
+                                according to the policy.
+                              type: string
+                            observedGeneration:
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: imagerepositories.image.toolkit.fluxcd.io
+            spec:
+              group: image.toolkit.fluxcd.io
+              names:
+                kind: ImageRepository
+                listKind: ImageRepositoryList
+                plural: imagerepositories
+                singular: imagerepository
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .status.lastScanResult.scanTime
+                      name: Last scan
+                      type: string
+                    - jsonPath: .status.lastScanResult.tagCount
+                      name: Tags
+                      type: string
+                  name: v1alpha1
+                  schema:
+                    openAPIV3Schema:
+                      description: ImageRepository is the Schema for the imagerepositories
+                        API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImageRepositorySpec defines the parameters for scanning
+                            an image repository, e.g., `fluxcd/flux`.
+                          properties:
+                            certSecretRef:
+                              description: "CertSecretRef can be given the name of a secret
+                          containing either or both of \n  - a PEM-encoded client
+                          certificate (`certFile`) and private  key (`keyFile`);  -
+                          a PEM-encoded CA certificate (`caFile`) \n  and whichever
+                          are supplied, will be used for connecting to the  registry.
+                          The client cert and key are useful if you are  authenticating
+                          with a certificate; the CA cert is useful if  you are using
+                          a self-signed server certificate."
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            image:
+                              description: Image is the name of the image repository
+                              type: string
+                            interval:
+                              description: Interval is the length of time to wait between
+                                scans of the image repository.
+                              type: string
+                            secretRef:
+                              description: SecretRef can be given the name of a secret containing
+                                credentials to use for the image registry. The secret should
+                                be created with `kubectl create secret docker-registry`,
+                                or the equivalent.
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            suspend:
+                              description: This flag tells the controller to suspend subsequent
+                                image scans. It does not apply to already started scans.
+                                Defaults to false.
+                              type: boolean
+                            timeout:
+                              description: Timeout for image scanning. Defaults to 'Interval'
+                                duration.
+                              type: string
+                          type: object
+                        status:
+                          description: ImageRepositoryStatus defines the observed state
+                            of ImageRepository
+                          properties:
+                            canonicalImageName:
+                              description: CanonicalName is the name of the image repository
+                                with all the implied bits made explicit; e.g., `docker.io/library/alpine`
+                                rather than `alpine`.
+                              type: string
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            lastScanResult:
+                              description: LastScanResult contains the number of fetched
+                                tags.
+                              properties:
+                                scanTime:
+                                  format: date-time
+                                  type: string
+                                tagCount:
+                                  type: integer
+                              required:
+                                - tagCount
+                              type: object
+                            observedGeneration:
+                              description: ObservedGeneration is the last reconciled generation.
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: false
+                  subresources:
+                    status: {}
+                - additionalPrinterColumns:
+                    - jsonPath: .status.lastScanResult.scanTime
+                      name: Last scan
+                      type: string
+                    - jsonPath: .status.lastScanResult.tagCount
+                      name: Tags
+                      type: string
+                  name: v1alpha2
+                  schema:
+                    openAPIV3Schema:
+                      description: ImageRepository is the Schema for the imagerepositories
+                        API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImageRepositorySpec defines the parameters for scanning
+                            an image repository, e.g., `fluxcd/flux`.
+                          properties:
+                            certSecretRef:
+                              description: "CertSecretRef can be given the name of a secret
+                          containing either or both of \n  - a PEM-encoded client
+                          certificate (`certFile`) and private  key (`keyFile`);  -
+                          a PEM-encoded CA certificate (`caFile`) \n  and whichever
+                          are supplied, will be used for connecting to the  registry.
+                          The client cert and key are useful if you are  authenticating
+                          with a certificate; the CA cert is useful if  you are using
+                          a self-signed server certificate."
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            image:
+                              description: Image is the name of the image repository
+                              type: string
+                            interval:
+                              description: Interval is the length of time to wait between
+                                scans of the image repository.
+                              type: string
+                            secretRef:
+                              description: SecretRef can be given the name of a secret containing
+                                credentials to use for the image registry. The secret should
+                                be created with `kubectl create secret docker-registry`,
+                                or the equivalent.
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            suspend:
+                              description: This flag tells the controller to suspend subsequent
+                                image scans. It does not apply to already started scans.
+                                Defaults to false.
+                              type: boolean
+                            timeout:
+                              description: Timeout for image scanning. Defaults to 'Interval'
+                                duration.
+                              type: string
+                          type: object
+                        status:
+                          description: ImageRepositoryStatus defines the observed state
+                            of ImageRepository
+                          properties:
+                            canonicalImageName:
+                              description: CanonicalName is the name of the image repository
+                                with all the implied bits made explicit; e.g., `docker.io/library/alpine`
+                                rather than `alpine`.
+                              type: string
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            lastScanResult:
+                              description: LastScanResult contains the number of fetched
+                                tags.
+                              properties:
+                                scanTime:
+                                  format: date-time
+                                  type: string
+                                tagCount:
+                                  type: integer
+                              required:
+                                - tagCount
+                              type: object
+                            observedGeneration:
+                              description: ObservedGeneration is the last reconciled generation.
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: false
+                  subresources:
+                    status: {}
+                - additionalPrinterColumns:
+                    - jsonPath: .status.lastScanResult.scanTime
+                      name: Last scan
+                      type: string
+                    - jsonPath: .status.lastScanResult.tagCount
+                      name: Tags
+                      type: string
+                  name: v1beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: ImageRepository is the Schema for the imagerepositories
+                        API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImageRepositorySpec defines the parameters for scanning
+                            an image repository, e.g., `fluxcd/flux`.
+                          properties:
+                            certSecretRef:
+                              description: "CertSecretRef can be given the name of a secret
+                          containing either or both of \n  - a PEM-encoded client
+                          certificate (`certFile`) and private  key (`keyFile`);  -
+                          a PEM-encoded CA certificate (`caFile`) \n  and whichever
+                          are supplied, will be used for connecting to the  registry.
+                          The client cert and key are useful if you are  authenticating
+                          with a certificate; the CA cert is useful if  you are using
+                          a self-signed server certificate."
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            image:
+                              description: Image is the name of the image repository
+                              type: string
+                            interval:
+                              description: Interval is the length of time to wait between
+                                scans of the image repository.
+                              type: string
+                            secretRef:
+                              description: SecretRef can be given the name of a secret containing
+                                credentials to use for the image registry. The secret should
+                                be created with `kubectl create secret docker-registry`,
+                                or the equivalent.
+                              properties:
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            suspend:
+                              description: This flag tells the controller to suspend subsequent
+                                image scans. It does not apply to already started scans.
+                                Defaults to false.
+                              type: boolean
+                            timeout:
+                              description: Timeout for image scanning. Defaults to 'Interval'
+                                duration.
+                              type: string
+                          type: object
+                        status:
+                          description: ImageRepositoryStatus defines the observed state
+                            of ImageRepository
+                          properties:
+                            canonicalImageName:
+                              description: CanonicalName is the name of the image repository
+                                with all the implied bits made explicit; e.g., `docker.io/library/alpine`
+                                rather than `alpine`.
+                              type: string
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            lastScanResult:
+                              description: LastScanResult contains the number of fetched
+                                tags.
+                              properties:
+                                scanTime:
+                                  format: date-time
+                                  type: string
+                                tagCount:
+                                  type: integer
+                              required:
+                                - tagCount
+                              type: object
+                            observedGeneration:
+                              description: ObservedGeneration is the last reconciled generation.
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: imageupdateautomations.image.toolkit.fluxcd.io
+            spec:
+              group: image.toolkit.fluxcd.io
+              names:
+                kind: ImageUpdateAutomation
+                listKind: ImageUpdateAutomationList
+                plural: imageupdateautomations
+                singular: imageupdateautomation
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .status.lastAutomationRunTime
+                      name: Last run
+                      type: string
+                  name: v1alpha1
+                  schema:
+                    openAPIV3Schema:
+                      description: ImageUpdateAutomation is the Schema for the imageupdateautomations
+                        API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImageUpdateAutomationSpec defines the desired state
+                            of ImageUpdateAutomation
+                          properties:
+                            checkout:
+                              description: Checkout gives the parameters for cloning the
+                                git repository, ready to make changes.
+                              properties:
+                                branch:
+                                  description: Branch gives the branch to clone from the
+                                    git repository. If `.spec.push` is not supplied, commits
+                                    will also be pushed to this branch.
+                                  type: string
+                                gitRepositoryRef:
+                                  description: GitRepositoryRef refers to the resource giving
+                                    access details to a git repository to update files in.
+                                  properties:
+                                    name:
+                                      description: Name of the referent
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - branch
+                                - gitRepositoryRef
+                              type: object
+                            commit:
+                              description: Commit specifies how to commit to the git repository.
+                              properties:
+                                authorEmail:
+                                  description: AuthorEmail gives the email to provide when
+                                    making a commit
+                                  type: string
+                                authorName:
+                                  description: AuthorName gives the name to provide when
+                                    making a commit
+                                  type: string
+                                messageTemplate:
+                                  description: MessageTemplate provides a template for the
+                                    commit message, into which will be interpolated the
+                                    details of the change made.
+                                  type: string
+                                signingKey:
+                                  description: SigningKey provides the option to sign commits
+                                    with a GPG key
+                                  properties:
+                                    secretRef:
+                                      description: SecretRef holds the name to a secret
+                                        that contains a 'git.asc' key corresponding to the
+                                        ASCII Armored file containing the GPG signing keypair
+                                        as the value. It must be in the same namespace as
+                                        the ImageUpdateAutomation.
+                                      properties:
+                                        name:
+                                          description: Name of the referent
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                              required:
+                                - authorEmail
+                                - authorName
+                              type: object
+                            interval:
+                              description: Interval gives an lower bound for how often the
+                                automation run should be attempted.
+                              type: string
+                            push:
+                              description: Push specifies how and where to push commits
+                                made by the automation. If missing, commits are pushed (back)
+                                to `.spec.checkout.branch`.
+                              properties:
+                                branch:
+                                  description: Branch specifies that commits should be pushed
+                                    to the branch named. The branch is created using `.spec.checkout.branch`
+                                    as the starting point, if it doesn't already exist.
+                                  type: string
+                              required:
+                                - branch
+                              type: object
+                            suspend:
+                              description: Suspend tells the controller to not run this
+                                automation, until it is unset (or set to false). Defaults
+                                to false.
+                              type: boolean
+                            update:
+                              default:
+                                strategy: Setters
+                              description: Update gives the specification for how to update
+                                the files in the repository. This can be left empty, to
+                                use the default value.
+                              properties:
+                                path:
+                                  description: Path to the directory containing the manifests
+                                    to be updated. Defaults to 'None', which translates
+                                    to the root path of the GitRepositoryRef.
+                                  type: string
+                                strategy:
+                                  default: Setters
+                                  description: Strategy names the strategy to be used.
+                                  enum:
+                                    - Setters
+                                  type: string
+                              required:
+                                - strategy
+                              type: object
+                          required:
+                            - checkout
+                            - commit
+                            - interval
+                          type: object
+                        status:
+                          description: ImageUpdateAutomationStatus defines the observed
+                            state of ImageUpdateAutomation
+                          properties:
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastAutomationRunTime:
+                              description: LastAutomationRunTime records the last time the
+                                controller ran this automation through to completion (even
+                                if no updates were made).
+                              format: date-time
+                              type: string
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            lastPushCommit:
+                              description: LastPushCommit records the SHA1 of the last commit
+                                made by the controller, for this automation object
+                              type: string
+                            lastPushTime:
+                              description: LastPushTime records the time of the last pushed
+                                change.
+                              format: date-time
+                              type: string
+                            observedGeneration:
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: false
+                  subresources:
+                    status: {}
+                - additionalPrinterColumns:
+                    - jsonPath: .status.lastAutomationRunTime
+                      name: Last run
+                      type: string
+                  name: v1alpha2
+                  schema:
+                    openAPIV3Schema:
+                      description: ImageUpdateAutomation is the Schema for the imageupdateautomations
+                        API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImageUpdateAutomationSpec defines the desired state
+                            of ImageUpdateAutomation
+                          properties:
+                            git:
+                              description: GitSpec contains all the git-specific definitions.
+                                This is technically optional, but in practice mandatory
+                                until there are other kinds of source allowed.
+                              properties:
+                                checkout:
+                                  description: Checkout gives the parameters for cloning
+                                    the git repository, ready to make changes. If not present,
+                                    the `spec.ref` field from the referenced `GitRepository`
+                                    or its default will be used.
+                                  properties:
+                                    ref:
+                                      description: Reference gives a branch, tag or commit
+                                        to clone from the Git repository.
+                                      properties:
+                                        branch:
+                                          default: master
+                                          description: The Git branch to checkout, defaults
+                                            to master.
+                                          type: string
+                                        commit:
+                                          description: The Git commit SHA to checkout, if
+                                            specified Tag filters will be ignored.
+                                          type: string
+                                        semver:
+                                          description: The Git tag semver expression, takes
+                                            precedence over Tag.
+                                          type: string
+                                        tag:
+                                          description: The Git tag to checkout, takes precedence
+                                            over Branch.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - ref
+                                  type: object
+                                commit:
+                                  description: Commit specifies how to commit to the git
+                                    repository.
+                                  properties:
+                                    author:
+                                      description: Author gives the email and optionally
+                                        the name to use as the author of commits.
+                                      properties:
+                                        email:
+                                          description: Email gives the email to provide
+                                            when making a commit.
+                                          type: string
+                                        name:
+                                          description: Name gives the name to provide when
+                                            making a commit.
+                                          type: string
+                                      required:
+                                        - email
+                                      type: object
+                                    messageTemplate:
+                                      description: MessageTemplate provides a template for
+                                        the commit message, into which will be interpolated
+                                        the details of the change made.
+                                      type: string
+                                    signingKey:
+                                      description: SigningKey provides the option to sign
+                                        commits with a GPG key
+                                      properties:
+                                        secretRef:
+                                          description: SecretRef holds the name to a secret
+                                            that contains a 'git.asc' key corresponding
+                                            to the ASCII Armored file containing the GPG
+                                            signing keypair as the value. It must be in
+                                            the same namespace as the ImageUpdateAutomation.
+                                          properties:
+                                            name:
+                                              description: Name of the referent
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                      type: object
+                                  required:
+                                    - author
+                                  type: object
+                                push:
+                                  description: Push specifies how and where to push commits
+                                    made by the automation. If missing, commits are pushed
+                                    (back) to `.spec.checkout.branch` or its default.
+                                  properties:
+                                    branch:
+                                      description: Branch specifies that commits should
+                                        be pushed to the branch named. The branch is created
+                                        using `.spec.checkout.branch` as the starting point,
+                                        if it doesn't already exist.
+                                      type: string
+                                  required:
+                                    - branch
+                                  type: object
+                              required:
+                                - commit
+                              type: object
+                            interval:
+                              description: Interval gives an lower bound for how often the
+                                automation run should be attempted.
+                              type: string
+                            sourceRef:
+                              description: SourceRef refers to the resource giving access
+                                details to a git repository.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent
+                                  type: string
+                                kind:
+                                  default: GitRepository
+                                  description: Kind of the referent
+                                  enum:
+                                    - GitRepository
+                                  type: string
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            suspend:
+                              description: Suspend tells the controller to not run this
+                                automation, until it is unset (or set to false). Defaults
+                                to false.
+                              type: boolean
+                            update:
+                              default:
+                                strategy: Setters
+                              description: Update gives the specification for how to update
+                                the files in the repository. This can be left empty, to
+                                use the default value.
+                              properties:
+                                path:
+                                  description: Path to the directory containing the manifests
+                                    to be updated. Defaults to 'None', which translates
+                                    to the root path of the GitRepositoryRef.
+                                  type: string
+                                strategy:
+                                  default: Setters
+                                  description: Strategy names the strategy to be used.
+                                  enum:
+                                    - Setters
+                                  type: string
+                              required:
+                                - strategy
+                              type: object
+                          required:
+                            - interval
+                            - sourceRef
+                          type: object
+                        status:
+                          description: ImageUpdateAutomationStatus defines the observed
+                            state of ImageUpdateAutomation
+                          properties:
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastAutomationRunTime:
+                              description: LastAutomationRunTime records the last time the
+                                controller ran this automation through to completion (even
+                                if no updates were made).
+                              format: date-time
+                              type: string
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            lastPushCommit:
+                              description: LastPushCommit records the SHA1 of the last commit
+                                made by the controller, for this automation object
+                              type: string
+                            lastPushTime:
+                              description: LastPushTime records the time of the last pushed
+                                change.
+                              format: date-time
+                              type: string
+                            observedGeneration:
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: false
+                  subresources:
+                    status: {}
+                - additionalPrinterColumns:
+                    - jsonPath: .status.lastAutomationRunTime
+                      name: Last run
+                      type: string
+                  name: v1beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: ImageUpdateAutomation is the Schema for the imageupdateautomations
+                        API
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: ImageUpdateAutomationSpec defines the desired state
+                            of ImageUpdateAutomation
+                          properties:
+                            git:
+                              description: GitSpec contains all the git-specific definitions.
+                                This is technically optional, but in practice mandatory
+                                until there are other kinds of source allowed.
+                              properties:
+                                checkout:
+                                  description: Checkout gives the parameters for cloning
+                                    the git repository, ready to make changes. If not present,
+                                    the `spec.ref` field from the referenced `GitRepository`
+                                    or its default will be used.
+                                  properties:
+                                    ref:
+                                      description: Reference gives a branch, tag or commit
+                                        to clone from the Git repository.
+                                      properties:
+                                        branch:
+                                          default: master
+                                          description: The Git branch to checkout, defaults
+                                            to master.
+                                          type: string
+                                        commit:
+                                          description: The Git commit SHA to checkout, if
+                                            specified Tag filters will be ignored.
+                                          type: string
+                                        semver:
+                                          description: The Git tag semver expression, takes
+                                            precedence over Tag.
+                                          type: string
+                                        tag:
+                                          description: The Git tag to checkout, takes precedence
+                                            over Branch.
+                                          type: string
+                                      type: object
+                                  required:
+                                    - ref
+                                  type: object
+                                commit:
+                                  description: Commit specifies how to commit to the git
+                                    repository.
+                                  properties:
+                                    author:
+                                      description: Author gives the email and optionally
+                                        the name to use as the author of commits.
+                                      properties:
+                                        email:
+                                          description: Email gives the email to provide
+                                            when making a commit.
+                                          type: string
+                                        name:
+                                          description: Name gives the name to provide when
+                                            making a commit.
+                                          type: string
+                                      required:
+                                        - email
+                                      type: object
+                                    messageTemplate:
+                                      description: MessageTemplate provides a template for
+                                        the commit message, into which will be interpolated
+                                        the details of the change made.
+                                      type: string
+                                    signingKey:
+                                      description: SigningKey provides the option to sign
+                                        commits with a GPG key
+                                      properties:
+                                        secretRef:
+                                          description: SecretRef holds the name to a secret
+                                            that contains a 'git.asc' key corresponding
+                                            to the ASCII Armored file containing the GPG
+                                            signing keypair as the value. It must be in
+                                            the same namespace as the ImageUpdateAutomation.
+                                          properties:
+                                            name:
+                                              description: Name of the referent
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                      type: object
+                                  required:
+                                    - author
+                                  type: object
+                                push:
+                                  description: Push specifies how and where to push commits
+                                    made by the automation. If missing, commits are pushed
+                                    (back) to `.spec.checkout.branch` or its default.
+                                  properties:
+                                    branch:
+                                      description: Branch specifies that commits should
+                                        be pushed to the branch named. The branch is created
+                                        using `.spec.checkout.branch` as the starting point,
+                                        if it doesn't already exist.
+                                      type: string
+                                  required:
+                                    - branch
+                                  type: object
+                              required:
+                                - commit
+                              type: object
+                            interval:
+                              description: Interval gives an lower bound for how often the
+                                automation run should be attempted.
+                              type: string
+                            sourceRef:
+                              description: SourceRef refers to the resource giving access
+                                details to a git repository.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent
+                                  type: string
+                                kind:
+                                  default: GitRepository
+                                  description: Kind of the referent
+                                  enum:
+                                    - GitRepository
+                                  type: string
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            suspend:
+                              description: Suspend tells the controller to not run this
+                                automation, until it is unset (or set to false). Defaults
+                                to false.
+                              type: boolean
+                            update:
+                              default:
+                                strategy: Setters
+                              description: Update gives the specification for how to update
+                                the files in the repository. This can be left empty, to
+                                use the default value.
+                              properties:
+                                path:
+                                  description: Path to the directory containing the manifests
+                                    to be updated. Defaults to 'None', which translates
+                                    to the root path of the GitRepositoryRef.
+                                  type: string
+                                strategy:
+                                  default: Setters
+                                  description: Strategy names the strategy to be used.
+                                  enum:
+                                    - Setters
+                                  type: string
+                              required:
+                                - strategy
+                              type: object
+                          required:
+                            - interval
+                            - sourceRef
+                          type: object
+                        status:
+                          description: ImageUpdateAutomationStatus defines the observed
+                            state of ImageUpdateAutomation
+                          properties:
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastAutomationRunTime:
+                              description: LastAutomationRunTime records the last time the
+                                controller ran this automation through to completion (even
+                                if no updates were made).
+                              format: date-time
+                              type: string
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            lastPushCommit:
+                              description: LastPushCommit records the SHA1 of the last commit
+                                made by the controller, for this automation object
+                              type: string
+                            lastPushTime:
+                              description: LastPushTime records the time of the last pushed
+                                change.
+                              format: date-time
+                              type: string
+                            observedGeneration:
+                              format: int64
+                              type: integer
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            metadata:
+              annotations:
+                controller-gen.kubebuilder.io/version: v0.5.0
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: kustomizations.kustomize.toolkit.fluxcd.io
+            spec:
+              group: kustomize.toolkit.fluxcd.io
+              names:
+                kind: Kustomization
+                listKind: KustomizationList
+                plural: kustomizations
+                shortNames:
+                  - ks
+                singular: kustomization
+              scope: Namespaced
+              versions:
+                - additionalPrinterColumns:
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+                      name: Ready
+                      type: string
+                    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+                      name: Status
+                      type: string
+                    - jsonPath: .metadata.creationTimestamp
+                      name: Age
+                      type: date
+                  name: v1beta1
+                  schema:
+                    openAPIV3Schema:
+                      description: Kustomization is the Schema for the kustomizations API.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          type: object
+                        spec:
+                          description: KustomizationSpec defines the desired state of a
+                            kustomization.
+                          properties:
+                            decryption:
+                              description: Decrypt Kubernetes secrets before applying them
+                                on the cluster.
+                              properties:
+                                provider:
+                                  description: Provider is the name of the decryption engine.
+                                  enum:
+                                    - sops
+                                  type: string
+                                secretRef:
+                                  description: The secret name containing the private OpenPGP
+                                    keys used for decryption.
+                                  properties:
+                                    name:
+                                      description: Name of the referent
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - provider
+                              type: object
+                            dependsOn:
+                              description: DependsOn may contain a dependency.CrossNamespaceDependencyReference
+                                slice with references to Kustomization resources that must
+                                be ready before this Kustomization can be reconciled.
+                              items:
+                                description: CrossNamespaceDependencyReference holds the
+                                  reference to a dependency.
+                                properties:
+                                  name:
+                                    description: Name holds the name reference of a dependency.
+                                    type: string
+                                  namespace:
+                                    description: Namespace holds the namespace reference
+                                      of a dependency.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            force:
+                              default: false
+                              description: Force instructs the controller to recreate resources
+                                when patching fails due to an immutable field change.
+                              type: boolean
+                            healthChecks:
+                              description: A list of resources to be included in the health
+                                assessment.
+                              items:
+                                description: NamespacedObjectKindReference contains enough
+                                  information to let you locate the typed referenced object
+                                  in any namespace
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent, if not specified
+                                      the Kubernetes preferred version will be used
+                                    type: string
+                                  kind:
+                                    description: Kind of the referent
+                                    type: string
+                                  name:
+                                    description: Name of the referent
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referent, when not specified
+                                      it acts as LocalObjectReference
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              type: array
+                            images:
+                              description: Images is a list of (image name, new name, new
+                                tag or digest) for changing image names, tags or digests.
+                                This can also be achieved with a patch, but this operator
+                                is simpler to specify.
+                              items:
+                                description: Image contains an image name, a new name, a
+                                  new tag or digest, which will replace the original name
+                                  and tag.
+                                properties:
+                                  digest:
+                                    description: Digest is the value used to replace the
+                                      original image tag. If digest is present NewTag value
+                                      is ignored.
+                                    type: string
+                                  name:
+                                    description: Name is a tag-less image name.
+                                    type: string
+                                  newName:
+                                    description: NewName is the value used to replace the
+                                      original name.
+                                    type: string
+                                  newTag:
+                                    description: NewTag is the value used to replace the
+                                      original tag.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            interval:
+                              description: The interval at which to reconcile the Kustomization.
+                              type: string
+                            kubeConfig:
+                              description: The KubeConfig for reconciling the Kustomization
+                                on a remote cluster. When specified, KubeConfig takes precedence
+                                over ServiceAccountName.
+                              properties:
+                                secretRef:
+                                  description: SecretRef holds the name to a secret that
+                                    contains a 'value' key with the kubeconfig file as the
+                                    value. It must be in the same namespace as the Kustomization.
+                                    It is recommended that the kubeconfig is self-contained,
+                                    and the secret is regularly updated if credentials such
+                                    as a cloud-access-token expire. Cloud specific `cmd-path`
+                                    auth helpers will not function without adding binaries
+                                    and credentials to the Pod that is responsible for reconciling
+                                    the Kustomization.
+                                  properties:
+                                    name:
+                                      description: Name of the referent
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            patches:
+                              description: Strategic merge and JSON patches, defined as
+                                inline YAML objects, capable of targeting objects based
+                                on kind, label and annotation selectors.
+                              items:
+                                description: Patch contains either a StrategicMerge or a
+                                  JSON6902 patch, either a file or inline, and the target
+                                  the patch should be applied to.
+                                properties:
+                                  patch:
+                                    description: Patch contains the JSON6902 patch document
+                                      with an array of operation objects.
+                                    type: string
+                                  target:
+                                    description: Target points to the resources that the
+                                      patch document should be applied to.
+                                    properties:
+                                      annotationSelector:
+                                        description: AnnotationSelector is a string that
+                                          follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                          It matches with the resource annotations.
+                                        type: string
+                                      group:
+                                        description: Group is the API group to select resources
+                                          from. Together with Version and Kind it is capable
+                                          of unambiguously identifying and/or selecting
+                                          resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                        type: string
+                                      kind:
+                                        description: Kind of the API Group to select resources
+                                          from. Together with Group and Version it is capable
+                                          of unambiguously identifying and/or selecting
+                                          resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                        type: string
+                                      labelSelector:
+                                        description: LabelSelector is a string that follows
+                                          the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                          It matches with the resource labels.
+                                        type: string
+                                      name:
+                                        description: Name to match resources with.
+                                        type: string
+                                      namespace:
+                                        description: Namespace to select resources from.
+                                        type: string
+                                      version:
+                                        description: Version of the API Group to select
+                                          resources from. Together with Group and Kind it
+                                          is capable of unambiguously identifying and/or
+                                          selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                            patchesJson6902:
+                              description: JSON 6902 patches, defined as inline YAML objects.
+                              items:
+                                description: JSON6902Patch contains a JSON6902 patch and
+                                  the target the patch should be applied to.
+                                properties:
+                                  patch:
+                                    description: Patch contains the JSON6902 patch document
+                                      with an array of operation objects.
+                                    items:
+                                      description: JSON6902 is a JSON6902 operation object.
+                                        https://tools.ietf.org/html/rfc6902#section-4
+                                      properties:
+                                        from:
+                                          type: string
+                                        op:
+                                          enum:
+                                            - test
+                                            - remove
+                                            - add
+                                            - replace
+                                            - move
+                                            - copy
+                                          type: string
+                                        path:
+                                          type: string
+                                        value:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      required:
+                                        - op
+                                        - path
+                                      type: object
+                                    type: array
+                                  target:
+                                    description: Target points to the resources that the
+                                      patch document should be applied to.
+                                    properties:
+                                      annotationSelector:
+                                        description: AnnotationSelector is a string that
+                                          follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                          It matches with the resource annotations.
+                                        type: string
+                                      group:
+                                        description: Group is the API group to select resources
+                                          from. Together with Version and Kind it is capable
+                                          of unambiguously identifying and/or selecting
+                                          resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                        type: string
+                                      kind:
+                                        description: Kind of the API Group to select resources
+                                          from. Together with Group and Version it is capable
+                                          of unambiguously identifying and/or selecting
+                                          resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                        type: string
+                                      labelSelector:
+                                        description: LabelSelector is a string that follows
+                                          the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                          It matches with the resource labels.
+                                        type: string
+                                      name:
+                                        description: Name to match resources with.
+                                        type: string
+                                      namespace:
+                                        description: Namespace to select resources from.
+                                        type: string
+                                      version:
+                                        description: Version of the API Group to select
+                                          resources from. Together with Group and Kind it
+                                          is capable of unambiguously identifying and/or
+                                          selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                        type: string
+                                    type: object
+                                required:
+                                  - patch
+                                  - target
+                                type: object
+                              type: array
+                            patchesStrategicMerge:
+                              description: Strategic merge patches, defined as inline YAML
+                                objects.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            path:
+                              description: Path to the directory containing the kustomization.yaml
+                                file, or the set of plain YAMLs a kustomization.yaml should
+                                be generated for. Defaults to 'None', which translates to
+                                the root path of the SourceRef.
+                              type: string
+                            postBuild:
+                              description: PostBuild describes which actions to perform
+                                on the YAML manifest generated by building the kustomize
+                                overlay.
+                              properties:
+                                substitute:
+                                  additionalProperties:
+                                    type: string
+                                  description: Substitute holds a map of key/value pairs.
+                                    The variables defined in your YAML manifests that match
+                                    any of the keys defined in the map will be substituted
+                                    with the set value. Includes support for bash string
+                                    replacement functions e.g. ${var:=default}, ${var:position}
+                                    and ${var/substring/replacement}.
+                                  type: object
+                                substituteFrom:
+                                  description: SubstituteFrom holds references to ConfigMaps
+                                    and Secrets containing the variables and their values
+                                    to be substituted in the YAML manifests. The ConfigMap
+                                    and the Secret data keys represent the var names and
+                                    they must match the vars declared in the manifests for
+                                    the substitution to happen.
+                                  items:
+                                    description: SubstituteReference contains a reference
+                                      to a resource containing the variables name and value.
+                                    properties:
+                                      kind:
+                                        description: Kind of the values referent, valid
+                                          values are ('Secret', 'ConfigMap').
+                                        enum:
+                                          - Secret
+                                          - ConfigMap
+                                        type: string
+                                      name:
+                                        description: Name of the values referent. Should
+                                          reside in the same namespace as the referring
+                                          resource.
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  type: array
+                              type: object
+                            prune:
+                              description: Prune enables garbage collection.
+                              type: boolean
+                            retryInterval:
+                              description: The interval at which to retry a previously failed
+                                reconciliation. When not specified, the controller uses
+                                the KustomizationSpec.Interval value to retry failures.
+                              type: string
+                            serviceAccountName:
+                              description: The name of the Kubernetes service account to
+                                impersonate when reconciling this Kustomization.
+                              type: string
+                            sourceRef:
+                              description: Reference of the source where the kustomization
+                                file is.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent
+                                  type: string
+                                kind:
+                                  description: Kind of the referent
+                                  enum:
+                                    - GitRepository
+                                    - Bucket
+                                  type: string
+                                name:
+                                  description: Name of the referent
+                                  type: string
+                                namespace:
+                                  description: Namespace of the referent, defaults to the
+                                    Kustomization namespace
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            suspend:
+                              description: This flag tells the controller to suspend subsequent
+                                kustomize executions, it does not apply to already started
+                                executions. Defaults to false.
+                              type: boolean
+                            targetNamespace:
+                              description: TargetNamespace sets or overrides the namespace
+                                in the kustomization.yaml file.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                            timeout:
+                              description: Timeout for validation, apply and health checking
+                                operations. Defaults to 'Interval' duration.
+                              type: string
+                            validation:
+                              description: Validate the Kubernetes objects before applying
+                                them on the cluster. The validation strategy can be 'client'
+                                (local dry-run), 'server' (APIServer dry-run) or 'none'.
+                                When 'Force' is 'true', validation will fallback to 'client'
+                                if set to 'server' because server-side validation is not
+                                supported in this scenario.
+                              enum:
+                                - none
+                                - client
+                                - server
+                              type: string
+                          required:
+                            - interval
+                            - prune
+                            - sourceRef
+                          type: object
+                        status:
+                          description: KustomizationStatus defines the observed state of
+                            a kustomization.
+                          properties:
+                            conditions:
+                              items:
+                                description: "Condition contains details for one aspect
+                            of the current state of this API Resource. --- This struct
+                            is intended for direct use as an array at the field path
+                            .status.conditions.  For example, type FooStatus struct{
+                            \    // Represents the observations of a foo's current
+                            state.     // Known .status.conditions.type are: \"Available\",
+                            \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                            \    // +patchStrategy=merge     // +listType=map     //
+                            +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                            patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                            \n     // other fields }"
+                                properties:
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time the
+                                      condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If
+                                      that is not known, then using the time when the API
+                                      field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human readable message indicating
+                                      details about the transition. This may be an empty
+                                      string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: observedGeneration represents the .metadata.generation
+                                      that the condition was set based upon. For instance,
+                                      if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                                      is 9, the condition is out of date with respect to
+                                      the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: reason contains a programmatic identifier
+                                      indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected
+                                      values and meanings for this field, and whether the
+                                      values are considered a guaranteed API. The value
+                                      should be a CamelCase string. This field may not be
+                                      empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False,
+                                      Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                      --- Many .condition.type values are consistent across
+                                      resources like Available, but because arbitrary conditions
+                                      can be useful (see .node.status.conditions), the ability
+                                      to deconflict is important. The regex it matches is
+                                      (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            lastAppliedRevision:
+                              description: The last successfully applied revision. The revision
+                                format for Git sources is <branch|tag>/<commit-sha>.
+                              type: string
+                            lastAttemptedRevision:
+                              description: LastAttemptedRevision is the revision of the
+                                last reconciliation attempt.
+                              type: string
+                            lastHandledReconcileAt:
+                              description: LastHandledReconcileAt holds the value of the
+                                most recent reconcile request value, so a change can be
+                                detected.
+                              type: string
+                            observedGeneration:
+                              description: ObservedGeneration is the last reconciled generation.
+                              format: int64
+                              type: integer
+                            snapshot:
+                              description: The last successfully applied revision metadata.
+                              properties:
+                                checksum:
+                                  description: The manifests sha1 checksum.
+                                  type: string
+                                entries:
+                                  description: A list of Kubernetes kinds grouped by namespace.
+                                  items:
+                                    description: Snapshot holds the metadata of namespaced
+                                      Kubernetes objects
+                                    properties:
+                                      kinds:
+                                        additionalProperties:
+                                          type: string
+                                        description: The list of Kubernetes kinds.
+                                        type: object
+                                      namespace:
+                                        description: The namespace of this entry.
+                                        type: string
+                                    required:
+                                      - kinds
+                                    type: object
+                                  type: array
+                              required:
+                                - checksum
+                                - entries
+                              type: object
+                          type: object
+                      type: object
+                  served: true
+                  storage: true
+                  subresources:
+                    status: {}
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+                control-plane: controller
+              name: helm-controller
+              namespace: flux-system
+            spec:
+              replicas: 1
+              selector:
+                matchLabels:
+                  app: helm-controller
+              template:
+                metadata:
+                  annotations:
+                    prometheus.io/port: "8080"
+                    prometheus.io/scrape: "true"
+                  labels:
+                    app: helm-controller
+                spec:
+                  containers:
+                    - args:
+                        - --watch-all-namespaces
+                        - --log-level=info
+                        - --log-encoding=json
+                        - --enable-leader-election
+                      env:
+                        - name: RUNTIME_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      image: fluxcd/helm-controller:v0.11.1
+                      imagePullPolicy: IfNotPresent
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: healthz
+                      name: manager
+                      ports:
+                        - containerPort: 8080
+                          name: http-prom
+                        - containerPort: 9440
+                          name: healthz
+                          protocol: TCP
+                      readinessProbe:
+                        httpGet:
+                          path: /readyz
+                          port: healthz
+                      resources:
+                        limits:
+                          cpu: 1000m
+                          memory: 1Gi
+                        requests:
+                          cpu: 100m
+                          memory: 64Mi
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                      volumeMounts:
+                        - mountPath: /tmp
+                          name: temp
+                  serviceAccountName: sa-helm-controller
+                  terminationGracePeriodSeconds: 600
+                  volumes:
+                    - emptyDir: {}
+                      name: temp
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+                control-plane: controller
+              name: image-automation-controller
+              namespace: flux-system
+            spec:
+              replicas: 1
+              selector:
+                matchLabels:
+                  app: image-automation-controller
+              template:
+                metadata:
+                  annotations:
+                    prometheus.io/port: "8080"
+                    prometheus.io/scrape: "true"
+                  labels:
+                    app: image-automation-controller
+                spec:
+                  containers:
+                    - args:
+                        - --events-addr=http://notification-controller/
+                        - --watch-all-namespaces
+                        - --log-level=info
+                        - --log-encoding=json
+                        - --enable-leader-election
+                      env:
+                        - name: RUNTIME_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      image: fluxcd/image-automation-controller:v0.14.0
+                      imagePullPolicy: IfNotPresent
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: healthz
+                      name: manager
+                      ports:
+                        - containerPort: 8080
+                          name: http-prom
+                        - containerPort: 9440
+                          name: healthz
+                          protocol: TCP
+                      readinessProbe:
+                        httpGet:
+                          path: /readyz
+                          port: healthz
+                      resources:
+                        limits:
+                          cpu: 1000m
+                          memory: 1Gi
+                        requests:
+                          cpu: 100m
+                          memory: 64Mi
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                      volumeMounts:
+                        - mountPath: /tmp
+                          name: temp
+                  securityContext:
+                    fsGroup: 1337
+                  serviceAccountName: sa-image-automation-controller
+                  terminationGracePeriodSeconds: 10
+                  volumes:
+                    - emptyDir: {}
+                      name: temp
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+                control-plane: controller
+              name: image-reflector-controller
+              namespace: flux-system
+            spec:
+              replicas: 1
+              selector:
+                matchLabels:
+                  app: image-reflector-controller
+              template:
+                metadata:
+                  annotations:
+                    prometheus.io/port: "8080"
+                    prometheus.io/scrape: "true"
+                  labels:
+                    app: image-reflector-controller
+                spec:
+                  containers:
+                    - args:
+                        - --events-addr=http://notification-controller/
+                        - --watch-all-namespaces
+                        - --log-level=info
+                        - --log-encoding=json
+                        - --enable-leader-election
+                      env:
+                        - name: RUNTIME_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      image: fluxcd/image-reflector-controller:v0.11.0
+                      imagePullPolicy: IfNotPresent
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: healthz
+                      name: manager
+                      ports:
+                        - containerPort: 8080
+                          name: http-prom
+                        - containerPort: 9440
+                          name: healthz
+                          protocol: TCP
+                      readinessProbe:
+                        httpGet:
+                          path: /readyz
+                          port: healthz
+                      resources:
+                        limits:
+                          cpu: 1000m
+                          memory: 1Gi
+                        requests:
+                          cpu: 100m
+                          memory: 64Mi
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                      volumeMounts:
+                        - mountPath: /tmp
+                          name: temp
+                        - mountPath: /data
+                          name: data
+                  securityContext:
+                    fsGroup: 1337
+                  serviceAccountName: sa-image-reflector-controller
+                  terminationGracePeriodSeconds: 10
+                  volumes:
+                    - emptyDir: {}
+                      name: temp
+                    - emptyDir: {}
+                      name: data
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+                control-plane: controller
+              name: kustomize-controller
+              namespace: flux-system
+            spec:
+              replicas: 1
+              selector:
+                matchLabels:
+                  app: kustomize-controller
+              template:
+                metadata:
+                  annotations:
+                    prometheus.io/port: "8080"
+                    prometheus.io/scrape: "true"
+                  labels:
+                    app: kustomize-controller
+                spec:
+                  containers:
+                    - args:
+                        - --events-addr=http://notification-controller/
+                        - --watch-all-namespaces
+                        - --log-level=info
+                        - --log-encoding=json
+                        - --enable-leader-election
+                      env:
+                        - name: RUNTIME_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      image: fluxcd/kustomize-controller:v0.13.1
+                      imagePullPolicy: IfNotPresent
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: healthz
+                      name: manager
+                      ports:
+                        - containerPort: 8080
+                          name: http-prom
+                        - containerPort: 9440
+                          name: healthz
+                          protocol: TCP
+                      readinessProbe:
+                        httpGet:
+                          path: /readyz
+                          port: healthz
+                      resources:
+                        limits:
+                          cpu: 1000m
+                          memory: 1Gi
+                        requests:
+                          cpu: 100m
+                          memory: 64Mi
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                      volumeMounts:
+                        - mountPath: /tmp
+                          name: temp
+                  securityContext:
+                    fsGroup: 1337
+                  serviceAccountName: sa-kustomize-controller
+                  terminationGracePeriodSeconds: 60
+                  volumes:
+                    - emptyDir: {}
+                      name: temp
+          - apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+                control-plane: controller
+              name: flux-source-controller
+              namespace: flux-system
+            spec:
+              replicas: 1
+              selector:
+                matchLabels:
+                  app: source-controller
+              strategy:
+                type: Recreate
+              template:
+                metadata:
+                  annotations:
+                    prometheus.io/port: "8080"
+                    prometheus.io/scrape: "true"
+                  labels:
+                    app: source-controller
+                spec:
+                  containers:
+                    - args:
+                        - --events-addr=http://notification-controller/
+                        - --watch-all-namespaces
+                        - --log-level=info
+                        - --log-encoding=json
+                        - --enable-leader-election
+                        - --storage-path=/data
+                        - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc
+                      env:
+                        - name: RUNTIME_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                      image: fluxcd/source-controller:v0.15.3
+                      imagePullPolicy: IfNotPresent
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: healthz
+                      name: manager
+                      ports:
+                        - containerPort: 9090
+                          name: http
+                        - containerPort: 8080
+                          name: http-prom
+                        - containerPort: 9440
+                          name: healthz
+                      readinessProbe:
+                        httpGet:
+                          path: /
+                          port: http
+                      resources:
+                        limits:
+                          cpu: 1000m
+                          memory: 1Gi
+                        requests:
+                          cpu: 50m
+                          memory: 64Mi
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                      volumeMounts:
+                        - mountPath: /data
+                          name: data
+                        - mountPath: /tmp
+                          name: tmp
+                  securityContext:
+                    fsGroup: 1337
+                  serviceAccountName: sa-source-controller
+                  terminationGracePeriodSeconds: 10
+                  volumes:
+                    - emptyDir: {}
+                      name: data
+                    - emptyDir: {}
+                      name: tmp
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: cluster-reconciler
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: cluster-admin
+            subjects:
+              - kind: ServiceAccount
+                name: sa-kustomize-controller
+                namespace: flux-system
+              - kind: ServiceAccount
+                name: sa-helm-controller
+                namespace: flux-system
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: crd-controller
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: cr-crd-controller
+            subjects:
+              - kind: ServiceAccount
+                name: sa-kustomize-controller
+                namespace: flux-system
+              - kind: ServiceAccount
+                name: sa-helm-controller
+                namespace: flux-system
+              - kind: ServiceAccount
+                name: sa-source-controller
+                namespace: flux-system
+              - kind: ServiceAccount
+                name: sa-notification-controller
+                namespace: flux-system
+              - kind: ServiceAccount
+                name: sa-image-reflector-controller
+                namespace: flux-system
+              - kind: ServiceAccount
+                name: sa-image-automation-controller
+                namespace: flux-system
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: cr-crd-controller
+            rules:
+              - apiGroups:
+                  - source.toolkit.fluxcd.io
+                resources:
+                  - '*'
+                verbs:
+                  - '*'
+              - apiGroups:
+                  - kustomize.toolkit.fluxcd.io
+                resources:
+                  - '*'
+                verbs:
+                  - '*'
+              - apiGroups:
+                  - helm.toolkit.fluxcd.io
+                resources:
+                  - '*'
+                verbs:
+                  - '*'
+              - apiGroups:
+                  - image.toolkit.fluxcd.io
+                resources:
+                  - '*'
+                verbs:
+                  - '*'
+              - apiGroups:
+                  - ""
+                resources:
+                  - secrets
+                verbs:
+                  - get
+                  - list
+                  - watch
+              - apiGroups:
+                  - ""
+                resources:
+                  - events
+                verbs:
+                  - create
+                  - patch
+              - apiGroups:
+                  - ""
+                resources:
+                  - configmaps
+                  - configmaps/status
+                verbs:
+                  - get
+                  - list
+                  - watch
+                  - create
+                  - update
+                  - patch
+                  - delete
+              - apiGroups:
+                  - coordination.k8s.io
+                resources:
+                  - leases
+                verbs:
+                  - get
+                  - list
+                  - watch
+                  - create
+                  - update
+                  - patch
+                  - delete
+          - apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: sa-helm-controller
+              namespace: flux-system
+          - apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: sa-image-automation-controller
+              namespace: flux-system
+          - apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: sa-image-reflector-controller
+              namespace: flux-system
+          - apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: sa-kustomize-controller
+              namespace: flux-system
+          - apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+              name: sa-source-controller
+              namespace: flux-system
+          - apiVersion: v1
+            kind: Service
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+                control-plane: controller
+              name: source-controller
+              namespace: flux-system
+            spec:
+              ports:
+                - name: http
+                  port: 80
+                  protocol: TCP
+                  targetPort: http
+              selector:
+                app: source-controller
+              type: ClusterIP
+          - apiVersion: v1
+            kind: Service
+            metadata:
+              labels:
+                app.kubernetes.io/instance: flux-system
+                control-plane: controller
+              name: webhook-receiver
+              namespace: flux-system
+            spec:
+              ports:
+                - name: http
+                  port: 80
+                  protocol: TCP
+                  targetPort: http-webhook
+              selector:
+                app: notification-controller
+              type: ClusterIP
+      type: k8s-objects
+  workflow:
+    steps:
+      - name: deploy-control-plane
+        type: apply-application
+      - name: deploy-runtime
+        type: deploy2runtime
+  {{- end }}
+

--- a/charts/vela-core/templates/addon_registry.yaml
+++ b/charts/vela-core/templates/addon_registry.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vela-addon-registry
-  namespace: {{ include "systemDefinitionNamespace" . }}
+  namespace: {{ .Release.Namespace }}
 data:
   registries: '{
   "KubeVela":{

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -131,3 +131,5 @@ test:
   k8s:
     repository: oamdev/alpine-k8s
     tag: 1.18.2
+
+enableFluxcdAddon: false

--- a/e2e/cli.go
+++ b/e2e/cli.go
@@ -80,6 +80,22 @@ func asyncExec(cli string) (*gexec.Session, error) {
 	return session, err
 }
 
+func LongTimeExecWithEnv(cli string, timeout time.Duration, env []string) (string, error) {
+	var output []byte
+	c := strings.Fields(cli)
+	commandName := path.Join(rudrPath, c[0])
+	command := exec.Command(commandName, c[1:]...)
+	command.Env = os.Environ()
+	command.Env = append(command.Env, env...)
+
+	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	if err != nil {
+		return string(output), err
+	}
+	s := session.Wait(timeout)
+	return string(s.Out.Contents()) + string(s.Err.Contents()), nil
+}
+
 // InteractiveExec executes a command with interactive input
 func InteractiveExec(cli string, consoleFn func(*expect.Console)) (string, error) {
 	var output []byte

--- a/references/cmd/cli/main.go
+++ b/references/cmd/cli/main.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/oam-dev/kubevela/apis/types"
+
 	"github.com/oam-dev/kubevela/references/a/preimport"
 	"github.com/oam-dev/kubevela/references/cli"
 )
@@ -28,6 +30,10 @@ import (
 func main() {
 	preimport.ResumeLogging()
 	rand.Seed(time.Now().UnixNano())
+
+	if ns := os.Getenv("DEFAULT_VELA_NS"); len(ns) != 0 {
+		types.DefaultKubeVelaNS = ns
+	}
 
 	command := cli.NewCommand()
 


### PR DESCRIPTION
1. helm install add parameter `-enableFluxcdAddon=true` to enable fluxcd addon by default. eg:
    ```
    helm install --create-namespace -n test-vela kubevela charts/vela-core/ --set multicluster.enabled=true --set systemDefinitionNamespace=test-vela  --wait
    ```
2. vela addon support user-defined KubeVela install namespace. eg: 
    ```
    DEFAULT_VELA_NS=test-vela vela addon list
    ```
Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->