### PR TITLE
Chore: Nominate Daniel as a Maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -28,6 +28,7 @@ Maintainers:
 - leejanee
 - zzxwill
 - BinaryHB0916
+- dhiguero
 
 Emeritus Members:
 - ryanzhang-oss


### PR DESCRIPTION
Signed-off-by: BinaryHB0916 <davidduan0916@gmail.com>


### Description of your changes

Daniel@[dhiguero](https://github.com/dhiguero)  has been consistently devoting his effort to help OAM Spec evolve and very active at the community call.

He was already a maintainer in OAM Spec repo based on serveral major contribtuions that made, such as [New application entity (v0.3.0)](https://github.com/oam-dev/spec/pull/447/files).

OAM/KubeVela is becoming pratical and clear for developers who needs a easily and sufficient application delivery platform or ecosystem. OAM Spec will serve the abstraction model layer of KubeVela and the latter tests what really developers need in the real world.

Based on the community membership updated recently, the goverance model of OAM/KubeVela community should be perceived universally for all the repos under the org of oam-dev.

Hence I nominee  Daniel as a maintainer. In future, Daniel continues to focus on the area of non Kubernetes runtime for OAM Spec and more proposal coming from their user scenarios.