### PR TITLE
Feat: support query the policy definitions

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -41,6 +41,8 @@ var DefaultKubeVelaNS = "vela-system"
 const (
 	// AnnoDefinitionDescription is the annotation which describe what is the capability used for in a WorkloadDefinition/TraitDefinition Object
 	AnnoDefinitionDescription = "definition.oam.dev/description"
+	// AnnoDefinitionIcon is the annotation which describe the icon url
+	AnnoDefinitionIcon = "definition.oam.dev/icon"
 	// AnnoDefinitionAppliedWorkloads is the annotation which describe what is the workloads used for in a TraitDefinition Object
 	AnnoDefinitionAppliedWorkloads = "definition.oam.dev/appliedWorkloads"
 	// LabelDefinition is the label for definition

--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -4496,6 +4496,19 @@
 				}
 			}
 		},
+		"common.DefinitionReference": {
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"version": {
+					"type": "string"
+				}
+			}
+		},
 		"common.Helm": {
 			"required": [
 				"release",
@@ -5046,8 +5059,8 @@
 		},
 		"model.Cluster": {
 			"required": [
-				"createTime",
 				"updateTime",
+				"createTime",
 				"name",
 				"alias",
 				"description",
@@ -5714,12 +5727,12 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
+				"createTime",
+				"version",
+				"envName",
 				"status",
 				"note",
-				"envName",
-				"triggerType",
-				"createTime",
-				"version"
+				"triggerType"
 			],
 			"properties": {
 				"codeInfo": {
@@ -6713,6 +6726,9 @@
 				"icon"
 			],
 			"properties": {
+				"component": {
+					"$ref": "#/definitions/v1beta1.ComponentDefinitionSpec"
+				},
 				"description": {
 					"type": "string"
 				},
@@ -6722,6 +6738,15 @@
 				"name": {
 					"type": "string"
 				},
+				"policy": {
+					"$ref": "#/definitions/v1beta1.PolicyDefinitionSpec"
+				},
+				"trait": {
+					"$ref": "#/definitions/v1beta1.TraitDefinitionSpec"
+				},
+				"workflowStep": {
+					"$ref": "#/definitions/v1beta1.WorkflowStepDefinitionSpec"
+				},
 				"workloadType": {
 					"type": "string"
 				}
@@ -6729,8 +6754,8 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"name",
 				"invisible",
+				"name",
 				"version",
 				"description",
 				"icon",
@@ -6806,13 +6831,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
+				"icon",
+				"name",
 				"alias",
 				"project",
 				"description",
 				"createTime",
 				"updateTime",
-				"icon",
-				"name",
 				"policies",
 				"envBindings",
 				"status",
@@ -6874,20 +6899,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"provider",
-				"kubeConfig",
-				"createTime",
 				"name",
-				"icon",
-				"status",
-				"dashboardURL",
-				"kubeConfigSecret",
 				"updateTime",
-				"labels",
-				"reason",
+				"createTime",
+				"provider",
 				"apiServerURL",
 				"alias",
 				"description",
+				"icon",
+				"status",
+				"labels",
+				"reason",
+				"dashboardURL",
+				"kubeConfig",
+				"kubeConfigSecret",
 				"resourceInfo"
 			],
 			"properties": {
@@ -6945,14 +6970,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
-				"createTime",
-				"updateTime",
-				"main",
-				"alias",
-				"appPrimaryKey",
-				"creator",
 				"name",
+				"appPrimaryKey",
 				"type",
+				"createTime",
+				"creator",
+				"alias",
+				"main",
+				"updateTime",
 				"definition"
 			],
 			"properties": {
@@ -7054,13 +7079,13 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"createTime",
 				"updateTime",
 				"name",
 				"type",
 				"description",
 				"creator",
-				"properties"
+				"properties",
+				"createTime"
 			],
 			"properties": {
 				"createTime": {
@@ -7090,17 +7115,17 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"deployUser",
-				"workflowName",
-				"reason",
-				"note",
-				"status",
-				"envName",
-				"triggerType",
 				"createTime",
 				"updateTime",
+				"reason",
+				"deployUser",
+				"workflowName",
+				"version",
+				"triggerType",
 				"appPrimaryKey",
-				"version"
+				"status",
+				"note",
+				"envName"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -7154,9 +7179,9 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
-				"name",
 				"createTime",
-				"updateTime"
+				"updateTime",
+				"name"
 			],
 			"properties": {
 				"alias": {
@@ -7193,12 +7218,12 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"status",
-				"name",
-				"namespace",
 				"workflowName",
 				"workflowAlias",
 				"applicationRevision",
+				"status",
+				"name",
+				"namespace",
 				"deployTime",
 				"deployUser",
 				"note",
@@ -7250,14 +7275,14 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"description",
+				"default",
 				"envName",
 				"createTime",
-				"updateTime",
 				"name",
 				"alias",
+				"description",
 				"enable",
-				"default"
+				"updateTime"
 			],
 			"properties": {
 				"alias": {
@@ -7853,10 +7878,10 @@
 		},
 		"v1.SystemInfoResponse": {
 			"required": [
-				"enableCollection",
 				"createTime",
 				"updateTime",
 				"installID",
+				"enableCollection",
 				"systemVersion"
 			],
 			"properties": {
@@ -8264,6 +8289,62 @@
 				}
 			}
 		},
+		"v1beta1.PolicyDefinitionSpec": {
+			"properties": {
+				"definitionRef": {
+					"$ref": "#/definitions/common.DefinitionReference"
+				},
+				"manageHealthCheck": {
+					"type": "boolean"
+				},
+				"schematic": {
+					"$ref": "#/definitions/common.Schematic"
+				}
+			}
+		},
+		"v1beta1.TraitDefinitionSpec": {
+			"properties": {
+				"appliesToWorkloads": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"conflictsWith": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"definitionRef": {
+					"$ref": "#/definitions/common.DefinitionReference"
+				},
+				"extension": {
+					"type": "string"
+				},
+				"manageWorkload": {
+					"type": "boolean"
+				},
+				"podDisruptive": {
+					"type": "boolean"
+				},
+				"revisionEnabled": {
+					"type": "boolean"
+				},
+				"schematic": {
+					"$ref": "#/definitions/common.Schematic"
+				},
+				"skipRevisionAffect": {
+					"type": "boolean"
+				},
+				"status": {
+					"$ref": "#/definitions/common.Status"
+				},
+				"workloadRefPath": {
+					"type": "string"
+				}
+			}
+		},
 		"v1beta1.Workflow": {
 			"properties": {
 				"ref": {
@@ -8309,6 +8390,16 @@
 				},
 				"type": {
 					"type": "string"
+				}
+			}
+		},
+		"v1beta1.WorkflowStepDefinitionSpec": {
+			"properties": {
+				"definitionRef": {
+					"$ref": "#/definitions/common.DefinitionReference"
+				},
+				"schematic": {
+					"$ref": "#/definitions/common.Schematic"
 				}
 			}
 		},

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -748,10 +748,16 @@ type DetailDefinitionResponse struct {
 
 // DefinitionBase is the definition base model
 type DefinitionBase struct {
-	Name         string `json:"name"`
-	Description  string `json:"description"`
-	WorkloadType string `json:"workloadType,omitempty"`
-	Icon         string `json:"icon"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Icon        string `json:"icon"`
+	// WorkloadType the component workload type
+	// Deprecated: it same as component.workload.type
+	WorkloadType string                              `json:"workloadType,omitempty"`
+	Trait        *v1beta1.TraitDefinitionSpec        `json:"trait,omitempty"`
+	Component    *v1beta1.ComponentDefinitionSpec    `json:"component,omitempty"`
+	Policy       *v1beta1.PolicyDefinitionSpec       `json:"policy,omitempty"`
+	WorkflowStep *v1beta1.WorkflowStepDefinitionSpec `json:"workflowStep,omitempty"`
 }
 
 // CreatePolicyRequest create app policy

--- a/pkg/apiserver/rest/usecase/definition.go
+++ b/pkg/apiserver/rest/usecase/definition.go
@@ -63,6 +63,7 @@ const (
 	kindComponentDefinition    = "ComponentDefinition"
 	kindTraitDefinition        = "TraitDefinition"
 	kindWorkflowStepDefinition = "WorkflowStepDefinition"
+	kindPolicyDefinition       = "PolicyDefinition"
 )
 
 // NewDefinitionUsecase new definition usecase
@@ -91,6 +92,11 @@ func (d *definitionUsecaseImpl) ListDefinitions(ctx context.Context, envName, de
 		defs.SetAPIVersion(definitionAPIVersion)
 		defs.SetKind(kindWorkflowStepDefinition)
 		return d.listDefinitions(ctx, defs, kindWorkflowStepDefinition, "")
+
+	case "policy":
+		defs.SetAPIVersion(definitionAPIVersion)
+		defs.SetKind(kindPolicyDefinition)
+		return d.listDefinitions(ctx, defs, kindPolicyDefinition, "")
 
 	default:
 		return nil, bcode.ErrDefinitionTypeNotSupport
@@ -143,6 +149,7 @@ func (d *definitionUsecaseImpl) listDefinitions(ctx context.Context, list *unstr
 		definition := &apisv1.DefinitionBase{
 			Name:        def.GetName(),
 			Description: def.GetAnnotations()[types.AnnoDefinitionDescription],
+			Icon:        def.GetAnnotations()[types.AnnoDefinitionIcon],
 		}
 		if cache == kindComponentDefinition {
 			compDef := &v1beta1.ComponentDefinition{}
@@ -150,6 +157,28 @@ func (d *definitionUsecaseImpl) listDefinitions(ctx context.Context, list *unstr
 				return nil, errors.Wrap(err, "invalid component definition")
 			}
 			definition.WorkloadType = compDef.Spec.Workload.Type
+			definition.Component = &compDef.Spec
+		}
+		if cache == kindTraitDefinition {
+			traitDef := &v1beta1.TraitDefinition{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(def.Object, traitDef); err != nil {
+				return nil, errors.Wrap(err, "invalid trait definition")
+			}
+			definition.Trait = &traitDef.Spec
+		}
+		if cache == kindWorkflowStepDefinition {
+			workflowStepDef := &v1beta1.WorkflowStepDefinition{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(def.Object, workflowStepDef); err != nil {
+				return nil, errors.Wrap(err, "invalid trait definition")
+			}
+			definition.WorkflowStep = &workflowStepDef.Spec
+		}
+		if cache == kindPolicyDefinition {
+			policyDef := &v1beta1.PolicyDefinition{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(def.Object, policyDef); err != nil {
+				return nil, errors.Wrap(err, "invalid trait definition")
+			}
+			definition.Policy = &policyDef.Spec
 		}
 		defs = append(defs, definition)
 	}

--- a/pkg/apiserver/rest/usecase/definition_test.go
+++ b/pkg/apiserver/rest/usecase/definition_test.go
@@ -87,6 +87,7 @@ var _ = Describe("Test namespace usecase functions", func() {
 		Expect(cmp.Diff(len(traits), 1)).Should(BeEmpty())
 		Expect(cmp.Diff(traits[0].Name, "myingress")).Should(BeEmpty())
 		Expect(traits[0].Description).ShouldNot(BeEmpty())
+		Expect(traits[0].Trait).ShouldNot(BeNil())
 
 		By("List workflow step definitions")
 		step, err := ioutil.ReadFile("./testdata/applyapplication-sd.yaml")
@@ -101,6 +102,29 @@ var _ = Describe("Test namespace usecase functions", func() {
 		Expect(cmp.Diff(len(wfstep), 1)).Should(BeEmpty())
 		Expect(cmp.Diff(wfstep[0].Name, "apply-application")).Should(BeEmpty())
 		Expect(wfstep[0].Description).ShouldNot(BeEmpty())
+		Expect(wfstep[0].WorkflowStep.Schematic).ShouldNot(BeNil())
+
+		By("List policy definitions")
+		var policy = v1beta1.PolicyDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "health",
+				Namespace: "vela-system",
+				Annotations: map[string]string{
+					"definition.oam.dev/description": "this is a policy definition",
+				},
+			},
+			Spec: v1beta1.PolicyDefinitionSpec{
+				ManageHealthCheck: true,
+			},
+		}
+		err = k8sClient.Create(context.Background(), &policy)
+		Expect(err).Should(Succeed())
+		policies, err := definitionUsecase.ListDefinitions(context.TODO(), "", "policy", "")
+		Expect(err).Should(BeNil())
+		Expect(cmp.Diff(len(policies), 1)).Should(BeEmpty())
+		Expect(cmp.Diff(policies[0].Name, "health")).Should(BeEmpty())
+		Expect(policies[0].Description).ShouldNot(BeEmpty())
+		Expect(policies[0].Policy.ManageHealthCheck).Should(BeTrue())
 	})
 
 	It("Test DetailDefinition function", func() {


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

* Add query policy definitions support.
* The query definitions API returns the spec.

Ref: oam-dev/velaux#395

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.