### PR TITLE
Fix: addon store&show complicated parameter  

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -852,6 +852,25 @@ func RenderArgsSecret(addon *InstallPackage, args map[string]interface{}) *unstr
 	return u
 }
 
+// FetchArgsFromSecret fetch addon args from secrets
+func FetchArgsFromSecret(sec *v1.Secret) (map[string]interface{}, error) {
+	res := map[string]interface{}{}
+	if args, ok := sec.Data[AddonParameterDataKey]; ok {
+		err := json.Unmarshal(args, &res)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+
+	// this is backward compatibility code for old way to storage parameter
+	res = make(map[string]interface{}, len(sec.Data))
+	for k, v := range sec.Data {
+		res[k] = string(v)
+	}
+	return res, nil
+}
+
 // Convert2SecName generate addon argument secret name
 func Convert2SecName(name string) string {
 	return addonSecPrefix + name

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -84,6 +83,9 @@ const (
 
 	// DefSchemaName is the addon definition schemas dir name
 	DefSchemaName string = "schemas"
+
+	// AddonParameterDataKey is the key of parameter in addon args secrets
+	AddonParameterDataKey string = "addonParameterDataKey"
 )
 
 // ParameterFileName is the addon resources/parameter.cue file name
@@ -828,14 +830,9 @@ func Convert2AppName(name string) string {
 
 // RenderArgsSecret render addon enable argument to secret
 func RenderArgsSecret(addon *InstallPackage, args map[string]interface{}) *unstructured.Unstructured {
-	data := make(map[string]string)
-	for k, v := range args {
-		switch v := v.(type) {
-		case bool:
-			data[k] = strconv.FormatBool(v)
-		default:
-			data[k] = fmt.Sprintf("%v", v)
-		}
+	argsByte, err := json.Marshal(args)
+	if err != nil {
+		return nil
 	}
 	sec := v1.Secret{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
@@ -843,8 +840,10 @@ func RenderArgsSecret(addon *InstallPackage, args map[string]interface{}) *unstr
 			Name:      Convert2SecName(addon.Name),
 			Namespace: types.DefaultKubeVelaNS,
 		},
-		StringData: data,
-		Type:       v1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			AddonParameterDataKey: argsByte,
+		},
+		Type: v1.SecretTypeOpaque,
 	}
 	u, err := util.Object2Unstructured(sec)
 	if err != nil {

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -147,9 +147,9 @@ type AddonDefinition struct {
 // AddonStatusResponse defines the format of addon status response
 type AddonStatusResponse struct {
 	AddonBaseStatus
-	Args             map[string]string `json:"args"`
-	EnablingProgress *EnablingProgress `json:"enabling_progress,omitempty"`
-	AppStatus        common.AppStatus  `json:"appStatus,omitempty"`
+	Args             map[string]interface{} `json:"args"`
+	EnablingProgress *EnablingProgress      `json:"enabling_progress,omitempty"`
+	AppStatus        common.AppStatus       `json:"appStatus,omitempty"`
 	// the status of multiple clusters
 	Clusters map[string]map[string]interface{} `json:"clusters,omitempty"`
 }

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -214,7 +214,16 @@ func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*ap
 	} else if errors2.IsNotFound(err) {
 		return &res, nil
 	}
-	res.Args = make(map[string]string, len(sec.Data))
+	if args, ok := sec.Data[pkgaddon.AddonParameterDataKey]; ok {
+		err := json.Unmarshal(args, &res.Args)
+		if err != nil {
+			return nil, err
+		}
+		return &res, nil
+	}
+
+	// this is backward compatibility code for old way to storage parameter
+	res.Args = make(map[string]interface{}, len(sec.Data))
 	for k, v := range sec.Data {
 		res.Args[k] = string(v)
 	}

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -214,18 +214,10 @@ func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*ap
 	} else if errors2.IsNotFound(err) {
 		return &res, nil
 	}
-	if args, ok := sec.Data[pkgaddon.AddonParameterDataKey]; ok {
-		err := json.Unmarshal(args, &res.Args)
-		if err != nil {
-			return nil, err
-		}
-		return &res, nil
-	}
 
-	// this is backward compatibility code for old way to storage parameter
-	res.Args = make(map[string]interface{}, len(sec.Data))
-	for k, v := range sec.Data {
-		res.Args[k] = string(v)
+	res.Args, err = pkgaddon.FetchArgsFromSecret(&sec)
+	if err != nil {
+		return nil, err
 	}
 
 	return &res, nil


### PR DESCRIPTION
fix complicate args storage

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

eg: vela addon enable velaux imagePullSecrets={myreg,myreg2}

request `127.0.0.1:8000/api/v1/addons/velaux/status` will return 
```json
{
    "name": "velaux",
    "phase": "enabled",
    "args": {
        "imagePullSecrets": [
            "myreg",
            "myreg2"
        ]
    },
}
```
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Refer to ：https://github.com/oam-dev/velaux/issues/372

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->