### PR TITLE
Feat: add reset backoff time in workflow status

### DIFF
--- a/apis/core.oam.dev/common/types.go
+++ b/apis/core.oam.dev/common/types.go
@@ -327,9 +327,10 @@ type PolicyStatus struct {
 
 // WorkflowStatus record the status of workflow
 type WorkflowStatus struct {
-	AppRevision string       `json:"appRevision,omitempty"`
-	Mode        WorkflowMode `json:"mode"`
-	Message     string       `json:"message,omitempty"`
+	AppRevision  string       `json:"appRevision,omitempty"`
+	Mode         WorkflowMode `json:"mode"`
+	Message      string       `json:"message,omitempty"`
+	ResetBackoff bool         `json:"resetBackoff,omitempty"`
 
 	Suspend    bool `json:"suspend"`
 	Terminated bool `json:"terminated"`

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -884,6 +884,8 @@ spec:
                           mode:
                             description: WorkflowMode describes the mode of workflow
                             type: string
+                          resetBackoff:
+                            type: boolean
                           startTime:
                             format: date-time
                             type: string
@@ -2719,6 +2721,8 @@ spec:
                           mode:
                             description: WorkflowMode describes the mode of workflow
                             type: string
+                          resetBackoff:
+                            type: boolean
                           startTime:
                             format: date-time
                             type: string

--- a/charts/vela-core/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applications.yaml
@@ -596,6 +596,8 @@ spec:
                   mode:
                     description: WorkflowMode describes the mode of workflow
                     type: string
+                  resetBackoff:
+                    type: boolean
                   startTime:
                     format: date-time
                     type: string
@@ -1118,6 +1120,8 @@ spec:
                   mode:
                     description: WorkflowMode describes the mode of workflow
                     type: string
+                  resetBackoff:
+                    type: boolean
                   startTime:
                     format: date-time
                     type: string

--- a/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
@@ -884,6 +884,8 @@ spec:
                           mode:
                             description: WorkflowMode describes the mode of workflow
                             type: string
+                          resetBackoff:
+                            type: boolean
                           startTime:
                             format: date-time
                             type: string
@@ -2719,6 +2721,8 @@ spec:
                           mode:
                             description: WorkflowMode describes the mode of workflow
                             type: string
+                          resetBackoff:
+                            type: boolean
                           startTime:
                             format: date-time
                             type: string

--- a/charts/vela-minimal/crds/core.oam.dev_applications.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applications.yaml
@@ -596,6 +596,8 @@ spec:
                   mode:
                     description: WorkflowMode describes the mode of workflow
                     type: string
+                  resetBackoff:
+                    type: boolean
                   startTime:
                     format: date-time
                     type: string
@@ -1118,6 +1120,8 @@ spec:
                   mode:
                     description: WorkflowMode describes the mode of workflow
                     type: string
+                  resetBackoff:
+                    type: boolean
                   startTime:
                     format: date-time
                     type: string

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -884,6 +884,8 @@ spec:
                           mode:
                             description: WorkflowMode describes the mode of workflow
                             type: string
+                          resetBackoff:
+                            type: boolean
                           startTime:
                             format: date-time
                             type: string
@@ -2719,6 +2721,8 @@ spec:
                           mode:
                             description: WorkflowMode describes the mode of workflow
                             type: string
+                          resetBackoff:
+                            type: boolean
                           startTime:
                             format: date-time
                             type: string

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applications.yaml
@@ -805,6 +805,8 @@ spec:
                   mode:
                     description: WorkflowMode describes the mode of workflow
                     type: string
+                  resetBackoff:
+                    type: boolean
                   startTime:
                     format: date-time
                     type: string
@@ -1500,6 +1502,8 @@ spec:
                   mode:
                     description: WorkflowMode describes the mode of workflow
                     type: string
+                  resetBackoff:
+                    type: boolean
                   startTime:
                     format: date-time
                     type: string

--- a/pkg/workflow/interface.go
+++ b/pkg/workflow/interface.go
@@ -35,4 +35,7 @@ type Workflow interface {
 
 	// GetBackoffWaitTime returns the wait time for next retry.
 	GetBackoffWaitTime() time.Duration
+
+	// UsePatch returns true if the workflow should use patch to update the resources.
+	UsePatch() bool
 }


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

add reset counter in workflow status

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

/cc @Somefive 