### PR TITLE
Fix: separate waiting and failed backoff time and make them configurable

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -108,6 +108,11 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       - name: Cache Go Dependencies
         uses: actions/cache@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ staticcheck: staticchecktool
 lint: golangci
 	$(GOLANGCILINT) run ./...
 
-reviewable: manifests fmt vet lint staticcheck
+reviewable: manifests fmt vet lint staticcheck helm-doc-gen
 	go mod tidy
 
 # Execute auto-gen code commands and ensure branch is clean.

--- a/charts/vela-core/README.md
+++ b/charts/vela-core/README.md
@@ -38,17 +38,20 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wai
 
 ### KubeVela core parameters
 
-| Name                          | Description                                                                                   | Value     |
-| ----------------------------- | --------------------------------------------------------------------------------------------- | --------- |
-| `systemDefinitionNamespace`   | System definition namespace, if unspecified, will use built-in variable `.Release.Namespace`. | `nil`     |
-| `applicationRevisionLimit`    | Application revision limit                                                                    | `10`      |
-| `definitionRevisionLimit`     | Definition revision limit                                                                     | `20`      |
-| `concurrentReconciles`        | concurrentReconciles is the concurrent reconcile number of the controller                     | `4`       |
-| `controllerArgs.reSyncPeriod` | The period for resync the applications                                                        | `5m`      |
-| `OAMSpecVer`                  | OAMSpecVer is the oam spec version controller want to setup                                   | `v0.3`    |
-| `disableCaps`                 | Disable capability                                                                            | `rollout` |
-| `enableFluxcdAddon`           | Whether to enable fluxcd addon                                                                | `false`   |
-| `dependCheckWait`             | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`     |
+| Name                             | Description                                                                                   | Value     |
+| -------------------------------- | --------------------------------------------------------------------------------------------- | --------- |
+| `systemDefinitionNamespace`      | System definition namespace, if unspecified, will use built-in variable `.Release.Namespace`. | `nil`     |
+| `applicationRevisionLimit`       | Application revision limit                                                                    | `10`      |
+| `definitionRevisionLimit`        | Definition revision limit                                                                     | `20`      |
+| `concurrentReconciles`           | concurrentReconciles is the concurrent reconcile number of the controller                     | `4`       |
+| `maxWorkflowWaitBackoffTime`     | is the max backoff time of workflow in a wait condition                                       | `60`      |
+| `maxWorkflowFailedBackoffTime`   | is the max backoff time of workflow in a failed condition                                     | `300`     |
+| `maxWorkflowStepErrorRetryTimes` | is the max retry times of a failed workflow step                                              | `10`      |
+| `controllerArgs.reSyncPeriod`    | The period for resync the applications                                                        | `5m`      |
+| `OAMSpecVer`                     | OAMSpecVer is the oam spec version controller want to setup                                   | `v0.3`    |
+| `disableCaps`                    | Disable capability                                                                            | `rollout` |
+| `enableFluxcdAddon`              | Whether to enable fluxcd addon                                                                | `false`   |
+| `dependCheckWait`                | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`     |
 
 
 ### KubeVela controller parameters

--- a/charts/vela-core/README.md
+++ b/charts/vela-core/README.md
@@ -38,20 +38,26 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wai
 
 ### KubeVela core parameters
 
