### PR TITLE
Feat(apiserver):  helm apiserver webservice (list chart, list version, extract helm values)

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -3587,6 +3587,129 @@
 				}
 			}
 		},
+		"/api/v1/repository/charts": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"repository",
+					"helm"
+				],
+				"summary": "list charts",
+				"operationId": "listCharts",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "helm repository url",
+						"name": "repoUrl",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/repository/charts/{chart}/versions": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"repository",
+					"helm"
+				],
+				"summary": "list versions",
+				"operationId": "listVersions",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "helm repository url",
+						"name": "repoUrl",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ChartVersionListResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/repository/charts/{chart}/versions/{version}/values": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"repository",
+					"helm"
+				],
+				"summary": "get chart value",
+				"operationId": "chartValues",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "helm repository url",
+						"name": "repoUrl",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/map[string]interface%20%7B%7D"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
 		"/api/v1/system_info": {
 			"get": {
 				"consumes": [
@@ -4198,6 +4321,128 @@
 					"format": "int32"
 				},
 				"Message": {
+					"type": "string"
+				}
+			}
+		},
+		"chart.Dependency": {
+			"required": [
+				"name",
+				"repository"
+			],
+			"properties": {
+				"alias": {
+					"type": "string"
+				},
+				"condition": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"import-values": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/chart.Dependency.import-values"
+					}
+				},
+				"name": {
+					"type": "string"
+				},
+				"repository": {
+					"type": "string"
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"version": {
+					"type": "string"
+				}
+			}
+		},
+		"chart.Dependency.import-values": {},
+		"chart.Maintainer": {
+			"properties": {
+				"email": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				}
+			}
+		},
+		"chart.Metadata": {
+			"properties": {
+				"annotations": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
+				"apiVersion": {
+					"type": "string"
+				},
+				"appVersion": {
+					"type": "string"
+				},
+				"condition": {
+					"type": "string"
+				},
+				"dependencies": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/chart.Dependency"
+					}
+				},
+				"deprecated": {
+					"type": "boolean"
+				},
+				"description": {
+					"type": "string"
+				},
+				"home": {
+					"type": "string"
+				},
+				"icon": {
+					"type": "string"
+				},
+				"keywords": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"kubeVersion": {
+					"type": "string"
+				},
+				"maintainers": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/chart.Maintainer"
+					}
+				},
+				"name": {
+					"type": "string"
+				},
+				"sources": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"tags": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				},
+				"version": {
 					"type": "string"
 				}
 			}
@@ -5292,6 +5537,45 @@
 				}
 			}
 		},
