### PR TITLE
Feat: add api for delete component

### DIFF
--- a/pkg/apiserver/model/application.go
+++ b/pkg/apiserver/model/application.go
@@ -83,7 +83,7 @@ type ApplicationComponent struct {
 	Name          string            `json:"name"`
 	Alias         string            `json:"alias"`
 	Type          string            `json:"type"`
-
+	Main          bool              `json:"main"`
 	// ExternalRevision specified the component revisionName
 	ExternalRevision string             `json:"externalRevision,omitempty"`
 	Properties       *JSONStruct        `json:"properties,omitempty"`

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -579,6 +579,7 @@ type ComponentBase struct {
 	Description   string            `json:"description"`
 	Labels        map[string]string `json:"labels,omitempty"`
 	ComponentType string            `json:"componentType"`
+	Main          bool              `json:"main"`
 	EnvNames      []string          `json:"envNames"`
 	Icon          string            `json:"icon,omitempty"`
 	DependsOn     []string          `json:"dependsOn"`

--- a/pkg/apiserver/rest/usecase/application.go
+++ b/pkg/apiserver/rest/usecase/application.go
@@ -82,12 +82,12 @@ type ApplicationUsecase interface {
 	Deploy(ctx context.Context, app *model.Application, req apisv1.ApplicationDeployRequest) (*apisv1.ApplicationDeployResponse, error)
 	GetApplicationComponent(ctx context.Context, app *model.Application, componentName string) (*model.ApplicationComponent, error)
 	ListComponents(ctx context.Context, app *model.Application, op apisv1.ListApplicationComponentOptions) ([]*apisv1.ComponentBase, error)
-	AddComponent(ctx context.Context, app *model.Application, com apisv1.CreateComponentRequest) (*apisv1.ComponentBase, error)
+	CreateComponent(ctx context.Context, app *model.Application, com apisv1.CreateComponentRequest) (*apisv1.ComponentBase, error)
 	DetailComponent(ctx context.Context, app *model.Application, componentName string) (*apisv1.DetailComponentResponse, error)
-	DeleteComponent(ctx context.Context, app *model.Application, componentName string) error
+	DeleteComponent(ctx context.Context, app *model.Application, component *model.ApplicationComponent) error
 	UpdateComponent(ctx context.Context, app *model.Application, component *model.ApplicationComponent, req apisv1.UpdateApplicationComponentRequest) (*apisv1.ComponentBase, error)
 	ListPolicies(ctx context.Context, app *model.Application) ([]*apisv1.PolicyBase, error)
-	AddPolicy(ctx context.Context, app *model.Application, policy apisv1.CreatePolicyRequest) (*apisv1.PolicyBase, error)
+	CreatePolicy(ctx context.Context, app *model.Application, policy apisv1.CreatePolicyRequest) (*apisv1.PolicyBase, error)
 	DetailPolicy(ctx context.Context, app *model.Application, policyName string) (*apisv1.DetailPolicyResponse, error)
 	DeletePolicy(ctx context.Context, app *model.Application, policyName string) error
 	UpdatePolicy(ctx context.Context, app *model.Application, policyName string, policy apisv1.UpdatePolicyRequest) (*apisv1.DetailPolicyResponse, error)
@@ -336,7 +336,6 @@ func (c *applicationUsecaseImpl) CreateApplication(ctx context.Context, req apis
 	if exist {
 		return nil, bcode.ErrApplicationExist
 	}
-
 	// check project
 	project, err := c.projectUsecase.GetProject(ctx, req.Project)
 	if err != nil {
@@ -345,7 +344,7 @@ func (c *applicationUsecaseImpl) CreateApplication(ctx context.Context, req apis
 	application.Project = project.Name
 
 	if req.Component != nil {
-		_, err = c.AddComponent(ctx, &application, *req.Component)
+		_, err = c.createComponent(ctx, &application, *req.Component, true)
 		if err != nil {
 			return nil, err
 		}
@@ -1054,26 +1053,50 @@ func (c *applicationUsecaseImpl) UpdateComponent(ctx context.Context, app *model
 	return converComponentModelToBase(component), nil
 }
 
-func (c *applicationUsecaseImpl) AddComponent(ctx context.Context, app *model.Application, com apisv1.CreateComponentRequest) (*apisv1.ComponentBase, error) {
+func (c *applicationUsecaseImpl) createComponent(ctx context.Context, app *model.Application, com apisv1.CreateComponentRequest, main bool) (*apisv1.ComponentBase, error) {
 	componentModel := model.ApplicationComponent{
 		AppPrimaryKey: app.PrimaryKey(),
 		Description:   com.Description,
 		Labels:        com.Labels,
 		Icon:          com.Icon,
-		// TODO: Get user information from ctx and assign a value.
-		Creator:   "",
-		Name:      com.Name,
-		Type:      com.ComponentType,
-		DependsOn: com.DependsOn,
-		Alias:     com.Alias,
+		Creator:       "", // TODO: Get user information from ctx and assign a value.
+		Name:          com.Name,
+		Type:          com.ComponentType,
+		DependsOn:     com.DependsOn,
+		Alias:         com.Alias,
+		Main:          main,
 	}
+	var traits []model.ApplicationTrait
+	var traitTypes = make(map[string]bool)
+	for _, trait := range com.Traits {
+		if _, ok := traitTypes[trait.Type]; ok {
+			return nil, bcode.ErrTraitAlreadyExist
+		}
+		traitTypes[trait.Type] = true
+		properties, err := model.NewJSONStructByString(trait.Properties)
+		if err != nil {
+			log.Logger.Errorf("new trait failure,%s", err.Error())
+			return nil, bcode.ErrInvalidProperties
+		}
+		traits = append(traits, model.ApplicationTrait{
+			Alias:       trait.Alias,
+			Description: trait.Description,
+			Type:        trait.Type,
+			Properties:  properties,
+			CreateTime:  time.Now(),
+			UpdateTime:  time.Now(),
+		})
+	}
+	componentModel.Traits = traits
 	properties, err := model.NewJSONStructByString(com.Properties)
 	if err != nil {
 		return nil, bcode.ErrInvalidProperties
 	}
 	componentModel.Properties = properties
-	// create default triat for component
-	c.initCreateDefaultTrait(&componentModel)
+	// create default trait for component
+	if len(componentModel.Traits) == 0 {
+		c.initCreateDefaultTrait(&componentModel)
+	}
 
 	if err := c.ds.Add(ctx, &componentModel); err != nil {
 		if errors.Is(err, datastore.ErrRecordExist) {
@@ -1083,6 +1106,10 @@ func (c *applicationUsecaseImpl) AddComponent(ctx context.Context, app *model.Ap
 		return nil, err
 	}
 	return converComponentModelToBase(&componentModel), nil
+}
+
+func (c *applicationUsecaseImpl) CreateComponent(ctx context.Context, app *model.Application, com apisv1.CreateComponentRequest) (*apisv1.ComponentBase, error) {
+	return c.createComponent(ctx, app, com, false)
 }
 
 func (c *applicationUsecaseImpl) initCreateDefaultTrait(component *model.ApplicationComponent) {
@@ -1097,7 +1124,7 @@ func (c *applicationUsecaseImpl) initCreateDefaultTrait(component *model.Applica
 		UpdateTime: time.Now(),
 	}
 	var initTraits = []model.ApplicationTrait{}
-	if component.Type == "webservice" && len(component.Traits) == 0 {
+	if component.Type == "webservice" {
 		initTraits = append(initTraits, replicationTrait)
 	}
 	component.Traits = initTraits
@@ -1115,17 +1142,17 @@ func converComponentModelToBase(componentModel *model.ApplicationComponent) *api
 		Icon:          componentModel.Icon,
 		DependsOn:     componentModel.DependsOn,
 		Creator:       componentModel.Creator,
+		Main:          componentModel.Main,
 		CreateTime:    componentModel.CreateTime,
 		UpdateTime:    componentModel.UpdateTime,
 	}
 }
 
-func (c *applicationUsecaseImpl) DeleteComponent(ctx context.Context, app *model.Application, componentName string) error {
-	var component = model.ApplicationComponent{
-		AppPrimaryKey: app.PrimaryKey(),
-		Name:          componentName,
+func (c *applicationUsecaseImpl) DeleteComponent(ctx context.Context, app *model.Application, component *model.ApplicationComponent) error {
+	if component.Main {
+		return bcode.ErrApplicationComponetNotAllowDelete
 	}
-	if err := c.ds.Delete(ctx, &component); err != nil {
+	if err := c.ds.Delete(ctx, component); err != nil {
 		if errors.Is(err, datastore.ErrRecordNotExist) {
 			return bcode.ErrApplicationComponetNotExist
 		}
@@ -1135,7 +1162,7 @@ func (c *applicationUsecaseImpl) DeleteComponent(ctx context.Context, app *model
 	return nil
 }
 
-func (c *applicationUsecaseImpl) AddPolicy(ctx context.Context, app *model.Application, createpolicy apisv1.CreatePolicyRequest) (*apisv1.PolicyBase, error) {
+func (c *applicationUsecaseImpl) CreatePolicy(ctx context.Context, app *model.Application, createpolicy apisv1.CreatePolicyRequest) (*apisv1.PolicyBase, error) {
 	policyModel := model.ApplicationPolicy{
 		AppPrimaryKey: app.PrimaryKey(),
 		Description:   createpolicy.Description,
@@ -1445,8 +1472,8 @@ func (c *applicationUsecaseImpl) createTargetClusterEnv(ctx context.Context, env
 			continue
 		}
 		if definition != nil {
-			if definition.Spec.Workload.Type == TerraformWorkfloadType ||
-				definition.Spec.Workload.Definition.Kind == TerraformWorkfloadKind {
+			if definition.Spec.Workload.Type == TerraformWorkloadType ||
+				definition.Spec.Workload.Definition.Kind == TerraformWorkloadKind {
 				properties := model.JSONStruct{
 					"providerRef": map[string]interface{}{
 						"name": "default",

--- a/pkg/apiserver/rest/usecase/envbinding.go
+++ b/pkg/apiserver/rest/usecase/envbinding.go
@@ -41,10 +41,10 @@ const (
 	Deploy2Env string = "deploy2env"
 	// DeployCloudResource deploy app to local and copy secret to target cluster, suitable for cloud application.
 	DeployCloudResource string = "deploy-cloud-resource"
-	// TerraformWorkfloadType cloud application
-	TerraformWorkfloadType string = "configurations.terraform.core.oam.dev"
-	// TerraformWorkfloadKind terraform workload kind
-	TerraformWorkfloadKind string = "Configuration"
+	// TerraformWorkloadType cloud application
+	TerraformWorkloadType string = "configurations.terraform.core.oam.dev"
+	// TerraformWorkloadKind terraform workload kind
+	TerraformWorkloadKind string = "Configuration"
 )
 
 // EnvBindingUsecase envbinding usecase

--- a/pkg/apiserver/rest/usecase/testdata/ui-schema.yaml
+++ b/pkg/apiserver/rest/usecase/testdata/ui-schema.yaml
@@ -4,26 +4,30 @@
   sort: 1
   uiType: ImageInput
   validate:
+    immutable: false
     required: true
 - description: Specifies the attributes of the memory resource required for the container.
   jsonKey: memory
   label: Memory Request&Limit
   sort: 3
   uiType: MemoryNumber
-  validate: {}
+  validate:
+    immutable: false
 - description: Number of CPU units for the service, like `0.5` (0.5 CPU core), `1`
     (1 CPU core)
   jsonKey: cpu
   label: CPU Request&Limit
   sort: 5
   uiType: CPUNumber
-  validate: {}
+  validate:
+    immutable: false
 - description: Specify image pull policy for your service
   jsonKey: imagePullPolicy
   label: Image Pull Policy
   sort: 7
   uiType: Select
   validate:
+    immutable: false
     options:
     - label: IfNotPresent
       value: IfNotPresent
@@ -36,7 +40,8 @@
   label: Container Start Command
   sort: 9
   uiType: Strings
-  validate: {}
+  validate:
+    immutable: false
 - description: Define arguments by using environment variables
   jsonKey: env
   label: Environments
@@ -57,13 +62,15 @@
     sort: 100
     uiType: Input
     validate:
+      immutable: false
       required: true
   - description: The value of the environment variable
     jsonKey: value
     label: Value
     sort: 100
     uiType: Input
-    validate: {}
+    validate:
+      immutable: false
   - description: Specifies a source the value of this var should come from
     jsonKey: valueFrom
     label: Secret Selector
@@ -80,6 +87,7 @@
         sort: 1
         uiType: SecretSelect
         validate:
+          immutable: false
           required: true
       - description: The key of the secret to select from. Must be a valid secret
           key
@@ -88,20 +96,106 @@
         sort: 3
         uiType: SecretKeySelect
         validate:
+          immutable: false
           required: true
       uiType: Ignore
       validate:
+        immutable: false
         required: true
     uiType: InnerGroup
-    validate: {}
+    validate:
+      immutable: false
   uiType: Structs
-  validate: {}
+  validate:
+    immutable: false
 - description: Instructions for assessing whether the container is in a suitable state
     to serve traffic.
   jsonKey: readinessProbe
   label: ReadinessProbe
   sort: 13
   subParameters:
+  - description: Number of consecutive failures required to determine the container
+      is not alive (liveness probe) or not ready (readiness probe).
+    jsonKey: failureThreshold
+    label: FailureThreshold
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 3
+      immutable: false
+      required: true
+  - description: Instructions for assessing container health by executing an HTTP
+      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
+      MUST be specified. This attribute is mutually exclusive with both the exec attribute
+      and the tcpSocket attribute.
+    jsonKey: httpGet
+    label: HttpGet
+    sort: 100
+    subParameters:
+    - description: The TCP socket within the container to which the HTTP GET request
+        should be directed.
+      jsonKey: port
+      label: Port
+      sort: 100
+      uiType: Number
+      validate:
+        immutable: false
+        required: true
+    - description: ""
+      jsonKey: httpHeaders
+      label: HttpHeaders
+      sort: 100
+      subParameters:
+      - description: ""
+        jsonKey: name
+        label: Name
+        sort: 100
+        uiType: Input
+        validate:
+          immutable: false
+          required: true
+      - description: ""
+        jsonKey: value
+        label: Value
+        sort: 100
+        uiType: Input
+        validate:
+          immutable: false
+          required: true
+      uiType: Structs
+      validate:
+        immutable: false
+    - description: The endpoint, relative to the port, to which the HTTP GET request
+        should be directed.
+      jsonKey: path
+      label: Path
+      sort: 100
+      uiType: Input
+      validate:
+        immutable: false
+        required: true
+    uiType: Group
+    validate:
+      immutable: false
+  - description: Number of seconds after the container is started before the first
+      probe is initiated.
+    jsonKey: initialDelaySeconds
+    label: InitialDelaySeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 0
+      immutable: false
+      required: true
+  - description: How often, in seconds, to execute the probe.
+    jsonKey: periodSeconds
+    label: PeriodSeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 10
+      immutable: false
+      required: true
   - description: Minimum consecutive successes for the probe to be considered successful
       after having failed.
     jsonKey: successThreshold
@@ -110,6 +204,7 @@
     uiType: Number
     validate:
       defaultValue: 1
+      immutable: false
       required: true
   - description: Instructions for assessing container health by probing a TCP socket.
       Either this attribute or the exec attribute or the httpGet attribute MUST be
@@ -126,9 +221,11 @@
       sort: 100
       uiType: Number
       validate:
+        immutable: false
         required: true
     uiType: Group
-    validate: {}
+    validate:
+      immutable: false
   - description: Number of seconds after which the probe times out.
     jsonKey: timeoutSeconds
     label: TimeoutSeconds
@@ -136,6 +233,7 @@
     uiType: Number
     validate:
       defaultValue: 1
+      immutable: false
       required: true
   - description: Instructions for assessing container health by executing a command.
       Either this attribute or the httpGet attribute or the tcpSocket attribute MUST
@@ -154,89 +252,109 @@
       sort: 100
       uiType: Strings
       validate:
+        immutable: false
         required: true
     uiType: Group
-    validate: {}
-  - description: Number of consecutive failures required to determine the container
-      is not alive (liveness probe) or not ready (readiness probe).
-    jsonKey: failureThreshold
-    label: FailureThreshold
-    sort: 100
-    uiType: Number
     validate:
-      defaultValue: 3
-      required: true
-  - description: Instructions for assessing container health by executing an HTTP
-      GET request. Either this attribute or the exec attribute or the tcpSocket attribute
-      MUST be specified. This attribute is mutually exclusive with both the exec attribute
-      and the tcpSocket attribute.
-    jsonKey: httpGet
-    label: HttpGet
-    sort: 100
-    subParameters:
-    - description: ""
-      jsonKey: httpHeaders
-      label: HttpHeaders
-      sort: 100
-      subParameters:
-      - description: ""
-        jsonKey: name
-        label: Name
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      - description: ""
-        jsonKey: value
-        label: Value
-        sort: 100
-        uiType: Input
-        validate:
-          required: true
-      uiType: Structs
-      validate: {}
-    - description: The endpoint, relative to the port, to which the HTTP GET request
-        should be directed.
-      jsonKey: path
-      label: Path
-      sort: 100
-      uiType: Input
-      validate:
-        required: true
-    - description: The TCP socket within the container to which the HTTP GET request
-        should be directed.
-      jsonKey: port
-      label: Port
-      sort: 100
-      uiType: Number
-      validate:
-        required: true
-    uiType: Group
-    validate: {}
-  - description: Number of seconds after the container is started before the first
-      probe is initiated.
-    jsonKey: initialDelaySeconds
-    label: InitialDelaySeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 0
-      required: true
-  - description: How often, in seconds, to execute the probe.
-    jsonKey: periodSeconds
-    label: PeriodSeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 10
-      required: true
+      immutable: false
   uiType: Group
-  validate: {}
+  validate:
+    immutable: false
 - description: Instructions for assessing whether the container is alive.
   jsonKey: livenessProbe
   label: LivenessProbe
   sort: 15
   subParameters:
+  - description: Number of seconds after the container is started before the first
+      probe is initiated.
+    jsonKey: initialDelaySeconds
+    label: InitialDelaySeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 0
+      immutable: false
+      required: true
+  - description: How often, in seconds, to execute the probe.
+    jsonKey: periodSeconds
+    label: PeriodSeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 10
+      immutable: false
+      required: true
+  - description: Minimum consecutive successes for the probe to be considered successful
+      after having failed.
+    jsonKey: successThreshold
+    label: SuccessThreshold
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 1
+      immutable: false
+      required: true
+  - description: Instructions for assessing container health by probing a TCP socket.
+      Either this attribute or the exec attribute or the httpGet attribute MUST be
+      specified. This attribute is mutually exclusive with both the exec attribute
+      and the httpGet attribute.
+    jsonKey: tcpSocket
+    label: TcpSocket
+    sort: 100
+    subParameters:
+    - description: The TCP socket within the container that should be probed to assess
+        container health.
+      jsonKey: port
+      label: Port
+      sort: 100
+      uiType: Number
+      validate:
+        immutable: false
+        required: true
+    uiType: Group
+    validate:
+      immutable: false
+  - description: Number of seconds after which the probe times out.
+    jsonKey: timeoutSeconds
+    label: TimeoutSeconds
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 1
+      immutable: false
+      required: true
+  - description: Instructions for assessing container health by executing a command.
+      Either this attribute or the httpGet attribute or the tcpSocket attribute MUST
+      be specified. This attribute is mutually exclusive with both the httpGet attribute
+      and the tcpSocket attribute.
+    jsonKey: exec
+    label: Exec
+    sort: 100
+    subParameters:
+    - description: A command to be executed inside the container to assess its health.
+        Each space delimited token of the command is a separate array element. Commands
+        exiting 0 are considered to be successful probes, whilst all other exit codes
+        are considered failures.
+      jsonKey: command
+      label: Command
+      sort: 100
+      uiType: Strings
+      validate:
+        immutable: false
+        required: true
+    uiType: Group
+    validate:
+      immutable: false
+  - description: Number of consecutive failures required to determine the container
+      is not alive (liveness probe) or not ready (readiness probe).
+    jsonKey: failureThreshold
+    label: FailureThreshold
+    sort: 100
+    uiType: Number
+    validate:
+      defaultValue: 3
+      immutable: false
+      required: true
   - description: Instructions for assessing container health by executing an HTTP
       GET request. Either this attribute or the exec attribute or the tcpSocket attribute
       MUST be specified. This attribute is mutually exclusive with both the exec attribute
@@ -256,6 +374,7 @@
         sort: 100
         uiType: Input
         validate:
+          immutable: false
           required: true
       - description: ""
         jsonKey: value
@@ -263,9 +382,11 @@
         sort: 100
         uiType: Input
         validate:
+          immutable: false
           required: true
       uiType: Structs
-      validate: {}
+      validate:
+        immutable: false
     - description: The endpoint, relative to the port, to which the HTTP GET request
         should be directed.
       jsonKey: path
@@ -273,6 +394,7 @@
       sort: 100
       uiType: Input
       validate:
+        immutable: false
         required: true
     - description: The TCP socket within the container to which the HTTP GET request
         should be directed.
@@ -281,92 +403,14 @@
       sort: 100
       uiType: Number
       validate:
+        immutable: false
         required: true
     uiType: Group
-    validate: {}
-  - description: Number of seconds after the container is started before the first
-      probe is initiated.
-    jsonKey: initialDelaySeconds
-    label: InitialDelaySeconds
-    sort: 100
-    uiType: Number
     validate:
-      defaultValue: 0
-      required: true
-  - description: How often, in seconds, to execute the probe.
-    jsonKey: periodSeconds
-    label: PeriodSeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 10
-      required: true
-  - description: Minimum consecutive successes for the probe to be considered successful
-      after having failed.
-    jsonKey: successThreshold
-    label: SuccessThreshold
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 1
-      required: true
-  - description: Instructions for assessing container health by probing a TCP socket.
-      Either this attribute or the exec attribute or the httpGet attribute MUST be
-      specified. This attribute is mutually exclusive with both the exec attribute
-      and the httpGet attribute.
-    jsonKey: tcpSocket
-    label: TcpSocket
-    sort: 100
-    subParameters:
-    - description: The TCP socket within the container that should be probed to assess
-        container health.
-      jsonKey: port
-      label: Port
-      sort: 100
-      uiType: Number
-      validate:
-        required: true
-    uiType: Group
-    validate: {}
-  - description: Number of seconds after which the probe times out.
-    jsonKey: timeoutSeconds
-    label: TimeoutSeconds
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 1
-      required: true
-  - description: Instructions for assessing container health by executing a command.
-      Either this attribute or the httpGet attribute or the tcpSocket attribute MUST
-      be specified. This attribute is mutually exclusive with both the httpGet attribute
-      and the tcpSocket attribute.
-    jsonKey: exec
-    label: Exec
-    sort: 100
-    subParameters:
-    - description: A command to be executed inside the container to assess its health.
-        Each space delimited token of the command is a separate array element. Commands
-        exiting 0 are considered to be successful probes, whilst all other exit codes
-        are considered failures.
-      jsonKey: command
-      label: Command
-      sort: 100
-      uiType: Strings
-      validate:
-        required: true
-    uiType: Group
-    validate: {}
-  - description: Number of consecutive failures required to determine the container
-      is not alive (liveness probe) or not ready (readiness probe).
-    jsonKey: failureThreshold
-    label: FailureThreshold
-    sort: 100
-    uiType: Number
-    validate:
-      defaultValue: 3
-      required: true
+      immutable: false
   uiType: Group
-  validate: {}
+  validate:
+    immutable: false
 - description: Which port do you want customer traffic sent to
   disable: true
   jsonKey: port
@@ -375,7 +419,26 @@
   uiType: Number
   validate:
     defaultValue: 80
+    immutable: false
     required: true
+- description: If addRevisionLabel is true, the appRevision label will be added to
+    the underlying pods
+  disable: true
+  jsonKey: addRevisionLabel
+  label: AddRevisionLabel
+  sort: 100
+  uiType: Switch
+  validate:
+    defaultValue: false
+    immutable: false
+    required: true
+- description: Specify image pull secrets for your service
+  jsonKey: imagePullSecrets
+  label: ImagePullSecrets
+  sort: 100
+  uiType: Strings
+  validate:
+    immutable: false
 - description: Declare volumes and volumeMounts
   disable: true
   jsonKey: volumes
@@ -383,11 +446,20 @@
   sort: 100
   subParameters:
   - description: ""
+    jsonKey: mountPath
+    label: MountPath
+    sort: 100
+    uiType: Input
+    validate:
+      immutable: false
+      required: true
+  - description: ""
     jsonKey: name
     label: Name
     sort: 100
     uiType: Input
     validate:
+      immutable: false
       required: true
   - description: 'Specify volume type, options: "pvc","configMap","secret","emptyDir"'
     jsonKey: type
@@ -395,6 +467,7 @@
     sort: 100
     uiType: Select
     validate:
+      immutable: false
       options:
       - label: Pvc
         value: pvc
@@ -405,28 +478,6 @@
       - label: EmptyDir
         value: emptyDir
       required: true
-  - description: ""
-    jsonKey: mountPath
-    label: MountPath
-    sort: 100
-    uiType: Input
-    validate:
-      required: true
   uiType: Structs
-  validate: {}
-- description: If addRevisionLabel is true, the appRevision label will be added to
-    the underlying pods
-  disable: true
-  jsonKey: addRevisionLabel
-  label: AddRevisionLabel
-  sort: 100
-  uiType: Switch
   validate:
-    defaultValue: false
-    required: true
-- description: Specify image pull secrets for your service
-  jsonKey: imagePullSecrets
-  label: ImagePullSecrets
-  sort: 100
-  uiType: Strings
-  validate: {}
+    immutable: false

--- a/pkg/apiserver/rest/usecase/workflow_model.go
+++ b/pkg/apiserver/rest/usecase/workflow_model.go
@@ -106,10 +106,10 @@ func GetSuitableDeployWay(ctx context.Context, kubeClient client.Client, ds data
 			// using Deploy2Env by default
 		}
 		if definition != nil {
-			if definition.Spec.Workload.Type == TerraformWorkfloadType {
+			if definition.Spec.Workload.Type == TerraformWorkloadType {
 				return DeployCloudResource
 			}
-			if definition.Spec.Workload.Definition.Kind == TerraformWorkfloadKind {
+			if definition.Spec.Workload.Definition.Kind == TerraformWorkloadKind {
 				return DeployCloudResource
 			}
 		}

--- a/pkg/apiserver/rest/utils/bcode/001_application.go
+++ b/pkg/apiserver/rest/utils/bcode/001_application.go
@@ -90,3 +90,6 @@ var ErrInvalidWebhookPayloadBody = NewBcode(400, 10023, "Invalid webhook payload
 
 // ErrApplicationTriggerNotExist means application trigger is not exist
 var ErrApplicationTriggerNotExist = NewBcode(404, 10024, "application trigger is not exist")
+
+// ErrApplicationComponetNotAllowDelete means the component is main in one application, and it must be deleted before delete app.
+var ErrApplicationComponetNotAllowDelete = NewBcode(400, 10025, "main component in application can not be deleted")

--- a/pkg/apiserver/rest/webservice/application.go
+++ b/pkg/apiserver/rest/webservice/application.go
@@ -196,11 +196,24 @@ func (c *applicationWebService) GetWebService() *restful.WebService {
 		Filter(c.appCheckFilter).
 		Filter(c.componentCheckFilter).
 		Param(ws.PathParameter("name", "identifier of the application").DataType("string")).
+		Param(ws.PathParameter("compName", "identifier of the component").DataType("string")).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Reads(apis.UpdateApplicationComponentRequest{}).
 		Returns(200, "", apis.ComponentBase{}).
 		Returns(400, "", bcode.Bcode{}).
 		Writes(apis.ComponentBase{}))
+
+	ws.Route(ws.DELETE("/{name}/components/{compName}").To(c.deleteComponent).
+		Doc("delete a component").
+		Filter(c.appCheckFilter).
+		Filter(c.componentCheckFilter).
+		Param(ws.PathParameter("name", "identifier of the application").DataType("string")).
+		Param(ws.PathParameter("compName", "identifier of the component").DataType("string")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(200, "", apis.EmptyResponse{}).
+		Returns(400, "", bcode.Bcode{}).
+		Returns(404, "", bcode.Bcode{}).
+		Writes(apis.EmptyResponse{}))
 
 	ws.Route(ws.GET("/{name}/policies").To(c.listApplicationPolicies).
 		Doc("list policy for application").
@@ -701,7 +714,7 @@ func (c *applicationWebService) createComponent(req *restful.Request, res *restf
 		bcode.ReturnError(req, res, err)
 		return
 	}
-	base, err := c.applicationUsecase.AddComponent(req.Request.Context(), app, createReq)
+	base, err := c.applicationUsecase.CreateComponent(req.Request.Context(), app, createReq)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return
@@ -749,6 +762,20 @@ func (c *applicationWebService) updateComponent(req *restful.Request, res *restf
 	}
 }
 
+func (c *applicationWebService) deleteComponent(req *restful.Request, res *restful.Response) {
+	app := req.Request.Context().Value(&apis.CtxKeyApplication).(*model.Application)
+	component := req.Request.Context().Value(&apis.CtxKeyApplicationComponent).(*model.ApplicationComponent)
+	err := c.applicationUsecase.DeleteComponent(req.Request.Context(), app, component)
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+	if err := res.WriteEntity(apis.EmptyResponse{}); err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}
+
 func (c *applicationWebService) createApplicationPolicy(req *restful.Request, res *restful.Response) {
 	app := req.Request.Context().Value(&apis.CtxKeyApplication).(*model.Application)
 	// Verify the validity of parameters
@@ -761,7 +788,7 @@ func (c *applicationWebService) createApplicationPolicy(req *restful.Request, re
 		bcode.ReturnError(req, res, err)
 		return
 	}
-	base, err := c.applicationUsecase.AddPolicy(req.Request.Context(), app, createReq)
+	base, err := c.applicationUsecase.CreatePolicy(req.Request.Context(), app, createReq)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return

--- a/test/e2e-apiserver-test/application_test.go
+++ b/test/e2e-apiserver-test/application_test.go
@@ -266,6 +266,16 @@ var _ = Describe("Test application rest api", func() {
 		Expect(cmp.Diff(res.StatusCode, 200)).Should(BeEmpty())
 	})
 
+	It("Test delete component", func() {
+		defer GinkgoRecover()
+		req, err := http.NewRequest(http.MethodDelete, "http://127.0.0.1:8000/api/v1/applications/"+appName+"/components/test2", nil)
+		Expect(err).ShouldNot(HaveOccurred())
+		res, err := http.DefaultClient.Do(req)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(res).ShouldNot(BeNil())
+		Expect(cmp.Diff(res.StatusCode, 200)).Should(BeEmpty())
+	})
+
 	It("Test create application policy", func() {
 		defer GinkgoRecover()
 		var req = apisv1.CreatePolicyRequest{


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

1. add an API for delete component;
2. support creating traits in create component API.
3. add `main` param for the component.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.