### PR TITLE
Feat: Nominee Wei as a maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,6 +24,7 @@ Maintainers:
 - barnettZQG
 - leejanee
 - zzxwill
+- BinaryHB0916
 
 Emeritus Members:
 - ryanzhang-oss


### PR DESCRIPTION
Wei has been playing a critical role for getting KubeVela to more developers and done several major consistent contribution to the community. Helping KubeVela onboarding to CNCF, tracking community's visibility and ensuring show up rate in series of CNCF KubeCon or related summits, assembling [KubeVela.io](http://kubevela.io/)(official doc) and VelaUX(UI dashboard) localization,  and keep hosting both Asia and Europe&America friendly biweekly community call in the past.

Community management is equally important as contributing code does. We shall encourage more efforts as this to help KubeVela community narrow the gap from us to more developers out there.