### PR TITLE
Feat: add the conditions for ui schema spec

### DIFF
--- a/pkg/apiserver/rest/usecase/definition.go
+++ b/pkg/apiserver/rest/usecase/definition.go
@@ -328,6 +328,9 @@ func patchSchema(defaultSchema, customSchema []*utils.UIParameter) []*utils.UIPa
 			if cusSchema.Style != nil {
 				dSchema.Style = cusSchema.Style
 			}
+			if cusSchema.Conditions != nil {
+				dSchema.Conditions = cusSchema.Conditions
+			}
 		}
 	}
 	sort.Slice(defaultSchema, func(i, j int) bool {

--- a/pkg/apiserver/rest/utils/ui_schema.go
+++ b/pkg/apiserver/rest/utils/ui_schema.go
@@ -34,11 +34,33 @@ type UIParameter struct {
 	UIType      string    `json:"uiType"`
 	Style       *Style    `json:"style,omitempty"`
 	// means disable parameter in ui
-	Disable                 *bool          `json:"disable,omitempty"`
+	Disable *bool `json:"disable,omitempty"`
+	// Conditions: control whether fields are enabled or disabled by certain conditions.
+	// Rules:
+	// if all conditions are not matching, the parameter will be disabled
+	// if there are no conditions, and disable==false the parameter will be enabled.
+	// if one disable action condition is matched, the parameter will be disabled.
+	// if all enable actions conditions are matched, the parameter will be enabled.
+	// +optional
+	Conditions              []Condition    `json:"conditions,omitempty"`
 	SubParameterGroupOption []GroupOption  `json:"subParameterGroupOption,omitempty"`
 	SubParameters           []*UIParameter `json:"subParameters,omitempty"`
 	AdditionalParameter     *UIParameter   `json:"additionalParameter,omitempty"`
 	Additional              *bool          `json:"additional,omitempty"`
+}
+
+// Condition control whether fields are enabled or disabled by certain conditions.
+type Condition struct {
+	// JSONKey specifies the path of the field, support the peer and subordinate fields.
+	JSONKey string `json:"jsonKey"`
+	// Op options includes `==` 、`!=` and `in`, default is `==`
+	// +optional
+	Op string `json:"op,omitempty"`
+	// Value specifies the prospective value.
+	Value interface{} `json:"value"`
+	// Action options includes `enable` or `disable`, default is `enable`
+	// +optional
+	Action string `json:"action,omitempty"`
 }
 
 // Style ui style


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

The Conditions are used to set conditions for rendering the form. such as: 

```
- jsonKey: url
  label: Repo URL
  uiType: HelmRepoSelect
  description: Please input or select the helm or git repo address.
  sort: 2
  validate:
    required: true
    pattern: ^(http|git).*$
- jsonKey: chart
  uiType: HelmChartSelect
  sort: 3
  label: Chart
  description: Please select the chart or input the chart path.
  conditions: 
    - jsonKey: url
      op: "!="
      value: ""
- jsonKey: version
  uiType: HelmChartVersionSelect
  sort: 4
  label: Version
  validate:
    required: true
    defaultValue: ""
  conditions: 
    - jsonKey: repoType
      value: "helm"
    - jsonKey: chart
      op: "!="
      value: ""
    - jsonKey: url
      op: "!="
      value: ""
```
The select chart form will not be rendered firstly, after the `url` form input value,  The select chart form will be rendered and shown.

* `jsonKey`:  specifies the path of the field, supports the peer and subordinate fields. such as `param1`、`param1.subparam1`
* `value`: specifies the prospective value.
* `op`: The op options includes `==` 、`!=` and `in`, default is `==`.
* `action`: The action options includes `enable` or `disable`, default is `enable`.

Rules:
* if all conditions are not matching, the parameter will be disabled
* if there are no conditions, and disable==false the parameter will be enabled.
* if one disable action condition is matched, the parameter will be disabled.
* if all enable actions conditions are matched, the parameter will be enabled.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.