### PR TITLE
Fix: fix hard code service account name in test

### DIFF
--- a/charts/vela-core/templates/test/test-application.yaml
+++ b/charts/vela-core/templates/test/test-application.yaml
@@ -29,7 +29,7 @@ metadata:
     "helm.sh/hook": test
     helm.sh/hook-delete-policy: hook-succeeded
 spec:
-  serviceAccountName: kubevela-vela-core
+  serviceAccountName: {{ include "kubevela.serviceAccountName" . }}
   containers:
     - name: {{ .Release.Name }}-application-test
       image: {{ .Values.imageRegistry }}{{ .Values.test.k8s.repository }}:{{ .Values.test.k8s.tag }}


### PR DESCRIPTION
fix test hook in helm chart with  hard code service account name

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3266

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->