### PR TITLE
Fix: clone request if round tripper modifies it

### DIFF
--- a/pkg/multicluster/proxy.go
+++ b/pkg/multicluster/proxy.go
@@ -51,7 +51,7 @@ func (rt *secretMultiClusterRoundTripper) RoundTrip(req *http.Request) (*http.Re
 	if !ok || clusterName == "" || clusterName == ClusterLocalName {
 		return rt.rt.RoundTrip(req)
 	}
-
+	req = req.Clone(ctx)
 	req.URL.Path = FormatProxyURL(clusterName, req.URL.Path)
 	return rt.rt.RoundTrip(req)
 }
@@ -85,7 +85,9 @@ type secretMultiClusterRoundTripperForCluster struct {
 
 // RoundTrip is the main function for the re-write API path logic
 func (rt *secretMultiClusterRoundTripperForCluster) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
 	if rt.clusterName != "" && rt.clusterName != ClusterLocalName {
+		req = req.Clone(ctx)
 		req.URL.Path = FormatProxyURL(rt.clusterName, req.URL.Path)
 	}
 	return rt.rt.RoundTrip(req)


### PR DESCRIPTION
### Description of your changes

Currently, multicluster round trippers are modifying request directly.
However, [golang documentation](https://pkg.go.dev/net/http#RoundTripper) says `RoundTrip` should not modify the request.

> RoundTrip should not modify the request, except for consuming and closing the Request's Body.
> RoundTrip may read fields of the request in a separate goroutine.
> Callers should not mutate or reuse the request until the Response's Body has been closed.

This commit fixes round trippers to clone the request before the modification.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

### Special notes for your reviewer

I referred following links:

- [golang-nuts / Correct use of http.RoundTripper](https://groups.google.com/g/golang-nuts/c/-j6p12SSpXI)
- [client-go round trippers](https://github.com/kubernetes/client-go/blob/35bf219cc60981cdf318b711e2630cc05e0a83e5/transport/round_trippers.go)