### PR TITLE
Feat: check if an addon is been used while disabling.

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1100,6 +1100,10 @@ func (h *Installer) dispatchAddonResource(addon *InstallPackage) error {
 		return errors.Wrap(err, "render addon definitions' schema fail")
 	}
 
+	if err := passDefInAppAnnotation(defs, app); err != nil {
+		return errors.Wrapf(err, "cannot pass definition to addon app's annotation")
+	}
+
 	err = h.apply.Apply(h.ctx, app, apply.DisableUpdateAnnotation())
 	if err != nil {
 		klog.Errorf("fail to create application: %v", err)

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -113,6 +113,9 @@ var (
 
 	// CLIMetaOptions get Addon metadata for CLI display
 	CLIMetaOptions = ListOptions{}
+
+	// UnInstallOptions used for addon uninstalling
+	UnInstallOptions = ListOptions{GetDefinition: true}
 )
 
 const (

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -61,6 +61,10 @@ var paths = []string{
 
 	"test-error-addon/metadata.yaml",
 	"test-error-addon/resources/parameter.cue",
+
+	"test-disable-addon/metadata.yaml",
+	"test-disable-addon/definitions/compDef.yaml",
+	"test-disable-addon/definitions/traitDef.cue",
 }
 
 var ossHandler http.HandlerFunc = func(rw http.ResponseWriter, req *http.Request) {
@@ -128,7 +132,7 @@ func testReaderFunc(t *testing.T, reader AsyncReader) {
 	rName := "KubeVela"
 	uiDataList, err := ListAddonUIDataFromReader(reader, registryMeta, rName, UIMetaOptions)
 	assert.True(t, strings.Contains(err.Error(), "#parameter.example: preference mark not allowed at this position"))
-	assert.Equal(t, len(uiDataList), 3)
+	assert.Equal(t, 4, len(uiDataList))
 	assert.Equal(t, uiDataList[0].RegistryName, rName)
 
 	// test get install package

--- a/pkg/addon/helper.go
+++ b/pkg/addon/helper.go
@@ -81,7 +81,7 @@ func DisableAddon(ctx context.Context, cli client.Client, name string, config *r
 			return err
 		}
 		if len(usingAddonApp) != 0 {
-			return fmt.Errorf("some applications still using this addon, cannot disable yet ")
+			return fmt.Errorf(fmt.Sprintf("%s please delete them first", usingAppsInfo(usingAddonApp)))
 		}
 	}
 

--- a/pkg/addon/testdata/test-disable-addon/definitions/compDef.yaml
+++ b/pkg/addon/testdata/test-disable-addon/definitions/compDef.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: my-comp
+  namespace: vela-system
+spec:
+  schematic:
+    cue:
+      template:

--- a/pkg/addon/testdata/test-disable-addon/definitions/traitDef.cue
+++ b/pkg/addon/testdata/test-disable-addon/definitions/traitDef.cue
@@ -1,0 +1,19 @@
+"my-trait": {
+	type: "trait"
+	annotations: {}
+	description: "Rollout the component."
+	attributes: {
+		manageWorkload: true
+		status: {
+			customStatus: #"""
+				message: context.outputs.rollout.status.rollingState
+				"""#
+			healthPolicy: #"""
+				isHealth: context.outputs.rollout.status.batchRollingState == "batchReady"
+				"""#
+		}
+	}
+}
+template: {
+	outputs: rollout: {}
+}

--- a/pkg/addon/testdata/test-disable-addon/metadata.yaml
+++ b/pkg/addon/testdata/test-disable-addon/metadata.yaml
@@ -1,0 +1,13 @@
+name: test-disable-addon
+version: 1.0.0
+
+tags:
+  - only_test
+
+deployTo:
+  control_plane: true
+  runtime_cluster: false
+
+dependencies: []
+
+invisible: false

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -206,6 +206,6 @@ func usingAppsInfo(apps []v1beta1.Application) string {
 		nameStr := strings.Join(appNames, ",")
 		res += fmt.Sprintf("(%s) in namespace:%s,", nameStr, namespace)
 	}
-	res = strings.TrimSuffix(res, ",") + " are string using this addon"
+	res = strings.TrimSuffix(res, ",") + " are still using this addon"
 	return res
 }

--- a/pkg/addon/utils.go
+++ b/pkg/addon/utils.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	errors "github.com/pkg/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	rest "k8s.io/client-go/rest"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/definition"
+	"github.com/oam-dev/kubevela/pkg/oam"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+)
+
+const (
+	compDefAnnotation         = "addon.oam.dev/componentDefinitions"
+	traitDefAnnotation        = "addon.oam.dev/traitDefinitions"
+	workflowStepDefAnnotation = "addon.oam.dev/workflowStepDefinitions"
+	defKeytemplate            = "addon-%s-%s"
+)
+
+// parse addon's created x-defs in addon-app's annotation, this will be used to check whether app still using it while disabling.
+func passDefInAppAnnotation(defs []*unstructured.Unstructured, app *v1beta1.Application) error {
+	var comps, traits, workflowSteps []string
+	for _, def := range defs {
+		switch def.GetObjectKind().GroupVersionKind().Kind {
+		case v1beta1.ComponentDefinitionKind:
+			comps = append(comps, def.GetName())
+		case v1beta1.TraitDefinitionKind:
+			traits = append(traits, def.GetName())
+		case v1beta1.WorkflowStepDefinitionKind:
+			workflowSteps = append(workflowSteps, def.GetName())
+		default:
+			return fmt.Errorf("cannot handle definition types %s, name %s", def.GetObjectKind().GroupVersionKind().Kind, def.GetName())
+		}
+	}
+	if len(comps) != 0 {
+		c, _ := json.Marshal(comps)
+		app.SetAnnotations(util.MergeMapOverrideWithDst(app.GetAnnotations(), map[string]string{compDefAnnotation: string(c)}))
+	}
+	if len(traits) != 0 {
+		t, _ := json.Marshal(traits)
+		app.SetAnnotations(util.MergeMapOverrideWithDst(app.GetAnnotations(), map[string]string{traitDefAnnotation: string(t)}))
+	}
+	if len(workflowSteps) != 0 {
+		w, _ := json.Marshal(workflowSteps)
+		app.SetAnnotations(util.MergeMapOverrideWithDst(app.GetAnnotations(), map[string]string{workflowStepDefAnnotation: string(w)}))
+	}
+	return nil
+}
+
+// check whether this addon has been used by some applications
+func checkAddonHasBeenUsed(ctx context.Context, k8sClient client.Client, name string, addonApp v1beta1.Application, config *rest.Config) ([]v1beta1.Application, error) {
+	apps := v1beta1.ApplicationList{}
+	if err := k8sClient.List(ctx, &apps, client.InNamespace("")); err != nil {
+		return nil, err
+	}
+
+	if len(apps.Items) == 0 {
+		return nil, nil
+	}
+
+	createdDefs := make(map[string]bool)
+	for key, defNames := range addonApp.GetAnnotations() {
+		switch key {
+		case compDefAnnotation, traitDefAnnotation, workflowStepDefAnnotation:
+			if err := merge2DefMap(key, defNames, createdDefs); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(createdDefs) == 0 {
+		if err := findLegacyAddonDefs(ctx, k8sClient, name, addonApp.GetLabels()[oam.LabelAddonRegistry], config, createdDefs); err != nil {
+			return nil, err
+		}
+	}
+
+	var res []v1beta1.Application
+CHECKNEXT:
+	for _, app := range apps.Items {
+		for _, component := range app.Spec.Components {
+			if createdDefs[fmt.Sprintf(defKeytemplate, "comp", component.Type)] {
+				res = append(res, app)
+				// this app has used this addon, there is no need check other components
+				continue CHECKNEXT
+			}
+			for _, trait := range component.Traits {
+				if createdDefs[fmt.Sprintf(defKeytemplate, "trait", trait.Type)] {
+					res = append(res, app)
+					continue CHECKNEXT
+				}
+			}
+		}
+		if app.Spec.Workflow == nil || len(app.Spec.Workflow.Steps) == 0 {
+			return res, nil
+		}
+		for _, s := range app.Spec.Workflow.Steps {
+			if createdDefs[fmt.Sprintf(defKeytemplate, "wfStep", s.Type)] {
+				res = append(res, app)
+				continue CHECKNEXT
+			}
+		}
+	}
+	return res, nil
+}
+
+//  merge2DefMap will parse annotation in addon's app to 'created x-definition'. Then stroe them in defMap
+func merge2DefMap(defType string, defNames string, defMap map[string]bool) error {
+	list := []string{}
+	err := json.Unmarshal([]byte(defNames), &list)
+	if err != nil {
+		return err
+	}
+	template := "addon-%s-%s"
+	for _, defName := range list {
+		switch defType {
+		case compDefAnnotation:
+			defMap[fmt.Sprintf(template, "comp", defName)] = true
+		case traitDefAnnotation:
+			defMap[fmt.Sprintf(template, "trait", defName)] = true
+		case workflowStepDefAnnotation:
+			defMap[fmt.Sprintf(template, "wfStep", defName)] = true
+		}
+	}
+	return nil
+}
+
+// for old addon's app no 'created x-definitions' annotation, fetch the definitions from alive addon registry. Put them in defMap
+func findLegacyAddonDefs(ctx context.Context, k8sClient client.Client, addonName string, registryName string, config *rest.Config, defs map[string]bool) error {
+	// if the addon enable by local we cannot fetch the source definitions yet, so skip the check
+	if registryName == "local" {
+		return nil
+	}
+
+	registryDS := NewRegistryDataStore(k8sClient)
+	registries, err := registryDS.ListRegistries(ctx)
+	if err != nil {
+		return err
+	}
+	var defObjects []*unstructured.Unstructured
+	for i, registry := range registries {
+		if registry.Name == registryName {
+			installer := NewAddonInstaller(ctx, k8sClient, nil, nil, config, &registries[i], nil, nil)
+			pkg, err := installer.loadInstallPackage(addonName)
+			if err != nil {
+				return errors.Wrapf(err, "cannot fetch addon files from registry")
+			}
+			for _, defYaml := range pkg.Definitions {
+				def, err := renderObject(defYaml)
+				if err != nil {
+					// don't let one error defined definition block whole disable process
+					continue
+				}
+				defObjects = append(defObjects, def)
+			}
+			for _, cueDef := range pkg.CUEDefinitions {
+				def := definition.Definition{Unstructured: unstructured.Unstructured{}}
+				err := def.FromCUEString(cueDef.Data, config)
+				if err != nil {
+					// don't let one error defined cue definition block whole disable process
+					continue
+				}
+				defObjects = append(defObjects, &def.Unstructured)
+			}
+		}
+	}
+	for _, defObject := range defObjects {
+		switch defObject.GetObjectKind().GroupVersionKind().Kind {
+		case v1beta1.ComponentDefinitionKind:
+			defs[fmt.Sprintf(defKeytemplate, "comp", defObject.GetName())] = true
+		case v1beta1.TraitDefinitionKind:
+			defs[fmt.Sprintf(defKeytemplate, "trait", defObject.GetName())] = true
+		case v1beta1.WorkflowStepDefinitionKind:
+			defs[fmt.Sprintf(defKeytemplate, "wfStep", defObject.GetName())] = true
+		}
+	}
+	return nil
+}

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -83,9 +83,9 @@ var _ = Describe("Test definition check", func() {
 
 		anno := addonApp.GetAnnotations()
 		Expect(len(anno)).Should(BeEquivalentTo(3))
-		Expect(anno[compDefAnnotation]).Should(BeEquivalentTo(`["my-comp"]`))
-		Expect(anno[traitDefAnnotation]).Should(BeEquivalentTo(`["my-trait"]`))
-		Expect(anno[workflowStepDefAnnotation]).Should(BeEquivalentTo(`["my-wfstep"]`))
+		Expect(anno[compDefAnnotation]).Should(BeEquivalentTo("my-comp"))
+		Expect(anno[traitDefAnnotation]).Should(BeEquivalentTo("my-trait"))
+		Expect(anno[workflowStepDefAnnotation]).Should(BeEquivalentTo("my-wfstep"))
 	})
 
 	It("Test checkAddonHasBeenUsed func", func() {
@@ -131,13 +131,20 @@ var _ = Describe("Test definition check", func() {
 
 func TestMerge2Map(t *testing.T) {
 	res := make(map[string]bool)
-	err := merge2DefMap(compDefAnnotation, `["my-comp1","my-comp2"]`, res)
-	assert.NoError(t, err)
-	err = merge2DefMap(traitDefAnnotation, `["my-trait1","my-trait2"]`, res)
-	assert.NoError(t, err)
-	err = merge2DefMap(workflowStepDefAnnotation, `["my-wfStep1","my-wfStep2"]`, res)
-	assert.NoError(t, err)
+	merge2DefMap(compDefAnnotation, "my-comp1,my-comp2", res)
+	merge2DefMap(traitDefAnnotation, "my-trait1,my-trait2", res)
+	merge2DefMap(workflowStepDefAnnotation, "my-wfStep1,my-wfStep2", res)
 	assert.Equal(t, 6, len(res))
+}
+
+func TestUsingAddonInfo(t *testing.T) {
+	apps := []v1beta1.Application{
+		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-1"}},
+		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-2", Name: "app-2"}},
+		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-3"}},
+	}
+	res := usingAppsInfo(apps)
+	assert.Equal(t, res, "application: (app-1,app-3) in namespace:namespace-1,(app-2) in namespace:namespace-2 are string using this addon")
 }
 
 const (
@@ -173,9 +180,9 @@ metadata:
     addons.oam.dev/name: myaddon
     addons.oam.dev/registry: KubeVela
   annotations:
-    addon.oam.dev/componentDefinitions: '["my-comp"]'
-    addon.oam.dev/traitDefinitions: '["my-trait"]'
-    addon.oam.dev/workflowStepDefinitions: '["my-wfstep"]'
+    addon.oam.dev/componentDefinitions: "my-comp"
+    addon.oam.dev/traitDefinitions: "my-trait"
+    addon.oam.dev/workflowStepDefinitions: "my-wfstep"
   name: addon-myaddon
   namespace: vela-system
 spec:

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	velatypes "github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/oam"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+)
+
+var _ = Describe("Test definition check", func() {
+	var compDef v1beta1.ComponentDefinition
+	var traitDef v1beta1.TraitDefinition
+	var wfStepDef v1beta1.WorkflowStepDefinition
+
+	BeforeEach(func() {
+		compDef = v1beta1.ComponentDefinition{}
+		traitDef = v1beta1.TraitDefinition{}
+		wfStepDef = v1beta1.WorkflowStepDefinition{}
+
+		Expect(yaml.Unmarshal([]byte(compDefYaml), &compDef)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &compDef)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+
+		Expect(yaml.Unmarshal([]byte(traitDefYaml), &traitDef)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &traitDef)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+
+		Expect(yaml.Unmarshal([]byte(wfStepDefYaml), &wfStepDef)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &wfStepDef)).Should(SatisfyAny(BeNil(), util.AlreadyExistMatcher{}))
+	})
+
+	It("Test pass def to app annotation", func() {
+		c := v1beta1.ComponentDefinition{TypeMeta: metav1.TypeMeta{APIVersion: "core.oam.dev/v1beta1", Kind: "ComponentDefinition"}}
+		c.SetName("my-comp")
+
+		t := v1beta1.TraitDefinition{TypeMeta: metav1.TypeMeta{APIVersion: "core.oam.dev/v1beta1", Kind: "TraitDefinition"}}
+		t.SetName("my-trait")
+
+		w := v1beta1.WorkflowStepDefinition{TypeMeta: metav1.TypeMeta{APIVersion: "core.oam.dev/v1beta1", Kind: "WorkflowStepDefinition"}}
+		w.SetName("my-wfstep")
+
+		var defs []*unstructured.Unstructured
+		cDef, err := util.Object2Unstructured(c)
+		Expect(err).Should(BeNil())
+		defs = append(defs, cDef)
+		tDef, err := util.Object2Unstructured(t)
+		defs = append(defs, tDef)
+		Expect(err).Should(BeNil())
+		wDef, err := util.Object2Unstructured(w)
+		Expect(err).Should(BeNil())
+		defs = append(defs, wDef)
+
+		addonApp := v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Name: "addon-app", Namespace: velatypes.DefaultKubeVelaNS}}
+		err = passDefInAppAnnotation(defs, &addonApp)
+		Expect(err).Should(BeNil())
+
+		anno := addonApp.GetAnnotations()
+		Expect(len(anno)).Should(BeEquivalentTo(3))
+		Expect(anno[compDefAnnotation]).Should(BeEquivalentTo(`["my-comp"]`))
+		Expect(anno[traitDefAnnotation]).Should(BeEquivalentTo(`["my-trait"]`))
+		Expect(anno[workflowStepDefAnnotation]).Should(BeEquivalentTo(`["my-wfstep"]`))
+	})
+
+	It("Test checkAddonHasBeenUsed func", func() {
+		addonApp := v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(addonAppYaml), &addonApp)).Should(BeNil())
+
+		app1 := v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(testApp1Yaml), &app1)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &app1)).Should(BeNil())
+
+		app2 := v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(testApp2Yaml), &app2)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &app2)).Should(BeNil())
+
+		Expect(k8sClient.Create(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}))
+		app3 := v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(testApp3Yaml), &app3)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &app3)).Should(BeNil())
+
+		usedApps, err := checkAddonHasBeenUsed(ctx, k8sClient, "my-addon", addonApp, cfg)
+		Expect(err).Should(BeNil())
+		Expect(len(usedApps)).Should(BeEquivalentTo(3))
+	})
+
+	It("check fetch lagacy addon definitions", func() {
+		res := make(map[string]bool)
+
+		server := httptest.NewServer(ossHandler)
+		defer server.Close()
+
+		url := server.URL
+		cmYaml := strings.ReplaceAll(registryCmYaml, "TEST_SERVER_URL", url)
+		cm := v1.ConfigMap{}
+		Expect(yaml.Unmarshal([]byte(cmYaml), &cm)).Should(BeNil())
+		Expect(k8sClient.Create(ctx, &cm)).Should(BeNil())
+
+		disableTestAddonApp := v1beta1.Application{}
+		Expect(yaml.Unmarshal([]byte(addonDisableTestAppYaml), &disableTestAddonApp)).Should(BeNil())
+		Expect(findLegacyAddonDefs(ctx, k8sClient, "test-disable-addon", disableTestAddonApp.GetLabels()[oam.LabelAddonRegistry], cfg, res)).Should(BeNil())
+		Expect(len(res)).Should(BeEquivalentTo(2))
+	})
+})
+
+func TestMerge2Map(t *testing.T) {
+	res := make(map[string]bool)
+	err := merge2DefMap(compDefAnnotation, `["my-comp1","my-comp2"]`, res)
+	assert.NoError(t, err)
+	err = merge2DefMap(traitDefAnnotation, `["my-trait1","my-trait2"]`, res)
+	assert.NoError(t, err)
+	err = merge2DefMap(workflowStepDefAnnotation, `["my-wfStep1","my-wfStep2"]`, res)
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(res))
+}
+
+const (
+	compDefYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+   name: my-comp
+   namespace: vela-system
+`
+	traitDefYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: TraitDefinition
+metadata:
+   name: my-trait
+   namespace: vela-system
+`
+	wfStepDefYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: WorkflowStepDefinition
+metadata:
+   name: my-wfstep
+   namespace: vela-system
+`
+)
+
+const (
+	addonAppYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  labels:
+    addons.oam.dev/name: myaddon
+    addons.oam.dev/registry: KubeVela
+  annotations:
+    addon.oam.dev/componentDefinitions: '["my-comp"]'
+    addon.oam.dev/traitDefinitions: '["my-trait"]'
+    addon.oam.dev/workflowStepDefinitions: '["my-wfstep"]'
+  name: addon-myaddon
+  namespace: vela-system
+spec:
+`
+	testApp1Yaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  labels:
+  name: app-1
+  namespace: default
+spec:
+  components:
+     - name: comp1
+       type: my-comp
+       traits:
+       - type: my-trait
+`
+	testApp2Yaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  labels:
+  name: app-2
+  namespace: default
+spec:
+  components:
+     - name: comp2
+       type: webservice
+       traits:
+       - type: my-trait
+`
+	testApp3Yaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: app-3
+  namespace: test-ns
+spec:
+  components:
+    - name: podinfo
+      type: webservice
+
+  workflow:      
+    steps:
+    - type: my-wfstep
+      name: deploy
+`
+	registryCmYaml = `
+apiVersion: v1
+data:
+  registries: '{ "KubeVela":{ "name": "KubeVela", "oss": { "end_point": "TEST_SERVER_URL",
+    "bucket": "", "path": "" } } }'
+kind: ConfigMap
+metadata:
+  name: vela-addon-registry
+  namespace: vela-system
+`
+	addonDisableTestAppYaml = `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: addon-test-disable-addon
+  namespace: vela-system
+  labels:
+    addons.oam.dev/name: test-disable-addon
+    addons.oam.dev/registry: KubeVela
+spec:
+  components:
+    - name: podinfo
+      type: webservice
+`
+)

--- a/pkg/addon/utils_test.go
+++ b/pkg/addon/utils_test.go
@@ -144,7 +144,7 @@ func TestUsingAddonInfo(t *testing.T) {
 		v1beta1.Application{ObjectMeta: metav1.ObjectMeta{Namespace: "namespace-1", Name: "app-3"}},
 	}
 	res := usingAppsInfo(apps)
-	assert.Equal(t, res, "application: (app-1,app-3) in namespace:namespace-1,(app-2) in namespace:namespace-2 are string using this addon")
+	assert.Equal(t, true, strings.Contains(res, "still using this addon"))
 }
 
 const (

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -62,7 +62,7 @@ type AddonHandler interface {
 	StatusAddon(ctx context.Context, name string) (*apis.AddonStatusResponse, error)
 	GetAddon(ctx context.Context, name string, registry string) (*apis.DetailAddonResponse, error)
 	EnableAddon(ctx context.Context, name string, args apis.EnableAddonRequest) error
-	DisableAddon(ctx context.Context, name string) error
+	DisableAddon(ctx context.Context, name string, force bool) error
 	ListEnabledAddon(ctx context.Context) ([]*apis.AddonBaseStatus, error)
 	UpdateAddon(ctx context.Context, name string, args apis.EnableAddonRequest) error
 }
@@ -383,8 +383,8 @@ func (u *defaultAddonHandler) EnableAddon(ctx context.Context, name string, args
 	return bcode.ErrAddonNotExist
 }
 
-func (u *defaultAddonHandler) DisableAddon(ctx context.Context, name string) error {
-	err := pkgaddon.DisableAddon(ctx, u.kubeClient, name)
+func (u *defaultAddonHandler) DisableAddon(ctx context.Context, name string, force bool) error {
+	err := pkgaddon.DisableAddon(ctx, u.kubeClient, name, u.config, force)
 	if err != nil {
 		log.Logger.Errorf("delete application fail: %s", err.Error())
 		return err

--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -17,6 +17,8 @@ limitations under the License.
 package webservice
 
 import (
+	"strconv"
+
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 
@@ -182,7 +184,13 @@ func (s *addonWebService) enableAddon(req *restful.Request, res *restful.Respons
 
 func (s *addonWebService) disableAddon(req *restful.Request, res *restful.Response) {
 	name := req.PathParameter("name")
-	err := s.handler.DisableAddon(req.Request.Context(), name)
+	forceParam := req.QueryParameter("force")
+	force, err := strconv.ParseBool(forceParam)
+	if err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+	err = s.handler.DisableAddon(req.Request.Context(), name, force)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return

--- a/references/cli/uninstall_test.go
+++ b/references/cli/uninstall_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Test Install Command", func() {
 	})
 
 	It("Test disable all addons", func() {
-		err := forceDisableAddon(context.Background(), k8sClient)
+		err := forceDisableAddon(context.Background(), k8sClient, cfg)
 		Expect(err).Should(BeNil())
 		Eventually(func() error {
 			addons, err := checkInstallAddon(k8sClient)


### PR DESCRIPTION
This pr done these things:

1. parse 'created x-defs' in addon-app's annotation。such as
```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  annotations:
    addon.oam.dev/traitDefinitions: '["rollout"]'
    addon.oam.dev/componentDefinitions: '["webservice"]'
  ....
```

3. check all applications whether using this addon while disabling.
4. for lagacy addon which don't have these annotation, so fetch them from alive registry.
5. give user a way to force disable addon and ignore the check

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3415 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->