-| Name                             | Description                                                                                   | Value     |
-| -------------------------------- | --------------------------------------------------------------------------------------------- | --------- |
-| `systemDefinitionNamespace`      | System definition namespace, if unspecified, will use built-in variable `.Release.Namespace`. | `nil`     |
-| `applicationRevisionLimit`       | Application revision limit                                                                    | `10`      |
-| `definitionRevisionLimit`        | Definition revision limit                                                                     | `20`      |
-| `concurrentReconciles`           | concurrentReconciles is the concurrent reconcile number of the controller                     | `4`       |
-| `maxWorkflowWaitBackoffTime`     | is the max backoff time of workflow in a wait condition                                       | `60`      |
-| `maxWorkflowFailedBackoffTime`   | is the max backoff time of workflow in a failed condition                                     | `300`     |
-| `maxWorkflowStepErrorRetryTimes` | is the max retry times of a failed workflow step                                              | `10`      |
-| `controllerArgs.reSyncPeriod`    | The period for resync the applications                                                        | `5m`      |
-| `OAMSpecVer`                     | OAMSpecVer is the oam spec version controller want to setup                                   | `v0.3`    |
-| `disableCaps`                    | Disable capability                                                                            | `rollout` |
-| `enableFluxcdAddon`              | Whether to enable fluxcd addon                                                                | `false`   |
-| `dependCheckWait`                | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`     |
+| Name                          | Description                                                                                   | Value     |
+| ----------------------------- | --------------------------------------------------------------------------------------------- | --------- |
+| `systemDefinitionNamespace`   | System definition namespace, if unspecified, will use built-in variable `.Release.Namespace`. | `nil`     |
+| `applicationRevisionLimit`    | Application revision limit                                                                    | `10`      |
+| `definitionRevisionLimit`     | Definition revision limit                                                                     | `20`      |
+| `concurrentReconciles`        | concurrentReconciles is the concurrent reconcile number of the controller                     | `4`       |
+| `controllerArgs.reSyncPeriod` | The period for resync the applications                                                        | `5m`      |
+| `OAMSpecVer`                  | OAMSpecVer is the oam spec version controller want to setup                                   | `v0.3`    |
+| `disableCaps`                 | Disable capability                                                                            | `rollout` |
+| `enableFluxcdAddon`           | Whether to enable fluxcd addon                                                                | `false`   |
+| `dependCheckWait`             | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`     |
+
+
+### KubeVela workflow parameters
+
+| Name                                   | Description                                            | Value |
+| -------------------------------------- | ------------------------------------------------------ | ----- |
+| `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition   | `60`  |
+| `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition | `300` |
+| `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step          | `10`  |
 
 
 ### KubeVela controller parameters

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -136,6 +136,9 @@ spec:
             - "--concurrent-reconciles={{ .Values.concurrentReconciles }}"
             - "--kube-api-qps={{ .Values.kubeClient.qps }}"
             - "--kube-api-burst={{ .Values.kubeClient.brust }}"
+            - "--max-workflow-wait-backoff-time={{ .Values.maxWorkflowWaitBackoffTime }}"
+            - "--max-workflow-failed-backoff-time={{ .Values.maxWorkflowFailedBackoffTime }}"
+            - "--max-workflow-step-error-retry-times={{ .Values.maxWorkflowStepErrorRetryTimes }}"
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
           resources:

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -136,9 +136,9 @@ spec:
             - "--concurrent-reconciles={{ .Values.concurrentReconciles }}"
             - "--kube-api-qps={{ .Values.kubeClient.qps }}"
             - "--kube-api-burst={{ .Values.kubeClient.brust }}"
-            - "--max-workflow-wait-backoff-time={{ .Values.maxWorkflowWaitBackoffTime }}"
-            - "--max-workflow-failed-backoff-time={{ .Values.maxWorkflowFailedBackoffTime }}"
-            - "--max-workflow-step-error-retry-times={{ .Values.maxWorkflowStepErrorRetryTimes }}"
+            - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
+            - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
+            - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
           resources:

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -16,13 +16,6 @@ definitionRevisionLimit: 20
 ## @param concurrentReconciles concurrentReconciles is the concurrent reconcile number of the controller
 concurrentReconciles: 4
 
-## @param maxWorkflowWaitBackoffTime is the max backoff time of workflow in a wait condition
-maxWorkflowWaitBackoffTime: 60
-## @param maxWorkflowFailedBackoffTime is the max backoff time of workflow in a failed condition
-maxWorkflowFailedBackoffTime: 300
-## @param maxWorkflowStepErrorRetryTimes is the max retry times of a failed workflow step
-maxWorkflowStepErrorRetryTimes: 10
-
 ## @param controllerArgs.reSyncPeriod The period for resync the applications
 controllerArgs:
   reSyncPeriod: 5m
@@ -38,6 +31,20 @@ enableFluxcdAddon: false
 
 ## @param dependCheckWait dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready
 dependCheckWait: 30s
+
+
+## @section KubeVela workflow parameters
+
+## @param workflow.backoff.maxTime.waitState The max backoff time of workflow in a wait condition
+## @param workflow.backoff.maxTime.failedState The max backoff time of workflow in a failed condition
+## @param workflow.step.errorRetryTimes The max retry times of a failed workflow step
+workflow:
+  backoff:
+    maxTime:
+      waitState: 60
+      failedState: 300
+  step:
+    errorRetryTimes: 10
 
 
 ## @section KubeVela controller parameters

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -16,6 +16,13 @@ definitionRevisionLimit: 20
 ## @param concurrentReconciles concurrentReconciles is the concurrent reconcile number of the controller
 concurrentReconciles: 4
 
+## @param maxWorkflowWaitBackoffTime is the max backoff time of workflow in a wait condition
+maxWorkflowWaitBackoffTime: 60
+## @param maxWorkflowFailedBackoffTime is the max backoff time of workflow in a failed condition
+maxWorkflowFailedBackoffTime: 300
+## @param maxWorkflowStepErrorRetryTimes is the max retry times of a failed workflow step
+maxWorkflowStepErrorRetryTimes: 10
+
 ## @param controllerArgs.reSyncPeriod The period for resync the applications
 controllerArgs:
   reSyncPeriod: 5m

--- a/charts/vela-minimal/README.md
+++ b/charts/vela-minimal/README.md
@@ -56,21 +56,27 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-minimal --
 
 ### KubeVela core parameters
 
-| Name                             | Description                                                                                   | Value                                                        |
-| -------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `systemDefinitionNamespace`      | System definition namespace, if unspecified, will use built-in variable `.Release.Namespace`. | `nil`                                                        |
-| `applicationRevisionLimit`       | Application revision limit                                                                    | `10`                                                         |
-| `definitionRevisionLimit`        | Definition revision limit                                                                     | `20`                                                         |
-| `concurrentReconciles`           | concurrentReconciles is the concurrent reconcile number of the controller                     | `4`                                                          |
-| `maxWorkflowWaitBackoffTime`     | is the max backoff time of workflow in a wait condition                                       | `60`                                                         |
-| `maxWorkflowFailedBackoffTime`   | is the max backoff time of workflow in a failed condition                                     | `300`                                                        |
-| `maxWorkflowStepErrorRetryTimes` | is the max retry times of a failed workflow step                                              | `10`                                                         |
-| `controllerArgs.reSyncPeriod`    | The period for resync the applications                                                        | `5m`                                                         |
-| `OAMSpecVer`                     | OAMSpecVer is the oam spec version controller want to setup                                   | `minimal`                                                    |
-| `disableCaps`                    | Disable capability                                                                            | `manualscalertrait,containerizedwokrload,envbinding,rollout` |
-| `applyOnceOnly`                  | Valid applyOnceOnly values: true/false/on/off/force                                           | `off`                                                        |
-| `enableFluxcdAddon`              | Whether to enable fluxcd addon                                                                | `false`                                                      |
-| `dependCheckWait`                | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`                                                        |
+| Name                          | Description                                                                                   | Value                                                        |
+| ----------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `systemDefinitionNamespace`   | System definition namespace, if unspecified, will use built-in variable `.Release.Namespace`. | `nil`                                                        |
+| `applicationRevisionLimit`    | Application revision limit                                                                    | `10`                                                         |
+| `definitionRevisionLimit`     | Definition revision limit                                                                     | `20`                                                         |
+| `concurrentReconciles`        | concurrentReconciles is the concurrent reconcile number of the controller                     | `4`                                                          |
+| `controllerArgs.reSyncPeriod` | The period for resync the applications                                                        | `5m`                                                         |
+| `OAMSpecVer`                  | OAMSpecVer is the oam spec version controller want to setup                                   | `minimal`                                                    |
+| `disableCaps`                 | Disable capability                                                                            | `manualscalertrait,containerizedwokrload,envbinding,rollout` |
+| `applyOnceOnly`               | Valid applyOnceOnly values: true/false/on/off/force                                           | `off`                                                        |
+| `enableFluxcdAddon`           | Whether to enable fluxcd addon                                                                | `false`                                                      |
+| `dependCheckWait`             | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`                                                        |
+
+
+### KubeVela workflow parameters
+
+| Name                                   | Description                                            | Value |
+| -------------------------------------- | ------------------------------------------------------ | ----- |
+| `workflow.backoff.maxTime.waitState`   | The max backoff time of workflow in a wait condition   | `60`  |
+| `workflow.backoff.maxTime.failedState` | The max backoff time of workflow in a failed condition | `300` |
+| `workflow.step.errorRetryTimes`        | The max retry times of a failed workflow step          | `10`  |
 
 
 ### KubeVela controller parameters

--- a/charts/vela-minimal/README.md
+++ b/charts/vela-minimal/README.md
@@ -56,18 +56,21 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-minimal --
 
 ### KubeVela core parameters
 
-| Name                          | Description                                                                                   | Value                                                        |
-| ----------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `systemDefinitionNamespace`   | System definition namespace, if unspecified, will use built-in variable `.Release.Namespace`. | `nil`                                                        |
-| `applicationRevisionLimit`    | Application revision limit                                                                    | `10`                                                         |
-| `definitionRevisionLimit`     | Definition revision limit                                                                     | `20`                                                         |
-| `concurrentReconciles`        | concurrentReconciles is the concurrent reconcile number of the controller                     | `4`                                                          |
-| `controllerArgs.reSyncPeriod` | The period for resync the applications                                                        | `5m`                                                         |
-| `OAMSpecVer`                  | OAMSpecVer is the oam spec version controller want to setup                                   | `minimal`                                                    |
-| `disableCaps`                 | Disable capability                                                                            | `manualscalertrait,containerizedwokrload,envbinding,rollout` |
-| `applyOnceOnly`               | Valid applyOnceOnly values: true/false/on/off/force                                           | `off`                                                        |
-| `enableFluxcdAddon`           | Whether to enable fluxcd addon                                                                | `false`                                                      |
-| `dependCheckWait`             | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`                                                        |
+| Name                             | Description                                                                                   | Value                                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `systemDefinitionNamespace`      | System definition namespace, if unspecified, will use built-in variable `.Release.Namespace`. | `nil`                                                        |
+| `applicationRevisionLimit`       | Application revision limit                                                                    | `10`                                                         |
+| `definitionRevisionLimit`        | Definition revision limit                                                                     | `20`                                                         |
+| `concurrentReconciles`           | concurrentReconciles is the concurrent reconcile number of the controller                     | `4`                                                          |
+| `maxWorkflowWaitBackoffTime`     | is the max backoff time of workflow in a wait condition                                       | `60`                                                         |
+| `maxWorkflowFailedBackoffTime`   | is the max backoff time of workflow in a failed condition                                     | `300`                                                        |
+| `maxWorkflowStepErrorRetryTimes` | is the max retry times of a failed workflow step                                              | `10`                                                         |
+| `controllerArgs.reSyncPeriod`    | The period for resync the applications                                                        | `5m`                                                         |
+| `OAMSpecVer`                     | OAMSpecVer is the oam spec version controller want to setup                                   | `minimal`                                                    |
+| `disableCaps`                    | Disable capability                                                                            | `manualscalertrait,containerizedwokrload,envbinding,rollout` |
+| `applyOnceOnly`                  | Valid applyOnceOnly values: true/false/on/off/force                                           | `off`                                                        |
+| `enableFluxcdAddon`              | Whether to enable fluxcd addon                                                                | `false`                                                      |
+| `dependCheckWait`                | dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready   | `30s`                                                        |
 
 
 ### KubeVela controller parameters

