### PR TITLE
Feat: support query applied resources by velaQL

### DIFF
--- a/charts/vela-core/templates/velaql/applied-resources.yaml
+++ b/charts/vela-core/templates/velaql/applied-resources.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v1"
 kind:       "ConfigMap"
 metadata: 
-  name:      "service-endpoints-view"
+  name:      "service-applied-resources-view"
   namespace: {{ include "systemDefinitionNamespace" . }}
 data:
   template: |
@@ -15,7 +15,7 @@ data:
           cluster?:   string
           clusterNs?: string
       }
-      resources: ql.#CollectServiceEndpoints & {
+      response: ql.#ListAppliedResources & {
           app: {
               name:      parameter.appName
               namespace: parameter.appNs
@@ -32,13 +32,13 @@ data:
               }
           }
       }
-      if resources.err == _|_ {
+      if response.err == _|_ {
           status: {
-              endpoints: resources.list
+              resources: response.list
           }
       }
-      if resources.err != _|_ {
+      if response.err != _|_ {
           status: {
-              error: resources.err
+              error: response.err
           }
       }

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -570,7 +570,7 @@ func RenderApp(ctx context.Context, addon *InstallPackage, config *rest.Config, 
 	for _, tmpl := range addon.CUETemplates {
 		comp, err := renderCUETemplate(tmpl, addon.Parameters, args)
 		if err != nil {
-			return nil, ErrRenderCueTmpl
+			return nil, NewAddonError(fmt.Sprintf("fail to render cue template %s", err.Error()))
 		}
 		if addon.Name == ObservabilityAddon && strings.HasSuffix(comp.Name, ".cue") {
 			comp.Name = strings.Split(comp.Name, ".cue")[0]

--- a/pkg/stdlib/pkgs/query.cue
+++ b/pkg/stdlib/pkgs/query.cue
@@ -19,6 +19,32 @@
 	...
 }
 
+#ListAppliedResources: {
+	#do:       "listAppliedResources"
+	#provider: "query"
+	app: {
+		name:      string
+		namespace: string
+		filter?: {
+			cluster?:          string
+			clusterNamespace?: string
+			components?: [...string]
+		}
+	}
+	list?: [...{
+		name:             string
+		namespace?:       string
+		cluster?:         string
+		component?:       string
+		trait?:           string
+		kind?:            string
+		uid?:             string
+		apiVersion?:      string
+		resourceVersion?: string
+	}]
+	...
+}
+
 #CollectPods: {
 	#do:       "collectPods"
 	#provider: "query"
@@ -71,6 +97,7 @@
 		filter?: {
 			cluster?:          string
 			clusterNamespace?: string
+			components?: [...string]
 		}
 	}
 	list?: [...{
@@ -82,7 +109,8 @@
 			path?:        string
 		}
 		ref: {...}
-		cluster?: string
+		cluster?:   string
+		component?: string
 		...
 	}]
 	...

--- a/pkg/stdlib/ql.cue
+++ b/pkg/stdlib/ql.cue
@@ -6,6 +6,8 @@
 
 #ListResourcesInApp: query.#ListResourcesInApp
 
+#ListAppliedResources: query.#ListAppliedResources
+
 #CollectPods: query.#CollectPods
 
 #SearchEvents: query.#SearchEvents

--- a/pkg/velaql/providers/query/types/type.go
+++ b/pkg/velaql/providers/query/types/type.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -36,9 +38,10 @@ const (
 
 // ServiceEndpoint record the access endpoints of the application services
 type ServiceEndpoint struct {
-	Endpoint Endpoint               `json:"endpoint"`
-	Ref      corev1.ObjectReference `json:"ref"`
-	Cluster  string                 `json:"cluster"`
+	Endpoint  Endpoint               `json:"endpoint"`
+	Ref       corev1.ObjectReference `json:"ref"`
+	Cluster   string                 `json:"cluster"`
+	Component string                 `json:"component"`
 }
 
 // String return endpoint URL
@@ -80,4 +83,22 @@ type Endpoint struct {
 
 	// the path for the endpoint
 	Path string `json:"path,omitempty"`
+}
+
+// AppliedResource resource metadata
+type AppliedResource struct {
+	Cluster         string    `json:"cluster"`
+	Component       string    `json:"component"`
+	Trait           string    `json:"trait"`
+	Kind            string    `json:"kind"`
+	Namespace       string    `json:"namespace,omitempty"`
+	Name            string    `json:"name,omitempty"`
+	UID             types.UID `json:"uid,omitempty"`
+	APIVersion      string    `json:"apiVersion,omitempty"`
+	ResourceVersion string    `json:"resourceVersion,omitempty"`
+}
+
+// GroupVersionKind returns the stored group, version, and kind of an object
+func (obj *AppliedResource) GroupVersionKind() schema.GroupVersionKind {
+	return schema.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -173,13 +173,13 @@ func NewAddonEnableCommand(c common.Args, ioStream cmdutil.IOStreams) *cobra.Com
 
 // AdditionalEndpointPrinter will print endpoints
 func AdditionalEndpointPrinter(ctx context.Context, c common.Args, k8sClient client.Client, name string) {
-	endpoints, _ := GetServiceEndpoints(ctx, k8sClient, pkgaddon.Convert2AppName(name), types.DefaultKubeVelaNS, c)
+	endpoints, _ := GetServiceEndpoints(ctx, k8sClient, pkgaddon.Convert2AppName(name), types.DefaultKubeVelaNS, c, Filter{})
 	if len(endpoints) > 0 {
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetColWidth(100)
-		table.SetHeader([]string{"Cluster", "Ref(Kind/Namespace/Name)", "Endpoint"})
+		table.SetHeader([]string{"Cluster", "Component", "Ref(Kind/Namespace/Name)", "Endpoint"})
 		for _, endpoint := range endpoints {
-			table.Append([]string{endpoint.Cluster, fmt.Sprintf("%s/%s/%s", endpoint.Ref.Kind, endpoint.Ref.Namespace, endpoint.Ref.Name), endpoint.String()})
+			table.Append([]string{endpoint.Cluster, endpoint.Component, fmt.Sprintf("%s/%s/%s", endpoint.Ref.Kind, endpoint.Ref.Namespace, endpoint.Ref.Name), endpoint.String()})
 		}
 		fmt.Printf("Please access the %s from the following endpoints:\n", name)
 		table.Render()


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

1. new cue provider function `ql.#ListAppliedResources`, list applied resources of an application, they read from ResourceTracker.
2. new velaQL view  `service-applied-resources-view`.
3. support filter service endpoints by component name. 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.