+		"repo.ChartVersion": {
+			"required": [
+				"Metadata",
+				"urls"
+			],
+			"properties": {
+				"Metadata": {
+					"$ref": "#/definitions/chart.Metadata"
+				},
+				"checksum": {
+					"type": "string"
+				},
+				"created": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"digest": {
+					"type": "string"
+				},
+				"engine": {
+					"type": "string"
+				},
+				"removed": {
+					"type": "boolean"
+				},
+				"tillerVersion": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				},
+				"urls": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
 		"types.Parameter": {
 			"required": [
 				"name"
@@ -6019,6 +6303,19 @@
 				},
 				"workflowName": {
 					"type": "string"
+				}
+			}
+		},
+		"v1.ChartVersionListResponse": {
+			"required": [
+				"versions"
+			],
+			"properties": {
+				"versions": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/repo.ChartVersion"
+					}
 				}
 			}
 		},

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -19,6 +19,8 @@ package v1
 import (
 	"time"
 
+	"helm.sh/helm/v3/pkg/repo"
+
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
@@ -1061,6 +1063,11 @@ type SystemInfoRequest struct {
 type SystemVersion struct {
 	VelaVersion string `json:"velaVersion"`
 	GitVersion  string `json:"gitVersion"`
+}
+
+// ChartVersionListResponse contains helm chart versions info
+type ChartVersionListResponse struct {
+	Versions repo.ChartVersions `json:"versions"`
 }
 
 // SimpleResponse simple response model for temporary

--- a/pkg/apiserver/rest/usecase/helm.go
+++ b/pkg/apiserver/rest/usecase/helm.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"
+
+	"github.com/oam-dev/kubevela/pkg/utils/helm"
+)
+
+const (
+	versionPatten = "repoUrl: %s, chart: %s"
+	valuePatten   = "repoUrl: %s, chart: %s, version: %s"
+)
+
+// NewHelmUsecase return a helmHandler
+func NewHelmUsecase() HelmHandler {
+	return defaultHelmHandler{
+		repoCache:    map[string]*utils.MemoryCache{},
+		versionCache: map[string]*utils.MemoryCache{},
+		valuesCache:  map[string]*utils.MemoryCache{},
+	}
+}
+
+// HelmHandler responsible handle helm related interface
+type HelmHandler interface {
+	ListChartNames(ctx context.Context, url string) ([]string, error)
+	ListChartVersions(ctx context.Context, url string, chartName string) ([]string, error)
+	GetChartValues(ctx context.Context, url string, chartName string, version string) (map[string]interface{}, error)
+}
+
+type defaultHelmHandler struct {
+	repoCache    map[string]*utils.MemoryCache
+	versionCache map[string]*utils.MemoryCache
+	valuesCache  map[string]*utils.MemoryCache
+}
+
+func (d defaultHelmHandler) ListChartNames(ctx context.Context, url string) ([]string, error) {
+	if m, ok := d.repoCache[url]; ok && !m.IsExpired() {
+		return m.GetData().([]string), nil
+	}
+	helper := &helm.Helper{}
+	charts, err := helper.ListChartsFromRepo(url)
+	if err != nil {
+		return nil, err
+	}
+	d.repoCache[url] = utils.NewMemoryCache(charts, 10*time.Minute)
+	return charts, nil
+}
+
+func (d defaultHelmHandler) ListChartVersions(ctx context.Context, url string, chartName string) ([]string, error) {
+	if m, ok := d.versionCache[fmt.Sprintf(versionPatten, url, chartName)]; ok && !m.IsExpired() {
+		return m.GetData().([]string), nil
+	}
+	helper := &helm.Helper{}
+	chartVersions, err := helper.ListVersions(url, chartName)
+	if err != nil {
+		return nil, err
+	}
+	res := make([]string, len(chartVersions))
+	j := 0
+	for _, v := range chartVersions {
+		res[j] = v.Version
+		j++
+	}
+	// helm version updating is more frequent， so set 1min expired time
+	d.versionCache[fmt.Sprintf(versionPatten, url, chartName)] = utils.NewMemoryCache(res, 1*time.Minute)
+	return res, nil
+}
+
+func (d defaultHelmHandler) GetChartValues(ctx context.Context, url string, chartName string, version string) (map[string]interface{}, error) {
+	if m, ok := d.valuesCache[fmt.Sprintf(valuePatten, url, chartName, version)]; ok && !m.IsExpired() {
+		return m.GetData().(map[string]interface{}), nil
+	}
+	helper := &helm.Helper{}
+	v, err := helper.GetValuesFromChart(url, chartName, version)
+	if err != nil {
+		return nil, err
+	}
+	res := make(map[string]interface{}, len(v))
+	flattenKey("", v, res)
+	// modify charts value is very low frequency operation, so 10 min is enough
+	d.valuesCache[fmt.Sprintf(valuePatten, url, chartName, version)] = utils.NewMemoryCache(res, 10*time.Minute)
+	return res, nil
+}
+
+// this func will flatten a nested map, the key will flatten with separator "." and the value's type will be keep
+// src is the map you want to flatten the output will be set in dest map
+// eg : src is  {a:{b:{c:true}}} , the dest is {a.b.c:true}
+func flattenKey(prefix string, src map[string]interface{}, dest map[string]interface{}) {
+	if len(prefix) > 0 {
+		prefix += "."
+	}
+	for k, v := range src {
+		switch child := v.(type) {
+		case map[string]interface{}:
+			flattenKey(prefix+k, child, dest)
+		case []interface{}:
+			for i := 0; i < len(child); i++ {
+				dest[prefix+k+"."+strconv.Itoa(i)] = child[i]
+			}
+		default:
+			dest[prefix+k] = v
+		}
+	}
+}

--- a/pkg/apiserver/rest/usecase/helm.go
+++ b/pkg/apiserver/rest/usecase/helm.go
@@ -65,7 +65,7 @@ func (d defaultHelmHandler) ListChartNames(ctx context.Context, url string) ([]s
 	if err != nil {
 		return nil, err
 	}
-	d.repoCache[url] = utils.NewMemoryCache(charts, 10*time.Minute)
+	d.repoCache[url] = utils.NewMemoryCache(charts, 3*time.Minute)
 	return charts, nil
 }
 
@@ -78,8 +78,7 @@ func (d defaultHelmHandler) ListChartVersions(ctx context.Context, url string, c
 	if err != nil {
 		return nil, err
 	}
-	// helm version updating is more frequent， so set 1min expired time
-	d.versionCache[fmt.Sprintf(versionPatten, url, chartName)] = utils.NewMemoryCache(chartVersions, 1*time.Minute)
+	d.versionCache[fmt.Sprintf(versionPatten, url, chartName)] = utils.NewMemoryCache(chartVersions, 3*time.Minute)
 	return chartVersions, nil
 }
 
@@ -94,8 +93,7 @@ func (d defaultHelmHandler) GetChartValues(ctx context.Context, url string, char
 	}
 	res := make(map[string]interface{}, len(v))
 	flattenKey("", v, res)
-	// modify charts value is very low frequency operation, so 10 min is enough
-	d.valuesCache[fmt.Sprintf(valuePatten, url, chartName, version)] = utils.NewMemoryCache(res, 10*time.Minute)
+	d.valuesCache[fmt.Sprintf(valuePatten, url, chartName, version)] = utils.NewMemoryCache(res, 3*time.Minute)
 	return res, nil
 }
 

