### PR TITLE
Fix: rework parallel execution for ApplyComponents and ResourceKeeper Dispatch

### DIFF
--- a/pkg/resourcekeeper/dispatch.go
+++ b/pkg/resourcekeeper/dispatch.go
@@ -119,7 +119,7 @@ func (h *resourceKeeper) record(ctx context.Context, manifests []*unstructured.U
 
 func (h *resourceKeeper) dispatch(ctx context.Context, manifests []*unstructured.Unstructured) error {
 	applyOpts := []apply.ApplyOption{apply.MustBeControlledByApp(h.app), apply.NotUpdateRenderHashEqual()}
-	errs := parallel.ParExec(func(manifest *unstructured.Unstructured) error {
+	errs := parallel.Run(func(manifest *unstructured.Unstructured) error {
 		applyCtx := multicluster.ContextWithClusterName(ctx, oam.GetCluster(manifest))
 		return h.applicator.Apply(applyCtx, manifest, applyOpts...)
 	}, manifests, MaxDispatchConcurrent)

--- a/pkg/utils/errors/list.go
+++ b/pkg/utils/errors/list.go
@@ -44,3 +44,17 @@ func (e ErrorList) HasError() bool {
 	}
 	return len(e) > 0
 }
+
+// AggregateErrors aggregate errors into ErrorList and filter nil, if no error found, return nil
+func AggregateErrors(errs []error) error {
+	var es ErrorList
+	for _, err := range errs {
+		if err != nil {
+			es = append(es, err)
+		}
+	}
+	if es.HasError() {
+		return es
+	}
+	return nil
+}

--- a/pkg/utils/parallel/parallel.go
+++ b/pkg/utils/parallel/parallel.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"reflect"
+)
+
+// ParInput input for parallel execution
+type ParInput interface{}
+
+// ParOutput output for parallel execution
+type ParOutput interface{}
+
+type orderedParOutput struct {
+	ParOutput
+	index int
+}
+
+// ParExecProto parallel execute handler function on parInputs, with maximum concurrency as parallelism
+func ParExecProto(handler func(ParInput) ParOutput, parInputs []ParInput, parallelism int) []ParOutput {
+	outs := make(chan orderedParOutput)
+	pool := make(chan struct{}, parallelism)
+	for _idx, _input := range parInputs {
+		go func(idx int, input ParInput) {
+			pool <- struct{}{}
+			output := handler(input)
+			outs <- orderedParOutput{ParOutput: output, index: idx}
+			<-pool
+		}(_idx, _input)
+	}
+	outputs := make([]ParOutput, len(parInputs))
+	for range parInputs {
+		out := <-outs
+		outputs[out.index] = out.ParOutput
+	}
+	return outputs
+}
+
+// ParExec execute handler on parInputs, with automatic type conversion and maximum concurrency as parallelism
+// Examples:
+// > out := ParExec(func(x int) int { return x*x }, []int{1,2,3,4,5}, 5)
+// < out: []int{1,4,19,16,25}
+// > out := ParExec(func(x int, y string) (string, bool) { return y, x%2==0 }, [][]interface{}{{1,"n"},{2,"y"}}, 2)
+// < out: [][]interface{{"n",false},{"y",true}}
+func ParExec(handler interface{}, parInputs interface{}, parallelism int) interface{} {
+	parInputsVal := reflect.ValueOf(parInputs)
+	elemLen := parInputsVal.Len()
+	_parInputVal := reflect.MakeSlice(reflect.TypeOf([]ParInput{}), elemLen, elemLen)
+	for i := 0; i < elemLen; i++ {
+		v := parInputsVal.Index(i)
+		if v.IsValid() {
+			_parInputVal.Index(i).Set(v)
+		}
+	}
+
+	handleFunc := reflect.ValueOf(handler)
+	handleFuncTyp := reflect.TypeOf(handler)
+	nParams, nReturns := handleFuncTyp.NumIn(), handleFuncTyp.NumOut()
+	parOutputTyp := reflect.TypeOf([]ParOutput{}).Elem()
+	_handler := reflect.MakeFunc(reflect.TypeOf(func(ParInput) ParOutput { return nil }), func(args []reflect.Value) (results []reflect.Value) {
+		in := make([]reflect.Value, nParams)
+		_inputVal := args[0].Elem()
+		if nParams > 1 {
+			for i := 0; i < nParams; i++ {
+				in[i] = _inputVal.Index(i).Elem()
+			}
+		} else if nParams == 1 {
+			in[0] = _inputVal
+		}
+		for i := 0; i < nParams; i++ {
+			if !in[i].IsValid() {
+				in[i] = reflect.New(handleFuncTyp.In(i)).Elem()
+			}
+		}
+		out := handleFunc.Call(in)
+
+		_outputVal := reflect.New(parOutputTyp).Elem()
+		if nReturns > 1 {
+			ret := reflect.MakeSlice(reflect.TypeOf([]interface{}{}), nReturns, nReturns)
+			for i := 0; i < nReturns; i++ {
+				if out[i].IsValid() {
+					ret.Index(i).Set(out[i])
+				}
+			}
+			_outputVal.Set(ret)
+		} else if nReturns == 1 {
+			if out[0].IsValid() {
+				_outputVal.Set(out[0])
+			}
+		}
+		return []reflect.Value{_outputVal}
+	})
+	outs := ParExecProto(_handler.Interface().(func(ParInput) ParOutput), _parInputVal.Interface().([]ParInput), parallelism)
+	if nReturns == 0 {
+		return nil
+	}
+	var outputs reflect.Value
+	if nReturns == 1 {
+		outputs = reflect.MakeSlice(reflect.SliceOf(handleFuncTyp.Out(0)), elemLen, elemLen)
+	} else {
+		outputs = reflect.MakeSlice(reflect.TypeOf([]interface{}{}), elemLen, elemLen)
+	}
+	for i := 0; i < elemLen; i++ {
+		v := reflect.ValueOf(outs[i])
+		if v.IsValid() {
+			outputs.Index(i).Set(v)
+		}
+	}
+	return outputs.Interface()
+}

--- a/pkg/utils/parallel/parallel_test.go
+++ b/pkg/utils/parallel/parallel_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
+)
+
+func TestParExecNto1(t *testing.T) {
+	var inputs [][]interface{}
+	size := 100
+	parallelism := 20
+	for i := 0; i < size; i++ {
+		if i%2 == 0 {
+			inputs = append(inputs, []interface{}{i, i + 1, math.Sqrt(float64(i)), nil})
+		} else {
+			inputs = append(inputs, []interface{}{i, i + 1, math.Sqrt(float64(i)), pointer.Int(i)})
+		}
+	}
+	outs := ParExec(func(a int, b int, c float64, d *int) *float64 {
+		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
+		if d == nil {
+			return nil
+		}
+		return pointer.Float64(float64(a*b) + c + float64(*d))
+	}, inputs, parallelism)
+	outputs, ok := outs.([]*float64)
+	r := require.New(t)
+	r.True(ok)
+	r.Equal(size, len(outputs))
+	for i, j := range outputs {
+		if i%2 == 0 {
+			r.Nil(j)
+		} else {
+			r.NotNil(j)
+			r.Equal(float64(i*(i+1))+math.Sqrt(float64(i))+float64(i), *j)
+		}
+	}
+}
+
+func TestParExec0toN(t *testing.T) {
+	var inputs [][]interface{}
+	size := 100
+	parallelism := 20
+	for i := 0; i < size; i++ {
+		inputs = append(inputs, nil)
+	}
+	outs := ParExec(func() (bool, string) {
+		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
+		return false, "ok"
+	}, inputs, parallelism)
+	outputs, ok := outs.([]interface{})
+	r := require.New(t)
+	r.True(ok)
+	r.Equal(size, len(outputs))
+	for _, _j := range outputs {
+		j, ok := _j.([]interface{})
+		r.True(ok)
+		r.Equal(2, len(j))
+		j0, ok := j[0].(bool)
+		r.True(ok)
+		r.False(j0)
+		j1, ok := j[1].(string)
+		r.True(ok)
+		r.Equal("ok", j1)
+	}
+}
+
+func TestParExec1to0(t *testing.T) {
+	var inputs []struct{ key int }
+	size := 100
+	parallelism := 20
+	for i := 0; i < size; i++ {
+		inputs = append(inputs, struct{ key int }{key: i})
+	}
+	outs := ParExec(func(obj struct{ key int }) {
+		time.Sleep(time.Duration(rand.Intn(50)+size-obj.key) * time.Millisecond)
+	}, inputs, parallelism)
+	r := require.New(t)
+	r.Nil(outs)
+}

--- a/pkg/utils/parallel/parallel_test.go
+++ b/pkg/utils/parallel/parallel_test.go
@@ -37,7 +37,7 @@ func TestParExecNto1(t *testing.T) {
 			inputs = append(inputs, []interface{}{i, i + 1, math.Sqrt(float64(i)), pointer.Int(i)})
 		}
 	}