--- a/charts/vela-minimal/templates/kubevela-controller.yaml
+++ b/charts/vela-minimal/templates/kubevela-controller.yaml
@@ -139,9 +139,9 @@ spec:
             - "--concurrent-reconciles={{ .Values.concurrentReconciles }}"
             - "--kube-api-qps={{ .Values.kubeClient.qps }}"
             - "--kube-api-burst={{ .Values.kubeClient.brust }}"
-            - "--max-workflow-wait-backoff-time={{ .Values.maxWorkflowWaitBackoffTime }}"
-            - "--max-workflow-failed-backoff-time={{ .Values.maxWorkflowFailedBackoffTime }}"
-            - "--max-workflow-step-error-retry-times={{ .Values.maxWorkflowStepErrorRetryTimes }}"
+            - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
+            - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
+            - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
           resources:

--- a/charts/vela-minimal/templates/kubevela-controller.yaml
+++ b/charts/vela-minimal/templates/kubevela-controller.yaml
@@ -139,6 +139,9 @@ spec:
             - "--concurrent-reconciles={{ .Values.concurrentReconciles }}"
             - "--kube-api-qps={{ .Values.kubeClient.qps }}"
             - "--kube-api-burst={{ .Values.kubeClient.brust }}"
+            - "--max-workflow-wait-backoff-time={{ .Values.maxWorkflowWaitBackoffTime }}"
+            - "--max-workflow-failed-backoff-time={{ .Values.maxWorkflowFailedBackoffTime }}"
+            - "--max-workflow-step-error-retry-times={{ .Values.maxWorkflowStepErrorRetryTimes }}"
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
           resources:

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -16,13 +16,6 @@ definitionRevisionLimit: 20
 ## @param concurrentReconciles concurrentReconciles is the concurrent reconcile number of the controller
 concurrentReconciles: 4
 
