### PR TITLE
Fix: trait env and storage conflict

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -126,14 +126,14 @@ spec:
         	// +patchKey=name
         	volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
 
-        	containers: [...{
+        	containers: [{
         		// +patchKey=name
         		env: configMapEnvMountsList + secretEnvMountsList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name
         		volumeMounts: pvcVolumeMountsList + configMapVolumeMountsList + secretVolumeMountsList + emptyDirVolumeMountsList
-        	}]
+        	}, ...]
 
         }
         outputs: {

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -126,14 +126,14 @@ spec:
         	// +patchKey=name
         	volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
 
-        	containers: [...{
+        	containers: [{
         		// +patchKey=name
         		env: configMapEnvMountsList + secretEnvMountsList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name
         		volumeMounts: pvcVolumeMountsList + configMapVolumeMountsList + secretVolumeMountsList + emptyDirVolumeMountsList
-        	}]
+        	}, ...]
 
         }
         outputs: {

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -134,14 +134,14 @@ template: {
 		// +patchKey=name
 		volumes: pvcVolumesList + configMapVolumesList + secretVolumesList + emptyDirVolumesList
 
-		containers: [...{
+		containers: [{
 			// +patchKey=name
 			env: configMapEnvMountsList + secretEnvMountsList
 			// +patchKey=name
 			volumeDevices: volumeDevicesList
 			// +patchKey=name
 			volumeMounts: pvcVolumeMountsList + configMapVolumeMountsList + secretVolumeMountsList + emptyDirVolumeMountsList
-		}]
+		}, ...]
 
 	}
 


### PR DESCRIPTION
Signed-off-by: maxiangbo <maxiangboo@cmbchina.com>

Fixes #3300.
Trait env, storage and webservice/worker properties env can be used at the same time.

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->