### PR TITLE
Fix: Let versioned  controller uses a separate election locker in one cluster.

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oam-dev/kubevela/pkg/utils/util"
+
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -199,12 +201,14 @@ func main() {
 		}
 	}
 	ctrl.SetLogger(klogr.New())
+
+	leaderElectionID := util.GenerateLeaderElectionID(kubevelaName, controllerArgs.IgnoreAppWithoutControllerRequirement)
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                     scheme,
 		MetricsBindAddress:         metricsAddr,
 		LeaderElection:             enableLeaderElection,
 		LeaderElectionNamespace:    leaderElectionNamespace,
-		LeaderElectionID:           kubevelaName,
+		LeaderElectionID:           leaderElectionID,
 		Port:                       webhookPort,
 		CertDir:                    certDir,
 		HealthProbeBindAddress:     healthAddr,

--- a/pkg/utils/util/factory.go
+++ b/pkg/utils/util/factory.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oam-dev/kubevela/version"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
@@ -34,6 +32,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/oam-dev/kubevela/version"
 )
 
 var defaultCacheDir = filepath.Join(homedir.HomeDir(), ".kube", "http-cache")
@@ -172,5 +172,8 @@ func computeDiscoverCacheDir(parentDir, host string) string {
 
 // GenerateLeaderElectionID returns the Leader Election ID.
 func GenerateLeaderElectionID(name string, versionedDeploy bool) string {
-	return name + "-" + strings.ToLower(strings.ReplaceAll(version.VelaVersion, ".", "z"))
+	if versionedDeploy {
+		return name + "-" + strings.ToLower(strings.ReplaceAll(version.VelaVersion, ".", "-"))
+	}
+	return name
 }

--- a/pkg/utils/util/factory.go
+++ b/pkg/utils/util/factory.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oam-dev/kubevela/version"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
@@ -166,4 +168,9 @@ func computeDiscoverCacheDir(parentDir, host string) string {
 	// now do a simple collapse of non-AZ09 characters.  Collisions are possible but unlikely.  Even if we do collide the problem is short lived
 	safeHost := overlyCautiousIllegalFileCharacters.ReplaceAllString(schemelessHost, "_")
 	return filepath.Join(parentDir, safeHost)
+}
+
+// GenerateLeaderElectionID returns the Leader Election ID.
+func GenerateLeaderElectionID(name string, versionedDeploy bool) string {
+	return name + "-" + strings.ToLower(strings.ReplaceAll(version.VelaVersion, ".", "z"))
 }

--- a/pkg/utils/util/factory_test.go
+++ b/pkg/utils/util/factory_test.go
@@ -8,8 +8,12 @@ import (
 
 func TestGenerateLeaderElectionID(t *testing.T) {
 	version.VelaVersion = "v10.13.0"
-	if id := GenerateLeaderElectionID("kubevela", true); id != "kubevela-v10z13z0" {
-		t.Errorf("id is not as expected(%s != kubevela-v10z13z0)", id)
+	if id := GenerateLeaderElectionID("kubevela", true); id != "kubevela-v10-13-0" {
+		t.Errorf("id is not as expected(%s != kubevela-v10-13-0)", id)
+		return
+	}
+	if id := GenerateLeaderElectionID("kubevela", false); id != "kubevela" {
+		t.Errorf("id is not as expected(%s != kubevela)", id)
 		return
 	}
 }

--- a/pkg/utils/util/factory_test.go
+++ b/pkg/utils/util/factory_test.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/oam-dev/kubevela/version"
+)
+
+func TestGenerateLeaderElectionID(t *testing.T) {
+	version.VelaVersion = "v10.13.0"
+	if id := GenerateLeaderElectionID("kubevela", true); id != "kubevela-v10z13z0" {
+		t.Errorf("id is not as expected(%s != kubevela-v10z13z0)", id)
+		return
+	}
+}

--- a/pkg/utils/util/factory_test.go
+++ b/pkg/utils/util/factory_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (


### PR DESCRIPTION
Signed-off-by: Jian.Li <lj176172@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

 Let versioned  controller uses a separate election locker in one cluster.
I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->