-## @param maxWorkflowWaitBackoffTime is the max backoff time of workflow in a wait condition
-maxWorkflowWaitBackoffTime: 60
-## @param maxWorkflowFailedBackoffTime is the max backoff time of workflow in a failed condition
-maxWorkflowFailedBackoffTime: 300
-## @param maxWorkflowStepErrorRetryTimes is the max retry times of a failed workflow step
-maxWorkflowStepErrorRetryTimes: 10
-
 ## @param controllerArgs.reSyncPeriod The period for resync the applications
 controllerArgs:
   reSyncPeriod: 5m
@@ -41,6 +34,21 @@ enableFluxcdAddon: false
 
 ## @param dependCheckWait dependCheckWait is the time to wait for ApplicationConfiguration's dependent-resource ready
 dependCheckWait: 30s
+
+
+## @section KubeVela workflow parameters
+
+## @param workflow.backoff.maxTime.waitState The max backoff time of workflow in a wait condition
+## @param workflow.backoff.maxTime.failedState The max backoff time of workflow in a failed condition
+## @param workflow.step.errorRetryTimes The max retry times of a failed workflow step
+workflow:
+  backoff:
+    maxTime:
+      waitState: 60
+      failedState: 300
+  step:
+    errorRetryTimes: 10
+
 
 ## @section KubeVela controller parameters
 

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -16,6 +16,13 @@ definitionRevisionLimit: 20
 ## @param concurrentReconciles concurrentReconciles is the concurrent reconcile number of the controller
 concurrentReconciles: 4
 
