### PR TITLE
Feat: support the mountPath of trait-storage-secret is optional

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -23,7 +23,7 @@ spec:
         	},
         ] | []
         configMapVolumesList: *[
-        			for v in parameter.configMap {
+        			for v in parameter.configMap if v.mountPath != _|_ {
         		{
         			name: "configmap-" + v.name
         			configMap: {
@@ -69,7 +69,7 @@ spec:
         	},
         ] | []
         configMapVolumeMountsList: *[
-        				for v in parameter.configMap {
+        				for v in parameter.configMap if v.mountPath != _|_ {
         		{
         			name:      "configmap-" + v.name
         			mountPath: v.mountPath
@@ -248,7 +248,7 @@ spec:
         			envName:      string
         			configMapKey: string
         		}
-        		mountPath:   string
+        		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
         		data?: {...}

--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -37,7 +37,7 @@ spec:
         	},
         ] | []
         secretVolumesList: *[
-        			for v in parameter.secret {
+        			for v in parameter.secret if v.mountPath != _|_ {
         		{
         			name: "secret-" + v.name
         			secret: {
@@ -88,7 +88,7 @@ spec:
         	},
         ] | []
         secretVolumeMountsList: *[
-        			for v in parameter.secret {
+        			for v in parameter.secret if v.mountPath != _|_ {
         		{
         			name:      "secret-" + v.name
         			mountPath: v.mountPath
@@ -267,7 +267,7 @@ spec:
         			envName:   string
         			secretKey: string
         		}
-        		mountPath:   string
+        		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
         		stringData?: {...}

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -23,7 +23,7 @@ spec:
         	},
         ] | []
         configMapVolumesList: *[
-        			for v in parameter.configMap {
+        			for v in parameter.configMap if v.mountPath != _|_ {
         		{
         			name: "configmap-" + v.name
         			configMap: {
@@ -69,7 +69,7 @@ spec:
         	},
         ] | []
         configMapVolumeMountsList: *[
-        				for v in parameter.configMap {
+        				for v in parameter.configMap if v.mountPath != _|_ {
         		{
         			name:      "configmap-" + v.name
         			mountPath: v.mountPath
@@ -248,7 +248,7 @@ spec:
         			envName:      string
         			configMapKey: string
         		}
-        		mountPath:   string
+        		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
         		data?: {...}

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -37,7 +37,7 @@ spec:
         	},
         ] | []
         secretVolumesList: *[
-        			for v in parameter.secret {
+        			for v in parameter.secret if v.mountPath != _|_ {
         		{
         			name: "secret-" + v.name
         			secret: {
@@ -88,7 +88,7 @@ spec:
         	},
         ] | []
         secretVolumeMountsList: *[
-        			for v in parameter.secret {
+        			for v in parameter.secret if v.mountPath != _|_ {
         		{
         			name:      "secret-" + v.name
         			mountPath: v.mountPath
@@ -267,7 +267,7 @@ spec:
         			envName:   string
         			secretKey: string
         		}
-        		mountPath:   string
+        		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
         		stringData?: {...}

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -19,7 +19,7 @@ template: {
 	] | []
 
 	configMapVolumesList: *[
-				for v in parameter.configMap {
+				for v in parameter.configMap if v.mountPath != _|_ {
 			{
 				name: "configmap-" + v.name
 				configMap: {
@@ -71,7 +71,7 @@ template: {
 	] | []
 
 	configMapVolumeMountsList: *[
-					for v in parameter.configMap {
+					for v in parameter.configMap if v.mountPath != _|_ {
 			{
 				name:      "configmap-" + v.name
 				mountPath: v.mountPath
@@ -260,7 +260,7 @@ template: {
 				envName:      string
 				configMapKey: string
 			}
-			mountPath:   string
+			mountPath?:  string
 			defaultMode: *420 | int
 			readOnly:    *false | bool
 			data?: {...}

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -34,7 +34,7 @@ template: {
 	] | []
 
 	secretVolumesList: *[
-				for v in parameter.secret {
+				for v in parameter.secret if v.mountPath != _|_ {
 			{
 				name: "secret-" + v.name
 				secret: {
@@ -92,7 +92,7 @@ template: {
 	] | []
 
 	secretVolumeMountsList: *[
-				for v in parameter.secret {
+				for v in parameter.secret if v.mountPath != _|_ {
 			{
 				name:      "secret-" + v.name
 				mountPath: v.mountPath
@@ -279,7 +279,7 @@ template: {
 				envName:   string
 				secretKey: string
 			}
-			mountPath:   string
+			mountPath?:  string
 			defaultMode: *420 | int
 			readOnly:    *false | bool
 			stringData?: {...}


### PR DESCRIPTION

Signed-off-by: maxiangbo maxiangboo@cmbchina.com


### Description of your changes

Support the mountPath parameter of trait-storage-secret is optional.
by this feature, we can valueFrom secret in container env, without mounting the secret to the container at the same time.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->