### PR TITLE
Feat: support vela cluster labels add/del to manage cluster labels

### DIFF
--- a/pkg/multicluster/virtual_cluster.go
+++ b/pkg/multicluster/virtual_cluster.go
@@ -47,6 +47,7 @@ type VirtualCluster struct {
 	Accepted bool
 	Labels   map[string]string
 	Metrics  *ClusterMetrics
+	Object   client.Object
 }
 
 // NewVirtualClusterFromSecret extract virtual cluster from cluster secret
@@ -70,6 +71,7 @@ func NewVirtualClusterFromSecret(secret *corev1.Secret) (*VirtualCluster, error)
 		Accepted: true,
 		Labels:   labels,
 		Metrics:  metricsMap[secret.Name],
+		Object:   secret,
 	}, nil
 }
 
@@ -85,6 +87,7 @@ func NewVirtualClusterFromManagedCluster(managedCluster *clusterv1.ManagedCluste
 		Accepted: managedCluster.Spec.HubAcceptsClient,
 		Labels:   managedCluster.GetLabels(),
 		Metrics:  metricsMap[managedCluster.Name],
+		Object:   managedCluster,
 	}, nil
 }
 

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -87,8 +87,7 @@ func ClusterCommandGroup(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Comm
 		NewClusterRenameCommand(&c),
 		NewClusterDetachCommand(&c),
 		NewClusterProbeCommand(&c),
-		NewClusterAddLabelsCommand(&c),
-		NewClusterDelLabelsCommand(&c),
+		NewClusterLabelCommandGroup(&c),
 	)
 	return cmd
 }
@@ -284,6 +283,20 @@ func NewClusterProbeCommand(c *common.Args) *cobra.Command {
 	return cmd
 }
 
+// NewClusterLabelCommandGroup create a group of commands to manage cluster labels
+func NewClusterLabelCommandGroup(c *common.Args) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "labels",
+		Short: "Manage Kubernetes Cluster Labels",
+		Long:  "Manage Kubernetes Cluster Labels for Continuous Delivery.",
+	}
+	cmd.AddCommand(
+		NewClusterAddLabelsCommand(c),
+		NewClusterDelLabelsCommand(c),
+	)
+	return cmd
+}
+
 func updateClusterLabelAndPrint(cmd *cobra.Command, cli client.Client, vc *multicluster.VirtualCluster, clusterName string) (err error) {
 	if err = cli.Update(context.Background(), vc.Object); err != nil {
 		return errors.Errorf("failed to update labels for cluster %s (type: %s)", vc.Name, vc.Type)
@@ -311,10 +324,10 @@ func updateClusterLabelAndPrint(cmd *cobra.Command, cli client.Client, vc *multi
 // NewClusterAddLabelsCommand create command to add labels for managed cluster
 func NewClusterAddLabelsCommand(c *common.Args) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "add-labels CLUSTER_NAME LABELS",
+		Use:     "add CLUSTER_NAME LABELS",
 		Short:   "add labels to managed cluster",
 		Long:    "add labels to managed cluster",
-		Example: "vela cluster add-labels my-cluster project=kubevela,owner=oam-dev",
+		Example: "vela cluster labels add my-cluster project=kubevela,owner=oam-dev",
 		Args:    cobra.ExactValidArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
@@ -347,11 +360,12 @@ func NewClusterAddLabelsCommand(c *common.Args) *cobra.Command {
 // NewClusterDelLabelsCommand create command to delete labels for managed cluster
 func NewClusterDelLabelsCommand(c *common.Args) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "del-labels CLUSTER_NAME LABELS",
+		Use:     "del CLUSTER_NAME LABELS",
+		Aliases: []string{"delete", "remove"},
 		Short:   "delete labels for managed cluster",
 		Long:    "delete labels for managed cluster",
 		Args:    cobra.ExactValidArgs(2),
-		Example: "vela cluster del-labels my-cluster project,owner",
+		Example: "vela cluster labels del my-cluster project,owner",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterName := args[0]
 			removeLabels := strings.Split(args[1], ",")

--- a/references/cli/cluster.go
+++ b/references/cli/cluster.go
@@ -84,6 +84,8 @@ func ClusterCommandGroup(c common.Args, ioStreams cmdutil.IOStreams) *cobra.Comm
 		NewClusterRenameCommand(&c),
 		NewClusterDetachCommand(&c),
 		NewClusterProbeCommand(&c),
+		NewClusterAddLabelsCommand(&c),
+		NewClusterDelLabelsCommand(&c),
 	)
 	return cmd
 }
@@ -273,6 +275,34 @@ func NewClusterProbeCommand(c *common.Args) *cobra.Command {
 			}
 			cmd.Printf("Connect to cluster %s successfully.\n%s\n", clusterName, string(content))
 			return nil
+		},
+	}
+	return cmd
+}
+
+// NewClusterAddLabelsCommand create command to add labels for managed cluster
+func NewClusterAddLabelsCommand(c *common.Args) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "add-labels CLUSTER_NAME LABELS",
+		Short: "add labels to managed cluster",
+		Long: "add labels to managed cluster",
+		Example: "vela cluster add-labels my-cluster project=kubevela,owner=oam-dev",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			
+		},
+	}
+	return cmd
+}
+
+// NewClusterDelLabelsCommand create command to delete labels for managed cluster
+func NewClusterDelLabelsCommand(c *common.Args) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "del-labels CLUSTER_NAME LABELS",
+		Short: "delete labels for managed cluster",
+		Long: "delete labels for managed cluster",
+		Example: "vela cluster del-labels my-cluster project,owner",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
 		},
 	}
 	return cmd

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -96,6 +96,19 @@ var _ = Describe("Test multicluster scenario", func() {
 			Expect(out).ShouldNot(ContainSubstring(newClusterName))
 		})
 