--- a/pkg/apiserver/rest/usecase/helm_test.go
+++ b/pkg/apiserver/rest/usecase/helm_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usecase
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenKeyFunc(t *testing.T) {
+	srcMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(src), &srcMap)
+	assert.NoError(t, err)
+
+	dstMap := map[string]interface{}{}
+	err = json.Unmarshal([]byte(dst), &dstMap)
+	assert.NoError(t, err)
+
+	res := map[string]interface{}{}
+	flattenKey("", srcMap, res)
+	assert.Equal(t, dstMap, res)
+}
+
+var (
+	src = `{
+    "OAMSpecVer":"v0.2",
+    "admissionWebhooks":{
+        "autoGenWorkloadDefinition":true,
+        "certManager":{
+            "enabled":false,
+            "revisionHistoryLimit":3
+        },
+        "certificate":{
+            "mountPath":"/etc/k8s-webhook-certs"
+        },
+        "enabled":true,
+        "failurePolicy":"Fail",
+        "patch":{
+            "affinity":{
+
+            },
+            "enabled":true,
+            "image":{
+                "pullPolicy":"IfNotPresent",
+                "repository":"oamdev/kube-webhook-certgen",
+                "tag":"v2.3"
+            },
+            "tolerations":[
+
+            ]
+        }
+    },
+    "affinity":{
+
+    },
+    "applyOnceOnly":"off",
+    "concurrentReconciles":4,
+    "dependCheckWait":"30s",
+    "disableCaps":"all",
+    "fullnameOverride":"",
+    "healthCheck":{
+        "port":11440
+    },
+    "image":{
+        "pullPolicy":"Always",
+        "repository":"oamdev/vela-core",
+        "tag":"v1.2.4"
+    },
+    "imagePullSecrets":[
+
+    ],
+    "imageRegistry":"",
+    "logDebug":false,
+    "logFileMaxSize":1024,
+    "logFilePath":"",
+    "nameOverride":"",
+    "nodeSelector":{
+
+    },
+    "podSecurityContext":{
+
+    },
+    "rbac":{
+        "create":true
+    },
+    "replicaCount":1,
+    "resources":{
+        "limits":{
+            "cpu":"500m",
+            "memory":"1Gi"
+        },
+        "requests":{
+            "cpu":"50m",
+            "memory":"20Mi"
+        }
+    },
+    "securityContext":{
+
+    },
+    "serviceAccount":{
+        "annotations":{
+
+        },
+        "create":true,
+        "name":null
+    },
+    "systemDefinitionNamespace":"oam-runtime-system",
+    "test":{
+        "app":{
+            "repository":"oamdev/busybox",
+            "tag":"v1"
+        }
+    },
+    "tolerations":[
+
+    ],
+    "webhookService":{
+        "port":11443,
+        "type":"ClusterIP"
+    }
+}`
+	dst = `{
+    "OAMSpecVer": "v0.2",
+    "admissionWebhooks.autoGenWorkloadDefinition": true,
+    "admissionWebhooks.certManager.enabled": false,
+    "admissionWebhooks.certManager.revisionHistoryLimit": 3,
+    "admissionWebhooks.certificate.mountPath": "/etc/k8s-webhook-certs",
+    "admissionWebhooks.enabled": true,
+    "admissionWebhooks.failurePolicy": "Fail",
+    "admissionWebhooks.patch.enabled": true,
+    "admissionWebhooks.patch.image.pullPolicy": "IfNotPresent",
+    "admissionWebhooks.patch.image.repository": "oamdev/kube-webhook-certgen",
+    "admissionWebhooks.patch.image.tag": "v2.3",
+    "applyOnceOnly": "off",
+    "concurrentReconciles": 4,
+    "dependCheckWait": "30s",
+    "disableCaps": "all",
+    "fullnameOverride": "",
+    "healthCheck.port": 11440,
+    "image.pullPolicy": "Always",
+    "image.repository": "oamdev/vela-core",
+    "image.tag": "v1.2.4",
+    "imageRegistry": "",
+    "logDebug": false,
+    "logFileMaxSize": 1024,
+    "logFilePath": "",
+    "nameOverride": "",
+    "rbac.create": true,
+    "replicaCount": 1,
+    "resources.limits.cpu": "500m",
+    "resources.limits.memory": "1Gi",
+    "resources.requests.cpu": "50m",
+    "resources.requests.memory": "20Mi",
+    "serviceAccount.create": true,
+    "serviceAccount.name": null,
+    "systemDefinitionNamespace": "oam-runtime-system",
+    "test.app.repository": "oamdev/busybox",
+    "test.app.tag": "v1",
+    "webhookService.port": 11443,
+    "webhookService.type": "ClusterIP"
+}`
+)

