### PR TITLE
Fix: windows vela cli addon bug

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -89,7 +89,7 @@ const (
 )
 
 // ParameterFileName is the addon resources/parameter.cue file name
-var ParameterFileName = filepath.Join("resources", "parameter.cue")
+var ParameterFileName = strings.Join([]string{"resources", "parameter.cue"}, "/")
 
 // ListOptions contains flags mark what files should be read in an addon directory
 type ListOptions struct {
@@ -182,7 +182,7 @@ var Patterns = []Pattern{{Value: ReadmeFileName}, {Value: MetadataFileName}, {Va
 func GetPatternFromItem(it Item, r AsyncReader, rootPath string) string {
 	relativePath := r.RelativePath(it)
 	for _, p := range Patterns {
-		if strings.HasPrefix(relativePath, filepath.Join(rootPath, p.Value)) {
+		if strings.HasPrefix(relativePath, strings.Join([]string{rootPath, p.Value}, "/")) {
 			return p.Value
 		}
 	}


### PR DESCRIPTION
Fix vela cli  addon bug in windows env. The root cause is misused of `filepath.join` func.

In linux  the separator is "/" but in windows is "\". The result won't match the url path. 

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3144 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->