### PR TITLE
Fix: Fix the inaccurate judgment of ready status 

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -506,15 +506,15 @@ spec:
       import "strconv"
       ready: {
       	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: "0"
+      		readyReplicas: 0
       	}
 
       	if context.output.status.readyReplicas != _|_ {
-      		readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
+      		readyReplicas: context.output.status.readyReplicas
       	}
       }
 
-      message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+      message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
     healthPolicy: |-
       ready: {
       	if context.output.status.updatedReplicas == _|_  {

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -506,23 +506,49 @@ spec:
       import "strconv"
       ready: {
       	if context.output.status.readyReplicas == _|_ {
-      		replica: "0"
+      		readyReplicas: "0"
       	}
+
       	if context.output.status.readyReplicas != _|_ {
-      		replica:  strconv.FormatInt(context.output.status.readyReplicas, 10)
+      		readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
       	}
       }
-      message: "Ready:" + ready.replica + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+
+      message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
     healthPolicy: |-
       ready: {
-      	if context.output.status.readyReplicas == _|_ {
-      		replica: 0
+      	if context.output.status.updatedReplicas == _|_  {
+      		updatedReplicas : 0
       	}
+
+      	if context.output.status.updatedReplicas != _|_  {
+      		updatedReplicas : context.output.status.updatedReplicas
+      	}
+
+      	if context.output.status.readyReplicas == _|_ {
+      		readyReplicas: 0
+      	}
+
       	if context.output.status.readyReplicas != _|_ {
-      		replica:  context.output.status.readyReplicas
+      		readyReplicas: context.output.status.readyReplicas
+      	}
+
+      	if context.output.status.replicas == _|_ {
+      		replicas: 0
+      	}
+      	if context.output.status.replicas != _|_ {
+      		replicas: context.output.status.replicas
+      	}
+
+      	if context.output.status.observedGeneration != _|_ {
+      		observedGeneration: context.output.status.observedGeneration
+      	}
+
+      	if context.output.status.observedGeneration == _|_ {
+      		observedGeneration: 0
       	}
       }
-      isHealth: context.output.spec.replicas == ready.replica
+      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
   workload:
     definition:
       apiVersion: apps/v1

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -399,15 +399,15 @@ spec:
       import "strconv"
       ready: {
       	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: "0"
+      		readyReplicas: 0
       	}
 
       	if context.output.status.readyReplicas != _|_ {
-      		readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
+      		readyReplicas: context.output.status.readyReplicas
       	}
       }
 
-      message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+      message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
     healthPolicy: |-
       ready: {
       	if context.output.status.updatedReplicas == _|_  {

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -399,23 +399,49 @@ spec:
       import "strconv"
       ready: {
       	if context.output.status.readyReplicas == _|_ {
-      		replica: "0"
+      		readyReplicas: "0"
       	}
+
       	if context.output.status.readyReplicas != _|_ {
-      		replica:  strconv.FormatInt(context.output.status.readyReplicas, 10)
+      		readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
       	}
       }
-      message: "Ready:" + ready.replica + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+
+      message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
     healthPolicy: |-
       ready: {
-      	if context.output.status.readyReplicas == _|_ {
-      		replica: 0
+      	if context.output.status.updatedReplicas == _|_  {
+      		updatedReplicas : 0
       	}
+
+      	if context.output.status.updatedReplicas != _|_  {
+      		updatedReplicas : context.output.status.updatedReplicas
+      	}
+
+      	if context.output.status.readyReplicas == _|_ {
+      		readyReplicas: 0
+      	}
+
       	if context.output.status.readyReplicas != _|_ {
-      		replica:  context.output.status.readyReplicas
+      		readyReplicas: context.output.status.readyReplicas
+      	}
+
+      	if context.output.status.replicas == _|_ {
+      		replicas: 0
+      	}
+      	if context.output.status.replicas != _|_ {
+      		replicas: context.output.status.replicas
+      	}
+
+      	if context.output.status.observedGeneration != _|_ {
+      		observedGeneration: context.output.status.observedGeneration
+      	}
+
+      	if context.output.status.observedGeneration == _|_ {
+      		observedGeneration: 0
       	}
       }
-      isHealth: context.output.spec.replicas == ready.replica
+      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
   workload:
     definition:
       apiVersion: apps/v1

--- a/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
@@ -506,15 +506,15 @@ spec:
       import "strconv"
       ready: {
       	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: "0"
+      		readyReplicas: 0
       	}
 
       	if context.output.status.readyReplicas != _|_ {
-      		readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
+      		readyReplicas: context.output.status.readyReplicas
       	}
       }
 
-      message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+      message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
     healthPolicy: |-
       ready: {
       	if context.output.status.updatedReplicas == _|_  {

--- a/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
@@ -506,23 +506,49 @@ spec:
       import "strconv"
       ready: {
       	if context.output.status.readyReplicas == _|_ {
-      		replica: "0"
+      		readyReplicas: "0"
       	}
+
       	if context.output.status.readyReplicas != _|_ {
-      		replica:  strconv.FormatInt(context.output.status.readyReplicas, 10)
+      		readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
       	}
       }
-      message: "Ready:" + ready.replica + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+
+      message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
     healthPolicy: |-
       ready: {
-      	if context.output.status.readyReplicas == _|_ {
-      		replica: 0
+      	if context.output.status.updatedReplicas == _|_  {
+      		updatedReplicas : 0
       	}
+
+      	if context.output.status.updatedReplicas != _|_  {
+      		updatedReplicas : context.output.status.updatedReplicas
+      	}
+
+      	if context.output.status.readyReplicas == _|_ {
+      		readyReplicas: 0
+      	}
+
       	if context.output.status.readyReplicas != _|_ {
-      		replica:  context.output.status.readyReplicas
+      		readyReplicas: context.output.status.readyReplicas
+      	}
+
+      	if context.output.status.replicas == _|_ {
+      		replicas: 0
+      	}
+      	if context.output.status.replicas != _|_ {
+      		replicas: context.output.status.replicas
+      	}
+
+      	if context.output.status.observedGeneration != _|_ {
+      		observedGeneration: context.output.status.observedGeneration
+      	}
+
+      	if context.output.status.observedGeneration == _|_ {
+      		observedGeneration: 0
       	}
       }
-      isHealth: context.output.spec.replicas == ready.replica
+      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
   workload:
     definition:
       apiVersion: apps/v1

--- a/charts/vela-minimal/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/worker.yaml
@@ -399,15 +399,15 @@ spec:
       import "strconv"
       ready: {
       	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: "0"
+      		readyReplicas: 0
       	}
 
       	if context.output.status.readyReplicas != _|_ {
-      		readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
+      		readyReplicas: context.output.status.readyReplicas
       	}
       }
 
-      message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+      message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
     healthPolicy: |-
       ready: {
       	if context.output.status.updatedReplicas == _|_  {

--- a/charts/vela-minimal/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/worker.yaml
@@ -399,23 +399,49 @@ spec:
       import "strconv"
       ready: {
       	if context.output.status.readyReplicas == _|_ {
-      		replica: "0"
+      		readyReplicas: "0"
       	}
+
       	if context.output.status.readyReplicas != _|_ {
-      		replica:  strconv.FormatInt(context.output.status.readyReplicas, 10)
+      		readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
       	}
       }
-      message: "Ready:" + ready.replica + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+
+      message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
     healthPolicy: |-
       ready: {
-      	if context.output.status.readyReplicas == _|_ {
-      		replica: 0
+      	if context.output.status.updatedReplicas == _|_  {
+      		updatedReplicas : 0
       	}
+
+      	if context.output.status.updatedReplicas != _|_  {
+      		updatedReplicas : context.output.status.updatedReplicas
+      	}
+
+      	if context.output.status.readyReplicas == _|_ {
+      		readyReplicas: 0
+      	}
+
       	if context.output.status.readyReplicas != _|_ {
-      		replica:  context.output.status.readyReplicas
+      		readyReplicas: context.output.status.readyReplicas
+      	}
+
+      	if context.output.status.replicas == _|_ {
+      		replicas: 0
+      	}
+      	if context.output.status.replicas != _|_ {
+      		replicas: context.output.status.replicas
+      	}
+
+      	if context.output.status.observedGeneration != _|_ {
+      		observedGeneration: context.output.status.observedGeneration
+      	}
+
+      	if context.output.status.observedGeneration == _|_ {
+      		observedGeneration: 0
       	}
       }
-      isHealth: context.output.spec.replicas == ready.replica
+      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
   workload:
     definition:
       apiVersion: apps/v1

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -19,22 +19,24 @@ webservice: {
 			customStatus: #"""
 				import "strconv"
 				ready: {
-					if context.output.status.readyReplicas == _|_ {
-						replica: "0"
+					if (context.output.status.updatedReplicas == context.output.spec.replicas) && (context.output.status.replicas == context.output.spec.replicas) && (context.output.status.availableReplicas == context.output.spec.replicas) && (context.output.status.readyReplicas != _|_) {
+						replica: strconv.FormatInt(context.output.status.readyReplicas, 10)
 					}
-					if context.output.status.readyReplicas != _|_ {
-						replica:  strconv.FormatInt(context.output.status.readyReplicas, 10)
+
+					if (context.output.status.updatedReplicas != context.output.spec.replicas) || (context.output.status.replicas != context.output.spec.replicas) || (context.output.status.availableReplicas != context.output.spec.replicas) || (context.output.status.readyReplicas == _|_) {
+						replica: "0"
 					}
 				}
 				message: "Ready:" + ready.replica + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
 				"""#
 			healthPolicy: #"""
 				ready: {
-					if context.output.status.readyReplicas == _|_ {
-						replica: 0
+					if (context.output.status.updatedReplicas == context.output.spec.replicas) && (context.output.status.replicas == context.output.spec.replicas) && (context.output.status.availableReplicas == context.output.spec.replicas) && (context.output.status.readyReplicas != _|_) {
+						replica: context.output.status.readyReplicas
 					}
-					if context.output.status.readyReplicas != _|_ {
-						replica:  context.output.status.readyReplicas
+
+					if (context.output.status.updatedReplicas != context.output.spec.replicas) || (context.output.status.replicas != context.output.spec.replicas) || (context.output.status.availableReplicas != context.output.spec.replicas) || (context.output.status.readyReplicas == _|_) {
+						replica: 0
 					}
 				}
 				isHealth: context.output.spec.replicas == ready.replica

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -20,15 +20,15 @@ webservice: {
 				import "strconv"
 				ready: {
 					if context.output.status.readyReplicas == _|_ {
-						readyReplicas: "0"
+						readyReplicas: 0
 					}
 
 					if context.output.status.readyReplicas != _|_ {
-						readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
+						readyReplicas: context.output.status.readyReplicas
 					}
 				}
 
-				message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+				message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
 				"""#
 			healthPolicy: #"""
 				ready: {

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -19,27 +19,51 @@ webservice: {
 			customStatus: #"""
 				import "strconv"
 				ready: {
-					if (context.output.status.updatedReplicas == context.output.spec.replicas) && (context.output.status.replicas == context.output.spec.replicas) && (context.output.status.availableReplicas == context.output.spec.replicas) && (context.output.status.readyReplicas != _|_) {
-						replica: strconv.FormatInt(context.output.status.readyReplicas, 10)
+					if context.output.status.readyReplicas == _|_ {
+						readyReplicas: "0"
 					}
 
-					if (context.output.status.updatedReplicas != context.output.spec.replicas) || (context.output.status.replicas != context.output.spec.replicas) || (context.output.status.availableReplicas != context.output.spec.replicas) || (context.output.status.readyReplicas == _|_) {
-						replica: "0"
+					if context.output.status.readyReplicas != _|_ {
+						readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
 					}
 				}
-				message: "Ready:" + ready.replica + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+
+				message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
 				"""#
 			healthPolicy: #"""
 				ready: {
-					if (context.output.status.updatedReplicas == context.output.spec.replicas) && (context.output.status.replicas == context.output.spec.replicas) && (context.output.status.availableReplicas == context.output.spec.replicas) && (context.output.status.readyReplicas != _|_) {
-						replica: context.output.status.readyReplicas
+					if context.output.status.updatedReplicas == _|_  {
+						updatedReplicas : 0
 					}
 
-					if (context.output.status.updatedReplicas != context.output.spec.replicas) || (context.output.status.replicas != context.output.spec.replicas) || (context.output.status.availableReplicas != context.output.spec.replicas) || (context.output.status.readyReplicas == _|_) {
-						replica: 0
+					if context.output.status.updatedReplicas != _|_  {
+						updatedReplicas : context.output.status.updatedReplicas
+					}
+
+					if context.output.status.readyReplicas == _|_ {
+						readyReplicas: 0
+					}
+
+					if context.output.status.readyReplicas != _|_ {
+						readyReplicas: context.output.status.readyReplicas
+					}
+
+					if context.output.status.replicas == _|_ {
+						replicas: 0
+					}
+					if context.output.status.replicas != _|_ {
+						replicas: context.output.status.replicas
+					}
+
+					if context.output.status.observedGeneration != _|_ {
+						observedGeneration: context.output.status.observedGeneration
+					}
+
+					if context.output.status.observedGeneration == _|_ {
+						observedGeneration: 0
 					}
 				}
-				isHealth: context.output.spec.replicas == ready.replica
+					isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
 				"""#
 		}
 	}

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -17,27 +17,51 @@ worker: {
 			customStatus: #"""
 				import "strconv"
 				ready: {
-					if (context.output.status.updatedReplicas == context.output.spec.replicas) && (context.output.status.replicas == context.output.spec.replicas) && (context.output.status.availableReplicas == context.output.spec.replicas) && (context.output.status.readyReplicas != _|_) {
-						replica: strconv.FormatInt(context.output.status.readyReplicas, 10)
+					if context.output.status.readyReplicas == _|_ {
+						readyReplicas: "0"
 					}
 
-					if (context.output.status.updatedReplicas != context.output.spec.replicas) || (context.output.status.replicas != context.output.spec.replicas) || (context.output.status.availableReplicas != context.output.spec.replicas) || (context.output.status.readyReplicas == _|_) {
-						replica: "0"
+					if context.output.status.readyReplicas != _|_ {
+						readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
 					}
 				}
-				message: "Ready:" + ready.replica + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+
+				message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
 				"""#
 			healthPolicy: #"""
 				ready: {
-					if (context.output.status.updatedReplicas == context.output.spec.replicas) && (context.output.status.replicas == context.output.spec.replicas) && (context.output.status.availableReplicas == context.output.spec.replicas) && (context.output.status.readyReplicas != _|_) {
-						replica: context.output.status.readyReplicas
+					if context.output.status.updatedReplicas == _|_  {
+						updatedReplicas : 0
 					}
 
-					if (context.output.status.updatedReplicas != context.output.spec.replicas) || (context.output.status.replicas != context.output.spec.replicas) || (context.output.status.availableReplicas != context.output.spec.replicas) || (context.output.status.readyReplicas == _|_) {
-						replica: 0
+					if context.output.status.updatedReplicas != _|_  {
+						updatedReplicas : context.output.status.updatedReplicas
+					}
+
+					if context.output.status.readyReplicas == _|_ {
+						readyReplicas: 0
+					}
+
+					if context.output.status.readyReplicas != _|_ {
+						readyReplicas: context.output.status.readyReplicas
+					}
+
+					if context.output.status.replicas == _|_ {
+						replicas: 0
+					}
+					if context.output.status.replicas != _|_ {
+						replicas: context.output.status.replicas
+					}
+
+					if context.output.status.observedGeneration != _|_ {
+						observedGeneration: context.output.status.observedGeneration
+					}
+
+					if context.output.status.observedGeneration == _|_ {
+						observedGeneration: 0
 					}
 				}
-				isHealth: context.output.spec.replicas == ready.replica
+					isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
 				"""#
 		}
 	}

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -18,15 +18,15 @@ worker: {
 				import "strconv"
 				ready: {
 					if context.output.status.readyReplicas == _|_ {
-						readyReplicas: "0"
+						readyReplicas: 0
 					}
 
 					if context.output.status.readyReplicas != _|_ {
-						readyReplicas: strconv.FormatInt(context.output.status.readyReplicas, 10)
+						readyReplicas: context.output.status.readyReplicas
 					}
 				}
 
-				message: "Ready:" + ready.readyReplicas + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+				message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
 				"""#
 			healthPolicy: #"""
 				ready: {

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -17,22 +17,24 @@ worker: {
 			customStatus: #"""
 				import "strconv"
 				ready: {
-					if context.output.status.readyReplicas == _|_ {
-						replica: "0"
+					if (context.output.status.updatedReplicas == context.output.spec.replicas) && (context.output.status.replicas == context.output.spec.replicas) && (context.output.status.availableReplicas == context.output.spec.replicas) && (context.output.status.readyReplicas != _|_) {
+						replica: strconv.FormatInt(context.output.status.readyReplicas, 10)
 					}
-					if context.output.status.readyReplicas != _|_ {
-						replica:  strconv.FormatInt(context.output.status.readyReplicas, 10)
+
+					if (context.output.status.updatedReplicas != context.output.spec.replicas) || (context.output.status.replicas != context.output.spec.replicas) || (context.output.status.availableReplicas != context.output.spec.replicas) || (context.output.status.readyReplicas == _|_) {
+						replica: "0"
 					}
 				}
 				message: "Ready:" + ready.replica + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
 				"""#
 			healthPolicy: #"""
 				ready: {
-					if context.output.status.readyReplicas == _|_ {
-						replica: 0
+					if (context.output.status.updatedReplicas == context.output.spec.replicas) && (context.output.status.replicas == context.output.spec.replicas) && (context.output.status.availableReplicas == context.output.spec.replicas) && (context.output.status.readyReplicas != _|_) {
+						replica: context.output.status.readyReplicas
 					}
-					if context.output.status.readyReplicas != _|_ {
-						replica:  context.output.status.readyReplicas
+
+					if (context.output.status.updatedReplicas != context.output.spec.replicas) || (context.output.status.replicas != context.output.spec.replicas) || (context.output.status.availableReplicas != context.output.spec.replicas) || (context.output.status.readyReplicas == _|_) {
+						replica: 0
 					}
 				}
 				isHealth: context.output.spec.replicas == ready.replica


### PR DESCRIPTION
Signed-off-by: kingram <kingram@163.com>


### Description of your changes

Fix the inaccurate judgment of ready status

Fixes https://github.com/oam-dev/kubevela/issues/3311


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested


### Special notes for your reviewer