--- a/pkg/apiserver/rest/webservice/helm.go
+++ b/pkg/apiserver/rest/webservice/helm.go
@@ -19,6 +19,8 @@ package webservice
 import (
 	"context"
 
+	"helm.sh/helm/v3/pkg/repo"
+
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 
@@ -58,7 +60,7 @@ func (h helmWebService) GetWebService() *restful.WebService {
 		Doc("list versions").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Param(ws.QueryParameter("repoUrl", "helm repository url").DataType("string")).
-		Returns(200, "", []string{}).
+		Returns(200, "", repo.ChartVersions{}).
 		Returns(400, "", bcode.Bcode{}).
 		Writes([]string{}))
 

--- a/pkg/apiserver/rest/webservice/helm.go
+++ b/pkg/apiserver/rest/webservice/helm.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webservice
+
+import (
+	"context"
+
+	restfulspec "github.com/emicklei/go-restful-openapi/v2"
+	"github.com/emicklei/go-restful/v3"
+
+	"github.com/oam-dev/kubevela/pkg/apiserver/rest/usecase"
+	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
+)
+
+type helmWebService struct {
+	usecase usecase.HelmHandler
+}
+
+// NewHelmWebService will return helm webService
+func NewHelmWebService(u usecase.HelmHandler) WebService {
+	return helmWebService{usecase: u}
+}
+
+func (h helmWebService) GetWebService() *restful.WebService {
+	ws := new(restful.WebService)
+	ws.Path(versionPrefix+"/helm").
+		Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML).
+		Doc("api for helm")
+
+	tags := []string{"helm"}
+
+	// List charts
+	ws.Route(ws.GET("/charts").To(h.listCharts).
+		Doc("list charts").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.QueryParameter("repoUrl", "helm repository url").DataType("string")).
+		Returns(200, "", []string{}).
+		Returns(400, "", bcode.Bcode{}).
+		Writes([]string{}))
+
+	// List available chart versions
+	ws.Route(ws.GET("/{chart}/versions").To(h.listVersions).
+		Doc("list versions").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.QueryParameter("repoUrl", "helm repository url").DataType("string")).
+		Returns(200, "", []string{}).
+		Returns(400, "", bcode.Bcode{}).
+		Writes([]string{}))
+
+	// List available chart versions
+	ws.Route(ws.GET("/{chart}/{version}/values").To(h.chartValues).
+		Doc("get chart value").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.QueryParameter("repoUrl", "helm repository url").DataType("string")).
+		Returns(200, "", map[string]interface{}{}).
+		Returns(400, "", bcode.Bcode{}).
+		Writes([]string{}))
+
+	return ws
+}
+
+func (h helmWebService) listCharts(req *restful.Request, res *restful.Response) {
+	url := req.QueryParameter("repoUrl")
+	charts, err := h.usecase.ListChartNames(context.Background(), url)
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+	}
+	err = res.WriteEntity(charts)
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}
+
+func (h helmWebService) listVersions(req *restful.Request, res *restful.Response) {
+	url := req.QueryParameter("repoUrl")
+	chartName := req.PathParameter("chart")
+	versions, err := h.usecase.ListChartVersions(context.Background(), url, chartName)
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+	}
+	err = res.WriteEntity(versions)
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}
+
+func (h helmWebService) chartValues(req *restful.Request, res *restful.Response) {
+	url := req.QueryParameter("repoUrl")
+	chartName := req.PathParameter("chart")
+	version := req.PathParameter("version")
+	versions, err := h.usecase.GetChartValues(context.Background(), url, chartName, version)
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+	}
+	err = res.WriteEntity(versions)
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}

