### PR TITLE
Chore: fix `issue-commands` workflow

### DIFF
--- a/.github/workflows/issue-commands.yml
+++ b/.github/workflows/issue-commands.yml
@@ -14,9 +14,9 @@ jobs:
         with:
           repository: "oam-dev/kubevela-github-actions"
           path: ./actions
-          ref: v0.4.1
+          ref: v0.4.2
       - name: Install Actions
-        run: npm install --production --prefix ./actions
+        run: npm ci --production --prefix ./actions
       - name: Run Commands
         uses: ./actions/commands
         with:


### PR DESCRIPTION
### Description of your changes

It seems that the [issue-commands](https://github.com/oam-dev/kubevela/actions/workflows/issue-commands.yml) workflow keeps failing.

This PR will fix the `issue-commands` workflow by bumping up the action version and replacing `npm install` with `npm ci` for reproducibility.

Refs: https://github.com/oam-dev/kubevela-github-actions/pull/11

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I tested with my personal repository

- [Actions Log](https://github.com/devholic/actions-test/runs/5557335137?check_suite_focus=true)
- [Workflow](https://github.com/devholic/actions-test/blob/d6c7771449b03075e93a51ae23e48c8fd1e4dd98/.github/workflows/issue.yaml)

### Special notes for your reviewer

This PR should be merged after https://github.com/oam-dev/kubevela-github-actions/pull/11 released.