+## @param maxWorkflowWaitBackoffTime is the max backoff time of workflow in a wait condition
+maxWorkflowWaitBackoffTime: 60
+## @param maxWorkflowFailedBackoffTime is the max backoff time of workflow in a failed condition
+maxWorkflowFailedBackoffTime: 300
+## @param maxWorkflowStepErrorRetryTimes is the max retry times of a failed workflow step
+maxWorkflowStepErrorRetryTimes: 10
+
 ## @param controllerArgs.reSyncPeriod The period for resync the applications
 controllerArgs:
   reSyncPeriod: 5m

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -30,8 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oam-dev/kubevela/pkg/utils/util"
-
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -51,7 +49,10 @@ import (
 	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/system"
+	"github.com/oam-dev/kubevela/pkg/utils/util"
 	oamwebhook "github.com/oam-dev/kubevela/pkg/webhook/core.oam.dev"
+	"github.com/oam-dev/kubevela/pkg/workflow"
+	"github.com/oam-dev/kubevela/pkg/workflow/tasks/custom"
 	"github.com/oam-dev/kubevela/version"
 )
 
@@ -136,6 +137,9 @@ func main() {
 	flag.BoolVar(&controllerArgs.IgnoreAppWithoutControllerRequirement, "ignore-app-without-controller-version", false, "If true, application controller will not process the app without 'app.oam.dev/controller-version-require' annotation")
 	standardcontroller.AddOptimizeFlags()
 	flag.IntVar(&resourcekeeper.MaxDispatchConcurrent, "max-dispatch-concurrent", 10, "Set the max dispatch concurrent number, default is 10")
+	flag.IntVar(&workflow.MaxWorkflowWaitBackoffTime, "max-workflow-wait-backoff-time", 60, "Set the max workflow wait backoff time, default is 60")
+	flag.IntVar(&workflow.MaxWorkflowFailedBackoffTime, "max-workflow-failed-backoff-time", 300, "Set the max workflow wait backoff time, default is 300")
+	flag.IntVar(&custom.MaxWorkflowStepErrorRetryTimes, "max-workflow-step-error-retry-times", 10, "Set the max workflow step error retry times, default is 10")
 
 	flag.Parse()
 	// setup logging

--- a/design/vela-core/workflow_policy.md
+++ b/design/vela-core/workflow_policy.md
@@ -142,7 +142,7 @@ If the status of workflow step is `waiting` or `failed`, the workflow will be re
 int(0.05 * 2^(n-1))
 ```
 
-Based on the above formula, we will take `1s` and `600s` as our min and max time.
+Based on the above formula, we will take `1s` min time.
 
 For example, if the workflow is `waiting`, the first ten reconciliation will be like:
 
@@ -160,13 +160,17 @@ For example, if the workflow is `waiting`, the first ten reconciliation will be 
 | 10 | 512 | 25.6 | 25 |
 | ... | ... | ... | ... |
 
+If the workflow step is `waiting`, the max backoff time is `60s`, you can change it by setting `maxWorkflowWaitBackoffTime`.
+
+If the workflow step is `failed`, the max backoff time is `300s`, you can change it by setting `maxWorkflowFailedBackoffTime`.
+
 #### Failed Workflow Steps
 
 If the workflow step is `failed`, it means that there may be some error in the workflow step, like some cue errors.
 
 > Note that if the workflow step is unhealthy, the workflow step will be marked as `wait` but not `failed` and it will wait for healthy.
 
-For this case, we will retry the workflow step 10 times, and if the workflow step is still `failed`, we will suspend this workflow, and it's message will be `The workflow suspends automatically because the failed times of steps have reached the limit(10 times)`.
+For this case, we will retry the workflow step 10 times by default, and if the workflow step is still `failed`, we will suspend this workflow, and it's message will be `The workflow suspends automatically because the failed times of steps have reached the limit`. You can change the retry times by setting `maxWorkflowStepErrorRetryTimes`.
 
 After the workflow is suspended, we can change the workflow step to make it work, and then use `vela workflow resume <workflow-name>` to resume it.
 

--- a/design/vela-core/workflow_policy.md
+++ b/design/vela-core/workflow_policy.md
@@ -160,9 +160,9 @@ For example, if the workflow is `waiting`, the first ten reconciliation will be 
 | 10 | 512 | 25.6 | 25 |
 | ... | ... | ... | ... |
 
-If the workflow step is `waiting`, the max backoff time is `60s`, you can change it by setting `maxWorkflowWaitBackoffTime`.
+If the workflow step is `waiting`, the max backoff time is `60s`, you can change it by setting `MaxWorkflowWaitBackoffTime`.
 
-If the workflow step is `failed`, the max backoff time is `300s`, you can change it by setting `maxWorkflowFailedBackoffTime`.
+If the workflow step is `failed`, the max backoff time is `300s`, you can change it by setting `MaxWorkflowFailedBackoffTime`.
 
 #### Failed Workflow Steps
 
@@ -170,7 +170,7 @@ If the workflow step is `failed`, it means that there may be some error in the w
 
 > Note that if the workflow step is unhealthy, the workflow step will be marked as `wait` but not `failed` and it will wait for healthy.
 
-For this case, we will retry the workflow step 10 times by default, and if the workflow step is still `failed`, we will suspend this workflow, and it's message will be `The workflow suspends automatically because the failed times of steps have reached the limit`. You can change the retry times by setting `maxWorkflowStepErrorRetryTimes`.
+For this case, we will retry the workflow step 10 times by default, and if the workflow step is still `failed`, we will suspend this workflow, and it's message will be `The workflow suspends automatically because the failed times of steps have reached the limit`. You can change the retry times by setting `MaxWorkflowStepErrorRetryTimes`.
 
 After the workflow is suspended, we can change the workflow step to make it work, and then use `vela workflow resume <workflow-name>` to resume it.
 

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -1690,7 +1690,7 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageInitializingWorkflow))
 
 		By("verify the first twenty reconciles")
-		for i := 0; i < custom.MaxErrorTimes; i++ {
+		for i := 0; i < custom.MaxWorkflowStepErrorRetryTimes; i++ {
 			testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
 			Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 			Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
@@ -1735,7 +1735,7 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 		Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
 
-		for i := 0; i < custom.MaxErrorTimes+1; i++ {
+		for i := 0; i < custom.MaxWorkflowStepErrorRetryTimes+1; i++ {
 			testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
 			Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 			Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))
@@ -1803,7 +1803,7 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(checkApp.Status.Workflow.Message).Should(BeEquivalentTo(workflow.MessageInitializingWorkflow))
 
 		By("verify the first twenty reconciles")
-		for i := 0; i < custom.MaxErrorTimes; i++ {
+		for i := 0; i < custom.MaxWorkflowStepErrorRetryTimes; i++ {
 			testutil.ReconcileOnce(reconciler, reconcile.Request{NamespacedName: appKey})
 			Expect(k8sClient.Get(ctx, appKey, checkApp)).Should(BeNil())
 			Expect(checkApp.Status.Phase).Should(BeEquivalentTo(common.ApplicationRunningWorkflow))

--- a/pkg/workflow/tasks/custom/task.go
+++ b/pkg/workflow/tasks/custom/task.go
@@ -39,6 +39,11 @@ import (
 	wfTypes "github.com/oam-dev/kubevela/pkg/workflow/types"
 )
 
+var (
+	// MaxWorkflowStepErrorRetryTimes is the max retry times of the failed workflow step.
+	MaxWorkflowStepErrorRetryTimes = 10
+)
+
 const (
 	// StatusReasonWait is the reason of the workflow progress condition which is Wait.
 	StatusReasonWait = "Wait"
@@ -54,8 +59,6 @@ const (
 	StatusReasonParameter = "ProcessParameter"
 	// StatusReasonOutput is the reason of the workflow progress condition which is Output.
 	StatusReasonOutput = "Output"
-	// MaxErrorTimes is the max times of the workflow progress condition which is Failed.
-	MaxErrorTimes = 10
 )
 
 // LoadTaskTemplate gets the workflowStep definition from cluster and resolve it.
@@ -289,7 +292,7 @@ func (exec *executor) err(ctx wfContext.Context, err error, reason string) {
 
 func (exec *executor) checkErrorTimes(ctx wfContext.Context) {
 	times := ctx.IncreaseCountValueInMemory(wfTypes.ContextPrefixFailedTimes, exec.wfStatus.ID)
-	if times >= MaxErrorTimes {
+	if times >= MaxWorkflowStepErrorRetryTimes {
 		exec.wait = false
 		exec.failedAfterRetries = true
 	}

--- a/pkg/workflow/tasks/custom/task_test.go
+++ b/pkg/workflow/tasks/custom/task_test.go
@@ -258,7 +258,7 @@ close({
 		case "failed-after-retries":
 			wfContext.CleanupMemoryStore("app-v1", "default")
 			newCtx := newWorkflowContextForTest(t)
-			for i := 0; i < MaxErrorTimes; i++ {
+			for i := 0; i < MaxWorkflowStepErrorRetryTimes; i++ {
 				status, operation, err = run.Run(newCtx, &types.TaskRunOptions{})
 				r.NoError(err)
 				r.Equal(operation.Waiting, true)

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -278,7 +278,7 @@ var _ = Describe("Test Workflow", func() {
 		_, err = wf.ExecuteSteps(ctx, revision, runners)
 		Expect(err).ToNot(HaveOccurred())
 		interval = e.getBackoffWaitTime()
-		Expect(interval).Should(BeEquivalentTo(maxWorkflowBackoffWaitTime))
+		Expect(interval).Should(BeEquivalentTo(MaxWorkflowWaitBackoffTime))
 
 		By("Test get backoff time after clean")
 		wfContext.CleanupMemoryStore(app.Name, app.Namespace)

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Test Workflow", func() {
 			Expect(interval).Should(BeEquivalentTo(minWorkflowBackoffWaitTime))
 		}
 
-		for i := 0; i < 9; i++ {
+		for i := 0; i < 6; i++ {
 			_, err = wf.ExecuteSteps(ctx, revision, runners)
 			Expect(err).ToNot(HaveOccurred())
 			interval := e.getBackoffWaitTime()


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

separate waiting and failed backoff time and make them configurable

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

/cc @Somefive @wonderflow @leejanee 