--- a/pkg/apiserver/rest/webservice/webservice.go
+++ b/pkg/apiserver/rest/webservice/webservice.go
@@ -73,6 +73,7 @@ func Init(ds datastore.DataStore, addonCacheTime time.Duration) {
 	applicationUsecase := usecase.NewApplicationUsecase(ds, workflowUsecase, envBindingUsecase, envUsecase, targetUsecase, definitionUsecase, projectUsecase)
 	webhookUsecase := usecase.NewWebhookUsecase(ds, applicationUsecase)
 	systemInfoUsecase := usecase.NewSystemInfoUsecase(ds)
+	helmUsecase := usecase.NewHelmUsecase()
 
 	// init for default values
 
@@ -97,4 +98,6 @@ func Init(ds datastore.DataStore, addonCacheTime time.Duration) {
 	RegisterWebService(NewWebhookWebService(webhookUsecase, applicationUsecase))
 
 	RegisterWebService(NewSystemInfoWebService(systemInfoUsecase))
+
+	RegisterWebService(NewHelmWebService(helmUsecase))
 }

--- a/pkg/utils/helm/helm_helper_test.go
+++ b/pkg/utils/helm/helm_helper_test.go
@@ -65,4 +65,10 @@ var _ = Describe("Test helm helper", func() {
 		Expect(cmp.Diff(len(versions), 2)).Should(BeEmpty())
 	})
 
+	It("Test getValues from chart", func() {
+		helper := NewHelper()
+		values, err := helper.GetValuesFromChart("./testdata", "autoscalertrait", "0.2.0")
+		Expect(err).Should(BeNil())
+		Expect(values).ShouldNot(BeEmpty())
+	})
 })


