### PR TITLE
Feat: enhance topology policy

### DIFF
--- a/apis/core.oam.dev/v1alpha1/policy_types.go
+++ b/apis/core.oam.dev/v1alpha1/policy_types.go
@@ -25,8 +25,24 @@ const (
 
 // TopologyPolicySpec defines the spec of topology policy
 type TopologyPolicySpec struct {
-	Clusters        []string          `json:"clusters,omitempty"`
+	// Clusters directly specify which cluster to use
+	Clusters []string `json:"clusters,omitempty"`
+	// ClusterLabelSelector label selector for cluster
+	ClusterLabelSelector map[string]string `json:"clusterLabelSelector,omitempty"`
+	// ClusterSelector is an alias to clusterLabelSelector
 	ClusterSelector map[string]string `json:"clusterSelector,omitempty"`
+	// Namespace specify the namespace for override, used along which clusters/clusterLabelSelector/clusterSelector
+	Namespace string `json:"namespace,omitempty"`
+	// Targets specify the delivery targets, used alone
+	Targets []string `json:"targets,omitempty"`
+}
+
+// GetClusterLabelSelector primary use of clusterLabelSelector
+func (in *TopologyPolicySpec) GetClusterLabelSelector() map[string]string {
+	if in.ClusterLabelSelector != nil {
+		return in.ClusterLabelSelector
+	}
+	return in.ClusterSelector
 }
 
 // OverridePolicySpec defines the spec of override policy

--- a/apis/core.oam.dev/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/core.oam.dev/v1alpha1/zz_generated.deepcopy.go
@@ -455,12 +455,24 @@ func (in *TopologyPolicySpec) DeepCopyInto(out *TopologyPolicySpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ClusterLabelSelector != nil {
+		in, out := &in.ClusterLabelSelector, &out.ClusterLabelSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.ClusterSelector != nil {
 		in, out := &in.ClusterSelector, &out.ClusterSelector
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Targets != nil {
+		in, out := &in.Targets, &out.Targets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/pkg/multicluster/targets.go
+++ b/pkg/multicluster/targets.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicluster
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	separator = "/"
+)
+
+// ParseTarget parse target into cluster and namespace
+// TODO: in future, we might have Target CRD where we should allow user to get target from existing CR object
+func ParseTarget(target string) (cluster string, namespace string, err error) {
+	parts := strings.Split(target, separator)
+	if len(parts) != 2 {
+		return "", "", errors.Errorf("invalid target %s", target)
+	}
+	cluster = ClusterLocalName
+	if parts[0] != "" {
+		cluster = parts[0]
+	}
+	namespace = parts[1]
+	return cluster, namespace, nil
+}

--- a/pkg/multicluster/virtual_cluster_test.go
+++ b/pkg/multicluster/virtual_cluster_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Test Virtual Cluster", func() {
 
 		vcs, err := ListVirtualClusters(ctx, k8sClient)
 		Expect(err).Should(Succeed())
-		Expect(len(vcs)).Should(Equal(3))
+		Expect(len(vcs)).Should(Equal(4))
 
 		vcs, err = FindVirtualClustersByLabels(ctx, k8sClient, map[string]string{"key": "value"})
 		Expect(err).Should(Succeed())

--- a/pkg/workflow/providers/multicluster/multicluster_test.go
+++ b/pkg/workflow/providers/multicluster/multicluster_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers/mock"
 )
@@ -548,9 +549,10 @@ func TestExpandTopology(t *testing.T) {
 		app:    app,
 	}
 	testCases := map[string]struct {
-		Input   string
-		Outputs []v1alpha1.PlacementDecision
-		Error   string
+		Input                 string
+		Outputs               []v1alpha1.PlacementDecision
+		Error                 string
+		DisableCrossNamespace bool
 	}{
 		"policies-404": {
 			Input: "{inputs:{}}",
@@ -572,14 +574,49 @@ func TestExpandTopology(t *testing.T) {
 			Input:   `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusters:["cluster-a"]}}]}}`,
 			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "test"}},
 		},
+		"topology-by-cluster-selector-404": {
+			Input: `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterSelector:{"key":"bad-value"}}}]}}`,
+			Error: "failed to find any cluster matches given labels",
+		},
 		"topology-by-cluster-selector": {
 			Input:   `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterSelector:{"key":"value"}}}]}}`,
 			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "test"}, {Cluster: "cluster-b", Namespace: "test"}},
+		},
+		"topology-by-cluster-label-selector": {
+			Input:   `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterLabelSelector:{"key":"value"}}}]}}`,
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "test"}, {Cluster: "cluster-b", Namespace: "test"}},
+		},
+		"topology-by-cluster-selector-and-namespace-invalid": {
+			Input:                 `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterSelector:{"key":"value"},namespace:"override"}}]}}`,
+			Error:                 "cannot cross namespace",
+			DisableCrossNamespace: true,
+		},
+		"topology-by-cluster-selector-and-namespace": {
+			Input:   `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterSelector:{"key":"value"},namespace:"override"}}]}}`,
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "override"}, {Cluster: "cluster-b", Namespace: "override"}},
+		},
+		"topology-by-invalid-targets": {
+			Input: `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{targets:["cluster-a"]}}]}}`,
+			Error: "invalid target cluster-a",
+		},
+		"topology-by-403-targets": {
+			Input:                 `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{targets:["cluster-a/override-y"]}}]}}`,
+			Error:                 "cannot cross namespace",
+			DisableCrossNamespace: true,
+		},
+		"topology-by-404-targets": {
+			Input: `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{targets:["cluster-x/override-y"]}}]}}`,
+			Error: "failed to get cluster",
+		},
+		"topology-by-targets": {
+			Input:   `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{targets:["cluster-a/override-a","cluster-b/override-b"]}}]}}`,
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "override-a"}, {Cluster: "cluster-b", Namespace: "override-b"}},
 		},
 	}
 	for name, tt := range testCases {
 		t.Run(name, func(t *testing.T) {
 			r := require.New(t)
+			resourcekeeper.AllowCrossNamespaceResource = !tt.DisableCrossNamespace
 			v, err := value.NewValue("", nil, "")
 			r.NoError(err)
 			r.NoError(v.FillRaw(tt.Input))


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR enhances topology policy through several aspects.
1. Allow local cluster as VirtualCluster. Now user can use local cluster in topology policy like previous env-binding policy.
2. Allow specifying namespace in topology policy. Now user can use a different namespace other than the original application namespace like previous env-binding policy. Notice that this will only work when bootstrap parameter `--allow-cross-namespace-resource` is set.
3. Allow directly using `targets` in topology policy. User can directly use targets in topology policy. *Target reference is not included in this PR.* /cc @barnettZQG 
4. Rename `clusterSelector` to `clusterLabelSelector` to make it more clear. `clusterSelector` is treated as an alias to `clusterLabelSelector`. /cc @yue9944882 

Example:
```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: example
  namespace: example-ns
spec:
  components:
    - name: nginx
      type: webservice
      properties:
        image: nginx
  policies:
    - name: topology-beijing-demo
      type: topology
      properties:
        clusterLabelSelector:
          region: beijing
        namespace: demo
    - name: topology-local
      type: topology
      properties:
        targets: ["local/demo", "local/example-demo"]
  workflow:
    steps:
      - type: deploy
        name: deploy-all
        properties:
          policies: ["topology-local", "topology-beijing-demo"]
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->