-	outs := ParExec(func(a int, b int, c float64, d *int) *float64 {
+	outs := Run(func(a int, b int, c float64, d *int) *float64 {
 		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
 		if d == nil {
 			return nil
@@ -65,7 +65,7 @@ func TestParExec0toN(t *testing.T) {
 	for i := 0; i < size; i++ {
 		inputs = append(inputs, nil)
 	}
-	outs := ParExec(func() (bool, string) {
+	outs := Run(func() (bool, string) {
 		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
 		return false, "ok"
 	}, inputs, parallelism)
@@ -93,7 +93,7 @@ func TestParExec1to0(t *testing.T) {
 	for i := 0; i < size; i++ {
 		inputs = append(inputs, struct{ key int }{key: i})
 	}
-	outs := ParExec(func(obj struct{ key int }) {
+	outs := Run(func(obj struct{ key int }) {
 		time.Sleep(time.Duration(rand.Intn(50)+size-obj.key) * time.Millisecond)
 	}, inputs, parallelism)
 	r := require.New(t)

--- a/pkg/workflow/providers/oam/apply.go
+++ b/pkg/workflow/providers/oam/apply.go
@@ -158,7 +158,7 @@ func (p *provider) ApplyComponents(ctx wfContext.Context, v *value.Value, act wf
 		return errors.Wrapf(err, "failed to looping over components")
 	}
 	// parallel execution
-	outputs := parallel.ParExec(func(name string, ctx wfContext.Context, v *value.Value, act wfTypes.Action, mu *sync.Mutex) error {
+	outputs := parallel.Run(func(name string, ctx wfContext.Context, v *value.Value, act wfTypes.Action, mu *sync.Mutex) error {
 		if err := p.applyComponent(ctx, v, act, mu); err != nil {
 			return errors.Wrapf(err, "failed to apply component %s", name)
 		}


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1. Rework parallel execution and use it in ApplyComponents and ResourceKeeper parallel dispatch.
2. This original apply components only lock the process of write back cue.Value. The read process of cue.Value should also be protected.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Add a unit test for apply 1000 components concurrently.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->