### PR TITLE
Feat: local virtual cluster + namespace in topology

### DIFF
--- a/apis/core.oam.dev/v1alpha1/policy_types.go
+++ b/apis/core.oam.dev/v1alpha1/policy_types.go
@@ -27,7 +27,8 @@ const (
 type TopologyPolicySpec struct {
 	// Placement embeds the selectors for choosing cluster
 	Placement `json:",inline"`
-	// Namespace specify the namespace for override, used along which clusters/clusterLabelSelector/clusterSelector
+	// Namespace is the target namespace to deploy in the selected clusters.
+	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }
 

--- a/apis/core.oam.dev/v1alpha1/policy_types.go
+++ b/apis/core.oam.dev/v1alpha1/policy_types.go
@@ -27,6 +27,8 @@ const (
 type TopologyPolicySpec struct {
 	// Placement embeds the selectors for choosing cluster
 	Placement `json:",inline"`
+	// Namespace specify the namespace for override, used along which clusters/clusterLabelSelector/clusterSelector
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // Placement describes which clusters to be selected in this topology

--- a/apis/types/multicluster.go
+++ b/apis/types/multicluster.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
+
+const (
+	// CredentialTypeInternal identifies the virtual cluster from internal kubevela system
+	CredentialTypeInternal v1alpha1.CredentialType = "Internal"
+	// CredentialTypeOCMManagedCluster identifies the virtual cluster from ocm
+	CredentialTypeOCMManagedCluster v1alpha1.CredentialType = "ManagedCluster"
+)

--- a/apis/types/multicluster.go
+++ b/apis/types/multicluster.go
@@ -23,4 +23,6 @@ const (
 	CredentialTypeInternal v1alpha1.CredentialType = "Internal"
 	// CredentialTypeOCMManagedCluster identifies the virtual cluster from ocm
 	CredentialTypeOCMManagedCluster v1alpha1.CredentialType = "ManagedCluster"
+	// ClusterBlankEndpoint identifies the endpoint of a cluster as blank (not available)
+	ClusterBlankEndpoint = "-"
 )

--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -39,6 +39,7 @@ import (
 	clusterv1alpha1 "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/policy/envbinding"
 	"github.com/oam-dev/kubevela/pkg/utils"
 	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
@@ -394,7 +395,7 @@ func DetachCluster(ctx context.Context, cli client.Client, clusterName string, o
 		if err := cli.Delete(ctx, clusterSecret); err != nil {
 			return errors.Wrapf(err, "failed to detach cluster %s", clusterName)
 		}
-	case CredentialTypeOCMManagedCluster:
+	case types.CredentialTypeOCMManagedCluster:
 		if args.managedClusterKubeConfigPath == "" {
 			return errors.New("kubeconfig-path must be set to detach ocm managed cluster")
 		}

--- a/pkg/multicluster/virtual_cluster.go
+++ b/pkg/multicluster/virtual_cluster.go
@@ -30,12 +30,8 @@ import (
 
 	"github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
 
+	"github.com/oam-dev/kubevela/apis/types"
 	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
-)
-
-const (
-	// CredentialTypeOCMManagedCluster identifies the virtual cluster from ocm
-	CredentialTypeOCMManagedCluster v1alpha1.CredentialType = "ManagedCluster"
 )
 
 // VirtualCluster contains base info of cluster, it unifies the difference between different cluster implementations
@@ -48,6 +44,18 @@ type VirtualCluster struct {
 	Labels   map[string]string
 	Metrics  *ClusterMetrics
 	Object   client.Object
+}
+
+// NewVirtualClusterFromLocal return virtual cluster corresponding to local cluster
+func NewVirtualClusterFromLocal() *VirtualCluster {
+	return &VirtualCluster{
+		Name:     ClusterLocalName,
+		Type:     types.CredentialTypeInternal,
+		EndPoint: "-",
+		Accepted: true,
+		Labels:   map[string]string{},
+		Metrics:  metricsMap[ClusterLocalName],
+	}
 }
 
 // NewVirtualClusterFromSecret extract virtual cluster from cluster secret
@@ -82,7 +90,7 @@ func NewVirtualClusterFromManagedCluster(managedCluster *clusterv1.ManagedCluste
 	}
 	return &VirtualCluster{
 		Name:     managedCluster.Name,
-		Type:     CredentialTypeOCMManagedCluster,
+		Type:     types.CredentialTypeOCMManagedCluster,
 		EndPoint: "-",
 		Accepted: managedCluster.Spec.HubAcceptsClient,
 		Labels:   managedCluster.GetLabels(),
@@ -93,6 +101,9 @@ func NewVirtualClusterFromManagedCluster(managedCluster *clusterv1.ManagedCluste
 
 // GetVirtualCluster returns virtual cluster with given clusterName
 func GetVirtualCluster(ctx context.Context, c client.Client, clusterName string) (vc *VirtualCluster, err error) {
+	if clusterName == ClusterLocalName {
+		return NewVirtualClusterFromLocal(), nil
+	}
 	secret := &corev1.Secret{}
 	err = c.Get(ctx, apitypes.NamespacedName{
 		Name:      clusterName,
@@ -161,7 +172,11 @@ func (m MatchVirtualClusterLabels) ApplyToDeleteAllOf(opts *client.DeleteAllOfOp
 
 // ListVirtualClusters will get all registered clusters in control plane
 func ListVirtualClusters(ctx context.Context, c client.Client) ([]VirtualCluster, error) {
-	return FindVirtualClustersByLabels(ctx, c, map[string]string{})
+	clusters, err := FindVirtualClustersByLabels(ctx, c, map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+	return append([]VirtualCluster{*NewVirtualClusterFromLocal()}, clusters...), nil
 }
 
 // FindVirtualClustersByLabels will get all virtual clusters with matched labels in control plane

--- a/pkg/multicluster/virtual_cluster.go
+++ b/pkg/multicluster/virtual_cluster.go
@@ -51,7 +51,7 @@ func NewVirtualClusterFromLocal() *VirtualCluster {
 	return &VirtualCluster{
 		Name:     ClusterLocalName,
 		Type:     types.CredentialTypeInternal,
-		EndPoint: "-",
+		EndPoint: types.ClusterBlankEndpoint,
 		Accepted: true,
 		Labels:   map[string]string{},
 		Metrics:  metricsMap[ClusterLocalName],
@@ -91,7 +91,7 @@ func NewVirtualClusterFromManagedCluster(managedCluster *clusterv1.ManagedCluste
 	return &VirtualCluster{
 		Name:     managedCluster.Name,
 		Type:     types.CredentialTypeOCMManagedCluster,
-		EndPoint: "-",
+		EndPoint: types.ClusterBlankEndpoint,
 		Accepted: managedCluster.Spec.HubAcceptsClient,
 		Labels:   managedCluster.GetLabels(),
 		Metrics:  metricsMap[managedCluster.Name],

--- a/pkg/multicluster/virtual_cluster_test.go
+++ b/pkg/multicluster/virtual_cluster_test.go
@@ -25,6 +25,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+
+	"github.com/oam-dev/kubevela/apis/types"
 )
 
 var _ = Describe("Test Virtual Cluster", func() {
@@ -102,13 +104,13 @@ var _ = Describe("Test Virtual Cluster", func() {
 
 		vc, err = GetVirtualCluster(ctx, k8sClient, "ocm-cluster")
 		Expect(err).Should(Succeed())
-		Expect(vc.Type).Should(Equal(CredentialTypeOCMManagedCluster))
+		Expect(vc.Type).Should(Equal(types.CredentialTypeOCMManagedCluster))
 
 		By("Test List Virtual Clusters")
 
 		vcs, err := ListVirtualClusters(ctx, k8sClient)
 		Expect(err).Should(Succeed())
-		Expect(len(vcs)).Should(Equal(3))
+		Expect(len(vcs)).Should(Equal(4))
 
 		vcs, err = FindVirtualClustersByLabels(ctx, k8sClient, map[string]string{"key": "value"})
 		Expect(err).Should(Succeed())

--- a/pkg/workflow/providers/multicluster/multicluster.go
+++ b/pkg/workflow/providers/multicluster/multicluster.go
@@ -29,6 +29,7 @@ import (
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	pkgpolicy "github.com/oam-dev/kubevela/pkg/policy"
 	"github.com/oam-dev/kubevela/pkg/policy/envbinding"
+	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
 	"github.com/oam-dev/kubevela/pkg/utils"
 	wfContext "github.com/oam-dev/kubevela/pkg/workflow/context"
 	"github.com/oam-dev/kubevela/pkg/workflow/providers"
@@ -173,13 +174,25 @@ func (p *provider) ExpandTopology(ctx wfContext.Context, v *value.Value, act wfT
 	}
 	var placements []v1alpha1.PlacementDecision
 	placementMap := map[string]struct{}{}
-	addCluster := func(cluster string) {
-		placement := v1alpha1.PlacementDecision{Cluster: cluster, Namespace: p.app.GetNamespace()}
+	addCluster := func(cluster string, ns string, validateCluster bool) error {
+		if validateCluster {
+			if _, e := multicluster.GetVirtualCluster(context.Background(), p, cluster); e != nil {
+				return errors.Wrapf(e, "failed to get cluster %s", cluster)
+			}
+		}
+		if ns == "" {
+			ns = p.app.GetNamespace()
+		}
+		if !resourcekeeper.AllowCrossNamespaceResource && ns != p.app.GetNamespace() {
+			return errors.Errorf("cannot cross namespace")
+		}
+		placement := v1alpha1.PlacementDecision{Cluster: cluster, Namespace: ns}
 		name := placement.String()
 		if _, found := placementMap[name]; !found {
 			placementMap[name] = struct{}{}
 			placements = append(placements, placement)
 		}
+		return nil
 	}
 	for _, policy := range *policies {
 		if policy.Type == v1alpha1.TopologyPolicyType {
@@ -187,20 +200,26 @@ func (p *provider) ExpandTopology(ctx wfContext.Context, v *value.Value, act wfT
 			if err := utils.StrictUnmarshal(policy.Properties.Raw, topologySpec); err != nil {
 				return errors.Wrapf(err, "failed to parse topology policy %s", policy.Name)
 			}
-			if topologySpec.Clusters != nil {
+			clusterLabelSelector := pkgpolicy.GetClusterLabelSelectorInTopology(topologySpec)
+			switch {
+			case topologySpec.Clusters != nil:
 				for _, cluster := range topologySpec.Clusters {
-					if _, err = multicluster.GetVirtualCluster(context.Background(), p, cluster); err != nil {
-						return errors.Wrapf(err, "failed to get cluster %s in topology %s", cluster, policy.Name)
+					if err := addCluster(cluster, topologySpec.Namespace, true); err != nil {
+						return err
 					}
-					addCluster(cluster)
 				}
-			} else if clusterLabelSelector := pkgpolicy.GetClusterLabelSelectorInTopology(topologySpec); clusterLabelSelector != nil {
+			case clusterLabelSelector != nil:
 				clusters, err := multicluster.FindVirtualClustersByLabels(context.Background(), p, clusterLabelSelector)
 				if err != nil {
 					return errors.Wrapf(err, "failed to find clusters in topology %s", policy.Name)
 				}
+				if len(clusters) == 0 {
+					return errors.Errorf("failed to find any cluster matches given labels")
+				}
 				for _, cluster := range clusters {
-					addCluster(cluster.Name)
+					if err = addCluster(cluster.Name, topologySpec.Namespace, false); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/pkg/utils"
 
@@ -195,7 +197,7 @@ var _ = Describe("Test multicluster scenario", func() {
 
 	})
 
-	Context("Test EnvBinding Application", func() {
+	Context("Test multi-cluster Application", func() {
 
 		var namespace string
 		var testNamespace string
@@ -408,6 +410,34 @@ var _ = Describe("Test multicluster scenario", func() {
 			By("test delete env")
 			err = k8sClient.Delete(hubCtx, &checkApp)
 			Expect(err).Should(BeNil())
+		})
+
+		It("Test deploy multi-cluster application with target", func() {
+			By("apply application")
+			app := &v1beta1.Application{
+				ObjectMeta: v12.ObjectMeta{Namespace: namespace, Name: "test-app-target"},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common.ApplicationComponent{{
+						Name:       "test-busybox",
+						Type:       "webservice",
+						Properties: &runtime.RawExtension{Raw: []byte(`{"image":"busybox","cmd":["sleep","86400"]}`)},
+					}},
+					Policies: []v1beta1.AppPolicy{{
+						Name:       "topology-local",
+						Type:       "topology",
+						Properties: &runtime.RawExtension{Raw: []byte(fmt.Sprintf(`{"clusters":["local"],"namespace":"%s"}`, testNamespace))},
+					}, {
+						Name:       "topology-remote",
+						Type:       "topology",
+						Properties: &runtime.RawExtension{Raw: []byte(fmt.Sprintf(`{"clusters":["%s"],"namespace":"%s"}`, WorkerClusterName, prodNamespace))},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(hubCtx, app)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(hubCtx, types.NamespacedName{Name: "test-busybox", Namespace: testNamespace}, &v13.Deployment{})).Should(Succeed())
+				g.Expect(k8sClient.Get(workerCtx, types.NamespacedName{Name: "test-busybox", Namespace: prodNamespace}, &v13.Deployment{})).Should(Succeed())
+			}, time.Minute).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1. Allow local cluster as VirtualCluster. Now user can use local cluster in topology policy like previous env-binding policy.
2. Allow specifying namespace in topology policy. Now user can use a different namespace other than the original application namespace like previous env-binding policy. Notice that this will only work when bootstrap parameter --allow-cross-namespace-resource is set.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

Picked from #3409.