### PR TITLE
Fix: auto deploy spec missing

### DIFF
--- a/pkg/workflow/step/dependency_test.go
+++ b/pkg/workflow/step/dependency_test.go
@@ -42,7 +42,7 @@ func TestLoadExternalPoliciesForWorkflow(t *testing.T) {
 	policies, err := LoadExternalPoliciesForWorkflow(context.Background(), cli, "demo", []v1beta1.WorkflowStep{{
 		Name:       "deploy",
 		Type:       DeployWorkflowStep,
-		Properties: &runtime.RawExtension{Raw: []byte(`{"policies":["ex","internal"]}`)},
+		Properties: &runtime.RawExtension{Raw: []byte(`{"auto":false,"policies":["ex","internal"]}`)},
 	}}, []v1beta1.AppPolicy{{
 		Name: "internal",
 		Type: "internal",

--- a/pkg/workflow/step/generator.go
+++ b/pkg/workflow/step/generator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	"github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/kubevela/pkg/utils"
 )
 
 // WorkflowStepGenerator generator generates workflow steps
@@ -165,11 +166,9 @@ func (g *DeployPreApproveWorkflowStepGenerator) Generate(app *v1beta1.Applicatio
 	lastSuspend := false
 	for _, step := range existingSteps {
 		if step.Type == "deploy" && !lastSuspend {
-			cfg := map[string]interface{}{}
-			_ = json.Unmarshal(step.Properties.Raw, &cfg)
-			_auto, found := cfg["auto"]
-			auto, isBool := _auto.(bool)
-			if found && isBool && !auto {
+			props := DeployWorkflowStepSpec{}
+			_ = utils.StrictUnmarshal(step.Properties.Raw, &props)
+			if props.Auto != nil && !*props.Auto {
 				steps = append(steps, v1beta1.WorkflowStep{
 					Name: "manual-approve-" + step.Name,
 					Type: "suspend",

--- a/pkg/workflow/step/types.go
+++ b/pkg/workflow/step/types.go
@@ -23,5 +23,7 @@ const (
 
 // DeployWorkflowStepSpec the spec of `deploy` WorkflowStep
 type DeployWorkflowStepSpec struct {
+	// Auto nil/true mean auto deploy, false means additional pre-approve step will be injected before the deploy step
+	Auto     *bool    `json:"auto,omitempty"`
 	Policies []string `json:"policies,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

The `deploy` WorkflowStep has the `auto` field which is not included in the spec. The strict unmarshal will trigger an error.

P.S. This is a follow-up for PR #3223.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->