### PR TITLE
Feat: add style and immutable parameters for uischema

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -154,7 +154,7 @@ spec:
         					}
 
         					if v.resources.requests.storage == _|_ {
-        						resources: requests: storage: "1Gi"
+        						resources: requests: storage: "8Gi"
         					}
         					if v.resources.requests.storage != _|_ {
         						resources: requests: storage: v.resources.requests.storage

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -154,7 +154,7 @@ spec:
         					}
 
         					if v.resources.requests.storage == _|_ {
-        						resources: requests: storage: "1Gi"
+        						resources: requests: storage: "8Gi"
         					}
         					if v.resources.requests.storage != _|_ {
         						resources: requests: storage: v.resources.requests.storage

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -127,8 +127,8 @@ type AddonBaseStatus struct {
 type DetailAddonResponse struct {
 	addon.Meta
 
-	APISchema *openapi3.Schema     `json:"schema"`
-	UISchema  []*utils.UIParameter `json:"uiSchema"`
+	APISchema *openapi3.Schema `json:"schema"`
+	UISchema  utils.UISchema   `json:"uiSchema"`
 
 	// More details about the addon, e.g. README
 	Detail       string             `json:"detail,omitempty"`
@@ -346,7 +346,7 @@ type ApplicationStatusResponse struct {
 type ApplicationStatisticsResponse struct {
 	EnvCount      int64 `json:"envCount"`
 	TargetCount   int64 `json:"targetCount"`
-	RevisonCount  int64 `json:"revisonCount"`
+	RevisionCount int64 `json:"revisionCount"`
 	WorkflowCount int64 `json:"workflowCount"`
 }
 

--- a/pkg/apiserver/rest/usecase/application.go
+++ b/pkg/apiserver/rest/usecase/application.go
@@ -1353,7 +1353,7 @@ func (c *applicationUsecaseImpl) Statistics(ctx context.Context, app *model.Appl
 	return &apisv1.ApplicationStatisticsResponse{
 		EnvCount:      int64(len(envbinding)),
 		TargetCount:   int64(len(targetMap)),
-		RevisonCount:  count,
+		RevisionCount: count,
 		WorkflowCount: c.workflowUsecase.CountWorkflow(ctx, app),
 	}, nil
 }

--- a/pkg/apiserver/rest/usecase/definition.go
+++ b/pkg/apiserver/rest/usecase/definition.go
@@ -296,6 +296,9 @@ func patchSchema(defaultSchema, customSchema []*utils.UIParameter) []*utils.UIPa
 			if cusSchema.Additional != nil {
 				dSchema.Additional = cusSchema.Additional
 			}
+			if cusSchema.Style != nil {
+				dSchema.Style = cusSchema.Style
+			}
 		}
 	}
 	sort.Slice(defaultSchema, func(i, j int) bool {

--- a/pkg/apiserver/rest/utils/ui_schema.go
+++ b/pkg/apiserver/rest/utils/ui_schema.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 )
 
+// UISchema ui schema
+type UISchema []*UIParameter
+
 // UIParameter Structured import table simple UI model
 type UIParameter struct {
 	Sort        uint      `json:"sort"`
@@ -29,12 +32,19 @@ type UIParameter struct {
 	Validate    *Validate `json:"validate,omitempty"`
 	JSONKey     string    `json:"jsonKey"`
 	UIType      string    `json:"uiType"`
+	Style       *Style    `json:"style,omitempty"`
 	// means disable parameter in ui
 	Disable                 *bool          `json:"disable,omitempty"`
 	SubParameterGroupOption []GroupOption  `json:"subParameterGroupOption,omitempty"`
 	SubParameters           []*UIParameter `json:"subParameters,omitempty"`
 	AdditionalParameter     *UIParameter   `json:"additionalParameter,omitempty"`
 	Additional              *bool          `json:"additional,omitempty"`
+}
+
+// Style ui style
+type Style struct {
+	// ColSpan the width of a responsive layout
+	ColSpan int `json:"colSpan"`
 }
 
 // GroupOption define multiple data structure composition options.
@@ -53,19 +63,14 @@ type Validate struct {
 	Pattern      string      `json:"pattern,omitempty"`
 	Options      []Option    `json:"options,omitempty"`
 	DefaultValue interface{} `json:"defaultValue,omitempty"`
+	// the parameter cannot be changed twice.
+	Immutable bool `json:"immutable"`
 }
 
 // Option select option
 type Option struct {
 	Label string      `json:"label"`
 	Value interface{} `json:"value"`
-}
-
-// ParseUIParameterFromDefinition cue of parameter in Definitions was analyzed to obtain the form description model.
-func ParseUIParameterFromDefinition(definition []byte) ([]*UIParameter, error) {
-	var params []*UIParameter
-
-	return params, nil
 }
 
 // FirstUpper Sets the first letter of the string to upper.

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -165,7 +165,7 @@ template: {
 						}
 
 						if v.resources.requests.storage == _|_ {
-							resources: requests: storage: "1Gi"
+							resources: requests: storage: "8Gi"
 						}
 						if v.resources.requests.storage != _|_ {
 							resources: requests: storage: v.resources.requests.storage


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

* `immutable`  set the immutable is true, indicates that the parameter cannot be changed.
* `style` support customize the reactive width of the field form.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.