### PR TITLE
Fix: fix bugs in vela def doc-gen from local file

### DIFF
--- a/hack/references/generate.go
+++ b/hack/references/generate.go
@@ -42,7 +42,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := ref.GenerateReferenceDocs(ctx, c, path, types.DefaultKubeVelaNS); err != nil {
+	ref.Remote = &plugins.Remote{Namespace: types.DefaultKubeVelaNS}
+	if err := ref.GenerateReferenceDocs(ctx, c, path); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/references/cli/common.go
+++ b/references/cli/common.go
@@ -27,7 +27,6 @@ const (
 	App       = "app"
 	Service   = "svc"
 	Namespace = "namespace"
-	Local     = "local"
 
 	// FlagDescription command flag to specify the description of the definition
 	FlagDescription = "desc"

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -457,36 +457,36 @@ func NewDefinitionGenDocCommand(c common.Args) *cobra.Command {
 				return fmt.Errorf("please specify definition name or a definition file")
 			}
 
-			var readFrom string
 			ref := &plugins.MarkdownReference{}
 			if strings.HasSuffix(args[0], ".yaml") {
+				// read from local file
 				localFilePath := args[0]
 				fileName := filepath.Base(localFilePath)
 				if !strings.HasSuffix(fileName, ".yaml") {
 					return fmt.Errorf("invalid local file path `%s`", localFilePath)
 				}
 				ref.DefinitionName = strings.TrimSuffix(fileName, ".yaml")
-				readFrom = localFilePath
+				ref.Local = &plugins.Local{Path: localFilePath}
 			} else {
 				namespace, err := cmd.Flags().GetString(FlagNamespace)
 				if err != nil {
 					return errors.Wrapf(err, "failed to get `%s`", Namespace)
 				}
 				ref.DefinitionName = args[0]
-				readFrom = namespace
+				ref.Remote = &plugins.Remote{Namespace: namespace}
 			}
 
 			ctx := context.Background()
 			pathEn := plugins.KubeVelaIOTerraformPath
 			ref.I18N = plugins.En
-			if err := ref.GenerateReferenceDocs(ctx, c, pathEn, readFrom); err != nil {
+			if err := ref.GenerateReferenceDocs(ctx, c, pathEn); err != nil {
 				return errors.Wrap(err, "failed to generate reference docs")
 			}
 			cmd.Printf("Generated docs in English for %s in %s/%s.md\n", args[0], pathEn, ref.DefinitionName)
 
 			pathZh := plugins.KubeVelaIOTerraformPathZh
 			ref.I18N = plugins.Zh
-			if err := ref.GenerateReferenceDocs(ctx, c, pathZh, readFrom); err != nil {
+			if err := ref.GenerateReferenceDocs(ctx, c, pathZh); err != nil {
 				return errors.Wrap(err, "failed to generate reference docs")
 			}
 			cmd.Printf("Generated docs in Chinese for %s in %s/%s.md\n", args[0], pathZh, ref.DefinitionName)

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -457,31 +457,39 @@ func NewDefinitionGenDocCommand(c common.Args) *cobra.Command {
 				return fmt.Errorf("please specify definition name or a definition file")
 			}
 
-			var namespace string
-			if !strings.HasSuffix(args[0], ".yaml") {
-				var err error
-				namespace, err = cmd.Flags().GetString(FlagNamespace)
-				if err != nil {
-					return errors.Wrapf(err, "failed to get `%s` or `%s`", Namespace, Local)
+			var readFrom string
+			ref := &plugins.MarkdownReference{}
+			if strings.HasSuffix(args[0], ".yaml") {
+				localFilePath := args[0]
+				fileName := filepath.Base(localFilePath)
+				if !strings.HasSuffix(fileName, ".yaml") {
+					return fmt.Errorf("invalid local file path `%s`", localFilePath)
 				}
+				ref.DefinitionName = strings.TrimSuffix(fileName, ".yaml")
+				readFrom = localFilePath
+			} else {
+				namespace, err := cmd.Flags().GetString(FlagNamespace)
+				if err != nil {
+					return errors.Wrapf(err, "failed to get `%s`", Namespace)
+				}
+				ref.DefinitionName = args[0]
+				readFrom = namespace
 			}
 
-			ref := &plugins.MarkdownReference{}
 			ctx := context.Background()
-			ref.DefinitionName = args[0]
 			pathEn := plugins.KubeVelaIOTerraformPath
 			ref.I18N = plugins.En
-			if err := ref.GenerateReferenceDocs(ctx, c, pathEn, namespace); err != nil {
+			if err := ref.GenerateReferenceDocs(ctx, c, pathEn, readFrom); err != nil {
 				return errors.Wrap(err, "failed to generate reference docs")
 			}
-			cmd.Printf("Generated docs in English for %s in %s/%s.md\n", args[0], pathEn, args[0])
+			cmd.Printf("Generated docs in English for %s in %s/%s.md\n", args[0], pathEn, ref.DefinitionName)
 
 			pathZh := plugins.KubeVelaIOTerraformPathZh
 			ref.I18N = plugins.Zh
-			if err := ref.GenerateReferenceDocs(ctx, c, pathZh, namespace); err != nil {
+			if err := ref.GenerateReferenceDocs(ctx, c, pathZh, readFrom); err != nil {
 				return errors.Wrap(err, "failed to generate reference docs")
 			}
-			cmd.Printf("Generated docs in Chinese for %s in %s/%s.md\n", args[0], pathZh, args[0])
+			cmd.Printf("Generated docs in Chinese for %s in %s/%s.md\n", args[0], pathZh, ref.DefinitionName)
 
 			return nil
 		},

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -24,12 +24,12 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/oam-dev/kubevela/apis/types"
-	"github.com/stretchr/testify/assert"
 )
 
 var RefTestDir = filepath.Join(TestDir, "ref")
@@ -597,7 +597,7 @@ func TestParseLocalFile(t *testing.T) {
 			localFilePath: "testdata/terraform-aws-elb.yaml",
 			want: types.Capability{
 				Name:                   "aws-elb",
-				Description:            "Terraform module which creates ELB resources on",
+				Description:            "Terraform module which creates ELB resources on AWS",
 				TerraformConfiguration: "https://github.com/terraform-aws-modules/terraform-aws-elb.git",
 				ConfigurationType:      "remote",
 				Path:                   "",
@@ -608,7 +608,7 @@ func TestParseLocalFile(t *testing.T) {
 			want: types.Capability{
 				Name:                   "azure-database-mariadb",
 				Description:            "Terraform configuration for Azure Database Mariadb",
-				TerraformConfiguration: "|\n        # Configure the Microsoft Azure Provider\n        provider \"azurerm\" {\n          features {}\n        }\n\n        resource \"azurerm_resource_group\" \"example\" {\n          name = var.resource_group\n          location = var.location\n        }\n\n        resource \"azurerm_mariadb_server\" \"example\" {\n          name = var.server_name\n          location = var.location\n          resource_group_name = azurerm_resource_group.example.name\n\n          sku_name = \"B_Gen5_2\"\n\n          storage_mb = 51200\n          backup_retention_days = 7\n          geo_redundant_backup_enabled = false\n\n          administrator_login = var.username\n          administrator_login_password = var.password\n          version = \"10.2\"\n          ssl_enforcement_enabled = true\n        }\n\n        resource \"azurerm_mariadb_database\" \"example\" {\n          name = var.db_name\n          resource_group_name = azurerm_resource_group.example.name\n          server_name = azurerm_mariadb_server.example.name\n          charset = \"utf8\"\n          collation = \"utf8_general_ci\"\n        }\n\n        variable \"server_name\" {\n          type = string\n          description = \"mariadb server name\"\n          default = \"mariadb-svr-sample\"\n        }\n\n        variable \"db_name\" {\n          default = \"backend\"\n          type = string\n          description = \"Database instance name\"\n        }\n\n        variable \"username\" {\n          default = \"acctestun\"\n          type = string\n          description = \"Database instance username\"\n        }\n\n        variable \"password\" {\n          default = \"H@Sh1CoR3!faked\"\n          type = string\n          description = \"Database instance password\"\n        }\n\n        variable \"location\" {\n          description = \"Azure location\"\n          type = string\n          default = \"West Europe\"\n        }\n\n        variable \"resource_group\" {\n          description = \"Resource group\"\n          type = string\n          default = \"kubevela-group\"\n        }\n\n        output \"SERVER_NAME\" {\n          value = var.server_name\n          description = \"mariadb server name\"\n        }\n\n        output \"DB_NAME\" {\n          value = var.db_name\n          description = \"Database instance name\"\n        }\n        output \"DB_USER\" {\n          value = var.username\n          description = \"Database instance username\"\n        }\n        output \"DB_PASSWORD\" {\n          sensitive = true\n          value = var.password\n          description = \"Database instance password\"\n        }\n        output \"DB_PORT\" {\n          value = \"3306\"\n          description = \"Database instance port\"\n        }\n        output \"DB_HOST\" {\n          value = azurerm_mariadb_server.example.fqdn\n          description = \"Database instance host\"\n        }",
+				TerraformConfiguration: "",
 				ConfigurationType:      "",
 				Path:                   "",
 			},
@@ -618,7 +618,7 @@ func TestParseLocalFile(t *testing.T) {
 			want: types.Capability{
 				Name:                   "baidu-vpc",
 				Description:            "Baidu Cloud VPC",
-				TerraformConfiguration: "|-\n        terraform {\n          required_providers {\n            baiducloud = {\n              source = \"baidubce/baiducloud\"\n              version = \"1.12.0\"\n            }\n          }\n        }\n\n        resource \"baiducloud_vpc\" \"default\" {\n          name        = var.name\n          description = var.description\n          cidr        = var.cidr\n        }\n\n        variable \"name\" {\n          default = \"terraform-vpc\"\n          description = \"The name of the VPC\"\n          type = string\n        }\n\n        variable \"description\" {\n          description = \"The description of the VPC\"\n          default = \"this is created by terraform\"\n          type = string\n        }\n\n        variable \"cidr\" {\n          description = \"The CIDR of the VPC\"\n          default = \"192.168.0.0/24\"\n          type = string\n        }\n\n        output \"vpcs\" {\n          value = baiducloud_vpc.default.id\n        }",
+				TerraformConfiguration: "",
 				ConfigurationType:      "",
 				Path:                   "",
 			},
@@ -638,7 +638,7 @@ func TestParseLocalFile(t *testing.T) {
 			want: types.Capability{
 				Name:                   "tencent-subnet",
 				Description:            "Tencent Cloud Subnet",
-				TerraformConfiguration: "|\n        terraform {\n          required_providers {\n            tencentcloud = {\n              source = \"tencentcloudstack/tencentcloud\"\n            }\n          }\n        }\n\n        variable \"availability_zone\" {\n          description = \"Availability Zone\"\n          default = \"ap-beijing-1\"\n          type = string\n        }\n\n        resource \"tencentcloud_vpc\" \"foo\" {\n          name       = \"guagua-ci-temp-test\"\n          cidr_block = \"10.0.0.0/16\"\n        }\n\n        resource \"tencentcloud_subnet\" \"subnet\" {\n          availability_zone = var.availability_zone\n          name              = var.name\n          vpc_id            = tencentcloud_vpc.foo.id\n          cidr_block        = var.cidr_block\n          is_multicast      = var.is_multicast\n        }\n\n        variable \"name\" {\n          description = \"Subnet name\"\n          default = \"guagua-ci-temp-test\"\n          type = string\n        }\n\n        variable \"cidr_block\" {\n          description = \"Subnet CIDR block\"\n          default = \"10.0.20.0/28\"\n          type = string\n        }\n\n        variable \"is_multicast\" {\n          description = \"Subnet is multicast\"\n          default = false\n          type = bool\n        }\n\n        output \"SUBNET_ID\" {\n          description = \"Subnet ID\"\n          value = tencentcloud_subnet.subnet.id\n        }",
+				TerraformConfiguration: "",
 				ConfigurationType:      "",
 				Path:                   "",
 			},
@@ -651,9 +651,24 @@ func TestParseLocalFile(t *testing.T) {
 				t.Errorf("ParseLocalFile(...): -want: %v, got error: %s\n", tc.want, err)
 			}
 			if !reflect.DeepEqual(*lc, tc.want) {
-				t.Errorf("ParseLocalFile(...): -want: %v, got: %v\n", tc.want, *lc)
+				if !reflect.DeepEqual(lc.Name, tc.want.Name) {
+					t.Errorf("Name not equal, - got: %v - want: %v", lc.Name, tc.want.Name)
+				}
+				if !reflect.DeepEqual(lc.Description, tc.want.Description) {
+					t.Errorf("Description not equal, - got: %v - want: %v", lc.Description, tc.want.Description)
+				}
+				if !reflect.DeepEqual(lc.TerraformConfiguration, tc.want.TerraformConfiguration) {
+					if len(lc.TerraformConfiguration) == 0 {
+						t.Errorf("Parse TerraformConfiguration failed")
+					}
+				}
+				if !reflect.DeepEqual(lc.ConfigurationType, tc.want.ConfigurationType) {
+					t.Errorf("ConfigurationType not equal, - got: %v - want: %v", lc.ConfigurationType, tc.want.ConfigurationType)
+				}
+				if !reflect.DeepEqual(lc.Path, tc.want.Path) {
+					t.Errorf("Path not equal, - got: %v - want: %v", lc.Path, tc.want.Path)
+				}
 			}
 		})
-		break
 	}
 }

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -28,9 +28,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/stretchr/testify/assert"
 )
 
 var RefTestDir = filepath.Join(TestDir, "ref")
@@ -651,9 +650,10 @@ func TestParseLocalFile(t *testing.T) {
 			if err != nil {
 				t.Errorf("ParseLocalFile(...): -want: %v, got error: %s\n", tc.want, err)
 			}
-			if reflect.DeepEqual(*lc, tc.want) {
+			if !reflect.DeepEqual(*lc, tc.want) {
 				t.Errorf("ParseLocalFile(...): -want: %v, got: %v\n", tc.want, *lc)
 			}
 		})
+		break
 	}
 }

--- a/references/plugins/reference_test.go
+++ b/references/plugins/reference_test.go
@@ -24,11 +24,12 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/oam-dev/kubevela/apis/types"
 )
 

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -88,7 +88,7 @@ type Remote struct {
 	Namespace string `json:"namespace"`
 }
 
-// Remote is the struct for input Definition Path
+// Local is the struct for input Definition Path
 type Local struct {
 	Path string `json:"path"`
 }

--- a/references/plugins/references.go
+++ b/references/plugins/references.go
@@ -95,9 +95,9 @@ type Local struct {
 
 // MarkdownReference is the struct for capability information in
 type MarkdownReference struct {
-	Remote 			*Remote `json:"remote"`
-	Local 			*Local  `json:"local"`
-	DefinitionName 	string `json:"definitionName"`
+	Remote         *Remote `json:"remote"`
+	Local          *Local  `json:"local"`
+	DefinitionName string  `json:"definitionName"`
 	ParseReference
 }
 
@@ -587,7 +587,7 @@ func (ref *MarkdownReference) GenerateReferenceDocs(ctx context.Context, c commo
 		return ref.CreateMarkdown(ctx, caps, baseRefPath, ReferenceSourcePath, nil)
 	}
 
-	if ref.Remote == nil{
+	if ref.Remote == nil {
 		return fmt.Errorf("failed to get capability %s without namespace or local filepath", ref.DefinitionName)
 	}
 


### PR DESCRIPTION
…rseLocalFile

Signed-off-by: Nicola115 <2225992901@qq.com>


### Description of your changes
  
1. add readFrom instead of namespace to pass either namespace or localFilePath to `GenerateRefeenceDocs`. 
2. set ref.DefinitionName as fileName if the args[0] is a filePath. 
3. change yaml.Unmarsh in ParseLocalFile to converting yaml to json using k8s pkg first.

Fixes #
  
1. using local filepath as generated markdown filename. 
4. failed to unmarshal parts of yaml data into ComponentDefinitions due to lack of yaml tags.  
5. wrong unit tests. 
  

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

1. pass TestParseLocalFile. 
2. I build the local vela and test `vela def doc-gen <localFilePath>` command.  


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->