### PR TITLE
Fix: Position of  parameter  is always changing on addon's details page.

### DIFF
--- a/pkg/apiserver/rest/usecase/definition.go
+++ b/pkg/apiserver/rest/usecase/definition.go
@@ -318,7 +318,37 @@ func renderDefaultUISchema(apiSchema *openapi3.Schema) []*utils.UIParameter {
 			params = append(params, param)
 		}
 	}
+	sortDefaultUISchema(params)
 	return params
+}
+
+// Sort Default UISchema
+// 1.Check validate.required. It is True, the sort number will be lower.
+// 2.Check subParameters. The more subparameters, the larger the sort number.
+// 3.If validate.required or subParameters is equal, sort by Label
+//
+// The sort number starts with 100.
+func sortDefaultUISchema(params []*utils.UIParameter) {
+	sort.Slice(params, func(i, j int) bool {
+		switch {
+		case params[i].Validate.Required && !params[j].Validate.Required:
+			return true
+		case !params[i].Validate.Required && params[j].Validate.Required:
+			return false
+		default:
+			switch {
+			case len(params[i].SubParameters) < len(params[j].SubParameters):
+				return true
+			case len(params[i].SubParameters) > len(params[j].SubParameters):
+				return false
+			default:
+				return params[i].Label < params[j].Label
+			}
+		}
+	})
+	for i, param := range params {
+		param.Sort += uint(i)
+	}
 }
 
 func renderUIParameter(key, label string, property *openapi3.SchemaRef, required []string) *utils.UIParameter {

--- a/pkg/apiserver/rest/usecase/definition_test.go
+++ b/pkg/apiserver/rest/usecase/definition_test.go
@@ -161,6 +161,9 @@ var _ = Describe("Test namespace usecase functions", func() {
 		err = ioutil.WriteFile("./testdata/ui-schema.yaml", outdata, 0755)
 		Expect(err).Should(Succeed())
 	})
+
+	It("Test sortDefaultUISchema", testSortDefaultUISchema)
+
 })
 
 func TestAddDefinitionUISchema(t *testing.T) {
@@ -183,5 +186,126 @@ func TestAddDefinitionUISchema(t *testing.T) {
 			}
 			t.Logf("create ui schema %s for %s definition", definitionName, typeNames[0])
 		}
+	}
+}
+func testSortDefaultUISchema() {
+	var params = []*utils.UIParameter{
+		{
+			Label: "P1",
+			Validate: &utils.Validate{
+				Required: true,
+			},
+			SubParameters: []*utils.UIParameter{
+				{Label: "P1S1"},
+			},
+			Sort: 100,
+		}, {
+			Label: "T2",
+			Validate: &utils.Validate{
+				Required: true,
+			},
+			SubParameters: []*utils.UIParameter{
+				{Label: "T2S1"},
+				{Label: "T2S2"},
+				{Label: "T2S3"},
+			},
+			Sort: 100,
+		}, {
+			Label: "T3",
+			Validate: &utils.Validate{
+				Required: false,
+			},
+			Sort: 100,
+		}, {
+			Label: "P4",
+			Validate: &utils.Validate{
+				Required: false,
+			},
+			Sort: 100,
+		}, {
+			Label: "T5",
+			Validate: &utils.Validate{
+				Required: true,
+			},
+			SubParameters: []*utils.UIParameter{
+				{Label: "T5S1"},
+				{Label: "T5S2"},
+			},
+			Sort: 100,
+		}, {
+			Label: "P6",
+			Validate: &utils.Validate{
+				Required: true,
+			},
+			SubParameters: []*utils.UIParameter{
+				{Label: "P6S1"},
+				{Label: "P6S2"},
+				{Label: "P6S3"},
+			},
+			Sort: 100,
+		},
+	}
+
+	var expectedParams = []*utils.UIParameter{
+		{
+			Label: "P1",
+			Validate: &utils.Validate{
+				Required: true,
+			},
+			SubParameters: []*utils.UIParameter{
+				{Label: "P1S1"},
+			},
+			Sort: 100,
+		}, {
+			Label: "T5",
+			Validate: &utils.Validate{
+				Required: true,
+			},
+			SubParameters: []*utils.UIParameter{
+				{Label: "T5S1"},
+				{Label: "T5S2"},
+			},
+			Sort: 101,
+		}, {
+			Label: "P6",
+			Validate: &utils.Validate{
+				Required: true,
+			},
+			SubParameters: []*utils.UIParameter{
+				{Label: "P6S1"},
+				{Label: "P6S2"},
+				{Label: "P6S3"},
+			},
+			Sort: 102,
+		}, {
+			Label: "T2",
+			Validate: &utils.Validate{
+				Required: true,
+			},
+			SubParameters: []*utils.UIParameter{
+				{Label: "T2S1"},
+				{Label: "T2S2"},
+				{Label: "T2S3"},
+			},
+			Sort: 103,
+		}, {
+			Label: "P4",
+			Validate: &utils.Validate{
+				Required: false,
+			},
+			Sort: 104,
+		}, {
+			Label: "T3",
+			Validate: &utils.Validate{
+				Required: false,
+			},
+			Sort: 105,
+		},
+	}
+
+	sortDefaultUISchema(params)
+	for i, param := range params {
+		Expect(param.Label).Should(Equal(expectedParams[i].Label))
+		Expect(param.Sort).Should(Equal(expectedParams[i].Sort))
 	}
 }


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3344 

Before:
The default value of "sort" is 100

After:
Set fixed value for every parameter


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->