### PR TITLE
Fix: add parallelism params for deploy step

### DIFF
--- a/pkg/stdlib/pkgs/oam.cue
+++ b/pkg/stdlib/pkgs/oam.cue
@@ -3,6 +3,7 @@
 	#do:         "component-apply"
 	cluster:     *"" | string
 	env:         *"" | string
+	namespace:   *"" | string
 	waitHealthy: *true | bool
 	value: {...}
 	patch?: {...}
@@ -16,6 +17,7 @@
 	components: [string]: {
 		cluster:     *"" | string
 		env:         *"" | string
+		namespace:   *"" | string
 		waitHealthy: *true | bool
 		value: {...}
 		patch?: {...}
@@ -29,6 +31,7 @@
 	#do:       "component-render"
 	cluster:   *"" | string
 	env:       *"" | string
+	namespace: *"" | string
 	value: {...}
 	patch?: {...}
 	output?: {...}

--- a/pkg/workflow/step/dependency_test.go
+++ b/pkg/workflow/step/dependency_test.go
@@ -42,7 +42,7 @@ func TestLoadExternalPoliciesForWorkflow(t *testing.T) {
 	policies, err := LoadExternalPoliciesForWorkflow(context.Background(), cli, "demo", []v1beta1.WorkflowStep{{
 		Name:       "deploy",
 		Type:       DeployWorkflowStep,
-		Properties: &runtime.RawExtension{Raw: []byte(`{"auto":false,"policies":["ex","internal"]}`)},
+		Properties: &runtime.RawExtension{Raw: []byte(`{"auto":false,"policies":["ex","internal"],"parallelism":10}`)},
 	}}, []v1beta1.AppPolicy{{
 		Name: "internal",
 		Type: "internal",
@@ -65,7 +65,7 @@ func TestLoadExternalPoliciesForWorkflow(t *testing.T) {
 	_, err = LoadExternalPoliciesForWorkflow(context.Background(), cli, "demo", []v1beta1.WorkflowStep{{
 		Name:       "deploy",
 		Type:       DeployWorkflowStep,
-		Properties: &runtime.RawExtension{Raw: []byte(`{policies:["ex","non"]}`)},
+		Properties: &runtime.RawExtension{Raw: []byte(`{"policies":["ex","non"],"unknown-field":"value"}`)},
 	}}, []v1beta1.AppPolicy{})
 	r.NotNil(err)
 	r.Contains(err.Error(), "invalid WorkflowStep deploy")

--- a/pkg/workflow/step/types.go
+++ b/pkg/workflow/step/types.go
@@ -24,6 +24,9 @@ const (
 // DeployWorkflowStepSpec the spec of `deploy` WorkflowStep
 type DeployWorkflowStepSpec struct {
 	// Auto nil/true mean auto deploy, false means additional pre-approve step will be injected before the deploy step
-	Auto     *bool    `json:"auto,omitempty"`
+	Auto *bool `json:"auto,omitempty"`
+	// Policies specifies the policies to use in the step
 	Policies []string `json:"policies,omitempty"`
+	// Parallelism allows setting parallelism for the component deploy process
+	Parallelism *int `json:"parallelism,omitempty"`
 }

--- a/test/e2e-test/application_test.go
+++ b/test/e2e-test/application_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e-test/application_test.go
+++ b/test/e2e-test/application_test.go
@@ -25,7 +25,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Minor fixes.
1. Support `deploy` workflow step specifying `parallelism` parameter.
2. Explicit cue declaration for namespace in `ApplyComponent`, `ApplyComponents` and `RenderComponent`.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->