+		It("Test manage labels for cluster", func() {
+			_, err := execCommand("cluster", "add-labels", WorkerClusterName, "purpose=test,creator=e2e")
+			Expect(err).Should(Succeed())
+			out, err := execCommand("cluster", "list")
+			Expect(err).Should(Succeed())
+			Expect(out).Should(ContainSubstring("purpose"))
+			_, err = execCommand("cluster", "del-labels", WorkerClusterName, "purpose")
+			Expect(err).Should(Succeed())
+			out, err = execCommand("cluster", "list")
+			Expect(err).Should(Succeed())
+			Expect(out).ShouldNot(ContainSubstring("purpose"))
+		})
+
 		It("Test detach cluster with application use", func() {
 			const testClusterName = "test-cluster"
 			_, err := execCommand("cluster", "join", "/tmp/worker.kubeconfig", "--name", testClusterName)

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -97,12 +97,12 @@ var _ = Describe("Test multicluster scenario", func() {
 		})
 
 		It("Test manage labels for cluster", func() {
-			_, err := execCommand("cluster", "add-labels", WorkerClusterName, "purpose=test,creator=e2e")
+			_, err := execCommand("cluster", "labels", "add", WorkerClusterName, "purpose=test,creator=e2e")
 			Expect(err).Should(Succeed())
 			out, err := execCommand("cluster", "list")
 			Expect(err).Should(Succeed())
 			Expect(out).Should(ContainSubstring("purpose"))
-			_, err = execCommand("cluster", "del-labels", WorkerClusterName, "purpose")
+			_, err = execCommand("cluster", "labels", "del", WorkerClusterName, "purpose")
 			Expect(err).Should(Succeed())
 			out, err = execCommand("cluster", "list")
 			Expect(err).Should(Succeed())


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Add two commands to help user manage cluster labels:
- vela cluster labels add example-cluster region=hangzhou,creator=kubevela
- vela cluster labels del example-cluster creator

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.


### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- [x] Test added.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

There is no protection for modifying cluster labels if some applications are using corresponding clusterLabelSelector.