### PR DESCRIPTION
helm apiserver webservice(list chart, list version, extract helm values)

the result ：

1. access the `/api/v1/helm/charts?repoUrl=https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core`
result is :
```json
[
    "oam-runtime",
    "vela-core",
    "vela-core-legacy",
    "vela-minimal",
    "vela-rollout"
]
```

2. access the `/api/v1/helm/oam-runtime/versions?repoUrl=https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core`

result is :
```json
[
{
        "name": "oam-runtime",
        "version": "1.2.4",
        "description": "A Helm chart for oam-runtime aligns with OAM spec v0.2",
        "apiVersion": "v2",
        "appVersion": "1.2.4",
        "type": "application",
        "urls": [
            "https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core/oam-runtime-1.2.4.tgz"
        ],
        "created": "2022-03-08T10:00:11.180129339Z",
        "digest": "80317c68dda2928c7a094f721775927be71964245762a07cd1b3d4a9656469dc"
    },
    {
        "name": "oam-runtime",
        "version": "1.2.3",
        "description": "A Helm chart for oam-runtime aligns with OAM spec v0.2",
        "apiVersion": "v2",
        "appVersion": "1.2.3",
        "type": "application",
        "urls": [
            "https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core/oam-runtime-1.2.3.tgz"
        ],
        "created": "2022-03-08T10:00:11.177665522Z",
        "digest": "b95f046494745cc38c734be54e8d35544dddb1b959c704efab9644039f70574c"
    },
...
]
```

3. `/api/v1/helm/oam-runtime/1.2.4/values?repoUrl=https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core`

```json
{
    "OAMSpecVer": "v0.2",
    "admissionWebhooks.autoGenWorkloadDefinition": true,
    "admissionWebhooks.certManager.enabled": false,
    "admissionWebhooks.certManager.revisionHistoryLimit": 3,
    "admissionWebhooks.certificate.mountPath": "/etc/k8s-webhook-certs",
    "admissionWebhooks.enabled": true,
    "admissionWebhooks.failurePolicy": "Fail",
    "admissionWebhooks.patch.enabled": true,
    "admissionWebhooks.patch.image.pullPolicy": "IfNotPresent",
    "admissionWebhooks.patch.image.repository": "oamdev/kube-webhook-certgen",
    "admissionWebhooks.patch.image.tag": "v2.3",
    "applyOnceOnly": "off",
    "concurrentReconciles": 4,
    "dependCheckWait": "30s",
    "disableCaps": "all",
    "fullnameOverride": "",
    "healthCheck.port": 11440,
    "image.pullPolicy": "Always",
    "image.repository": "oamdev/vela-core",
    "image.tag": "v1.2.4",
    "imageRegistry": "",
    "logDebug": false,
    "logFileMaxSize": 1024,
    "logFilePath": "",
    "nameOverride": "",
    "rbac.create": true,
    "replicaCount": 1,
    "resources.limits.cpu": "500m",
    "resources.limits.memory": "1Gi",
    "resources.requests.cpu": "50m",
    "resources.requests.memory": "20Mi",
    "serviceAccount.create": true,
    "serviceAccount.name": null,
    "systemDefinitionNamespace": "oam-runtime-system",
    "test.app.repository": "oamdev/busybox",
    "test.app.tag": "v1",
    "webhookService.port": 11443,
    "webhookService.type": "ClusterIP"
}
```

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->