### PR TITLE
Feat: support specify clusters in addon installation

### DIFF
--- a/apis/types/multicluster.go
+++ b/apis/types/multicluster.go
@@ -25,4 +25,7 @@ const (
 	CredentialTypeOCMManagedCluster v1alpha1.CredentialType = "ManagedCluster"
 	// ClusterBlankEndpoint identifies the endpoint of a cluster as blank (not available)
 	ClusterBlankEndpoint = "-"
+
+	// ClustersArg indicates the argument for specific clusters to install addon
+	ClustersArg = "clusters"
 )

--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -3239,9 +3239,9 @@
 				"parameters": [
 					{
 						"enum": [
-							"component",
 							"trait",
-							"workflowstep"
+							"workflowstep",
+							"component"
 						],
 						"type": "string",
 						"description": "query the definition type",
@@ -6217,8 +6217,8 @@
 		},
 		"v1.AddonStatusResponse": {
 			"required": [
-				"phase",
 				"name",
+				"phase",
 				"args"
 			],
 			"properties": {
@@ -6365,11 +6365,11 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
-				"createTime",
 				"version",
+				"note",
+				"createTime",
 				"status",
 				"envName",
-				"note",
 				"triggerType"
 			],
 			"properties": {
@@ -7422,11 +7422,11 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"name",
 				"description",
-				"invisible",
-				"version",
 				"icon",
+				"name",
+				"version",
+				"invisible",
 				"schema",
 				"uiSchema",
 				"definitions"
@@ -7499,13 +7499,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
-				"name",
-				"description",
 				"icon",
-				"alias",
+				"name",
 				"project",
 				"createTime",
 				"updateTime",
+				"alias",
+				"description",
 				"policies",
 				"envBindings",
 				"applicationType",
@@ -7566,20 +7566,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
+				"createTime",
 				"reason",
+				"updateTime",
+				"alias",
+				"apiServerURL",
 				"dashboardURL",
+				"kubeConfigSecret",
+				"description",
+				"icon",
+				"labels",
 				"kubeConfig",
 				"name",
 				"status",
-				"description",
-				"icon",
-				"createTime",
-				"alias",
 				"provider",
-				"apiServerURL",
-				"kubeConfigSecret",
-				"updateTime",
-				"labels",
 				"resourceInfo"
 			],
 			"properties": {
@@ -7637,14 +7637,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
+				"main",
+				"alias",
 				"type",
 				"creator",
 				"name",
-				"createTime",
-				"alias",
-				"updateTime",
 				"appPrimaryKey",
-				"main",
+				"createTime",
+				"updateTime",
 				"definition"
 			],
 			"properties": {
@@ -7746,13 +7746,13 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"creator",
-				"properties",
 				"createTime",
 				"updateTime",
 				"name",
 				"type",
-				"description"
+				"description",
+				"creator",
+				"properties"
 			],
 			"properties": {
 				"createTime": {
@@ -7783,15 +7783,15 @@
 		"v1.DetailRevisionResponse": {
 			"required": [
 				"createTime",
-				"status",
 				"reason",
+				"triggerType",
+				"note",
+				"version",
+				"updateTime",
 				"deployUser",
 				"envName",
 				"appPrimaryKey",
-				"updateTime",
-				"version",
-				"note",
-				"triggerType",
+				"status",
 				"workflowName"
 			],
 			"properties": {
@@ -7846,9 +7846,9 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
-				"updateTime",
+				"name",
 				"createTime",
-				"name"
+				"updateTime"
 			],
 			"properties": {
 				"alias": {
@@ -7885,11 +7885,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
-				"name",
-				"email",
 				"disabled",
 				"createTime",
 				"lastLoginTime",
+				"name",
+				"email",
 				"projects"
 			],
 			"properties": {
@@ -7923,12 +7923,12 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
+				"name",
 				"namespace",
 				"workflowName",
 				"workflowAlias",
 				"applicationRevision",
 				"status",
-				"name",
 				"deployTime",
 				"deployUser",
 				"note",
@@ -7980,13 +7980,13 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
+				"description",
 				"default",
 				"envName",
 				"createTime",
 				"updateTime",
 				"name",
 				"alias",
-				"description",
 				"enable"
 			],
 			"properties": {
@@ -8051,6 +8051,12 @@
 			"properties": {
 				"args": {
 					"type": "object"
+				},
+				"clusters": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				}
 			}
 		},
@@ -8173,8 +8179,8 @@
 		},
 		"v1.EnvBindingTarget": {
 			"required": [
-				"name",
-				"alias"
+				"alias",
+				"name"
 			],
 			"properties": {
 				"alias": {
@@ -8670,11 +8676,11 @@
 		},
 		"v1.SystemInfoResponse": {
 			"required": [
-				"installID",
-				"enableCollection",
 				"loginType",
 				"createTime",
 				"updateTime",
+				"installID",
+				"enableCollection",
 				"systemVersion"
 			],
 			"properties": {

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -228,15 +228,16 @@ func TestRender(t *testing.T) {
 
 func TestRenderApp(t *testing.T) {
 	addon := baseAddon
-	app, err := RenderApp(ctx, &addon, nil, nil, map[string]interface{}{})
+	app, err := RenderApp(ctx, &addon, nil, map[string]interface{}{})
 	assert.NoError(t, err, "render app fail")
-	assert.Equal(t, len(app.Spec.Components), 2)
+	// definition should not be rendered
+	assert.Equal(t, len(app.Spec.Components), 1)
 }
 
 func TestRenderAppWithNeedNamespace(t *testing.T) {
 	addon := baseAddon
-	addon.NeedNamespace = append(addon.NeedNamespace, types.DefaultKubeVelaNS)
-	app, err := RenderApp(ctx, &addon, nil, nil, map[string]interface{}{})
+	addon.NeedNamespace = append(addon.NeedNamespace, types.DefaultKubeVelaNS, "test-ns2")
+	app, err := RenderApp(ctx, &addon, nil, map[string]interface{}{})
 	assert.NoError(t, err, "render app fail")
 	assert.Equal(t, len(app.Spec.Components), 2)
 	for _, c := range app.Spec.Components {
@@ -257,7 +258,7 @@ func TestRenderDeploy2RuntimeAddon(t *testing.T) {
 	assert.Equal(t, def.GetAPIVersion(), "core.oam.dev/v1beta1")
 	assert.Equal(t, def.GetKind(), "TraitDefinition")
 
-	app, err := RenderApp(ctx, &addonDeployToRuntime, nil, nil, map[string]interface{}{})
+	app, err := RenderApp(ctx, &addonDeployToRuntime, nil, map[string]interface{}{})
 	assert.NoError(t, err)
 	steps := app.Spec.Workflow.Steps
 	assert.True(t, len(steps) >= 2)
@@ -278,7 +279,7 @@ func TestRenderDefinitions(t *testing.T) {
 	assert.Equal(t, def.GetAPIVersion(), "core.oam.dev/v1beta1")
 	assert.Equal(t, def.GetKind(), "TraitDefinition")
 
-	app, err := RenderApp(ctx, &addonDeployToRuntime, nil, nil, map[string]interface{}{})
+	app, err := RenderApp(ctx, &addonDeployToRuntime, nil, map[string]interface{}{})
 	assert.NoError(t, err)
 	// addon which app work on no-runtime-cluster mode workflow is nil
 	assert.Nil(t, app.Spec.Workflow)
@@ -291,7 +292,7 @@ func TestRenderK8sObjects(t *testing.T) {
 		RuntimeCluster:      false,
 	}
 
-	app, err := RenderApp(ctx, &addonMultiYaml, nil, nil, map[string]interface{}{})
+	app, err := RenderApp(ctx, &addonMultiYaml, nil, map[string]interface{}{})
 	assert.NoError(t, err)
 	assert.Equal(t, len(app.Spec.Components), 1)
 	comp := app.Spec.Components[0]
@@ -556,7 +557,7 @@ func TestRenderApp4Observability(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run("", func(t *testing.T) {
-			app, err := RenderApp(ctx, &tc.addon, nil, k8sClient, tc.args)
+			app, err := RenderApp(ctx, &tc.addon, k8sClient, tc.args)
 			assert.Equal(t, tc.err, err)
 			if app != nil {
 				data, err := json.Marshal(app)
@@ -603,7 +604,7 @@ func TestRenderApp4ObservabilityWithK8sData(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run("", func(t *testing.T) {
-			app, err := RenderApp(ctx, &tc.addon, nil, k8sClient, tc.args)
+			app, err := RenderApp(ctx, &tc.addon, k8sClient, tc.args)
 			assert.Equal(t, tc.err, err)
 			if app != nil {
 				data, err := json.Marshal(app)

--- a/pkg/addon/suite_test.go
+++ b/pkg/addon/suite_test.go
@@ -22,6 +22,9 @@ import (
 	"time"
 
 	"k8s.io/client-go/discovery"
+	ocmclusterv1 "open-cluster-management.io/api/cluster/v1"
+	ocmclusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	ocmworkv1 "open-cluster-management.io/api/work/v1"
 
 	v12 "k8s.io/api/core/v1"
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -79,6 +82,9 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(coreoam.AddToScheme(scheme)).NotTo(HaveOccurred())
 	Expect(clientgoscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
 	Expect(crdv1.AddToScheme(scheme)).NotTo(HaveOccurred())
+	_ = ocmclusterv1alpha1.Install(scheme)
+	_ = ocmclusterv1.Install(scheme)
+	_ = ocmworkv1.Install(scheme)
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())

--- a/pkg/addon/type.go
+++ b/pkg/addon/type.go
@@ -43,13 +43,18 @@ type UIData struct {
 type InstallPackage struct {
 	Meta
 
-	Definitions    []ElementFile        `json:"definitions"`
-	CUEDefinitions []ElementFile        `json:"CUEDefinitions"`
-	Parameters     string               `json:"parameters"`
-	CUETemplates   []ElementFile        `json:"CUETemplates"`
-	YAMLTemplates  []ElementFile        `json:"YAMLTemplates,omitempty"`
-	DefSchemas     []ElementFile        `json:"def_schemas,omitempty"`
-	AppTemplate    *v1beta1.Application `json:"appTemplate"`
+	// Definitions and CUEDefinitions are converted as OAM X-Definitions, they will only in control plane cluster
+	Definitions    []ElementFile `json:"definitions"`
+	CUEDefinitions []ElementFile `json:"CUEDefinitions"`
+	// DefSchemas are UI schemas read by VelaUX, it will only be installed in control plane clusters
+	DefSchemas []ElementFile `json:"def_schemas,omitempty"`
+
+	Parameters string `json:"parameters"`
+
+	// CUETemplates and YAMLTemplates are resources needed to be installed in managed clusters
+	CUETemplates  []ElementFile        `json:"CUETemplates"`
+	YAMLTemplates []ElementFile        `json:"YAMLTemplates,omitempty"`
+	AppTemplate   *v1beta1.Application `json:"appTemplate"`
 }
 
 // Meta defines the format for a single addon

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -104,6 +104,8 @@ type ListAddonRegistryResponse struct {
 type EnableAddonRequest struct {
 	// Args is the key-value environment variables, e.g. AK/SK credentials.
 	Args map[string]interface{} `json:"args,omitempty"`
+	// Clusters specify the clusters this addon should be installed, if not specified, it will follow the configure in addon metadata.yaml
+	Clusters []string `json:"clusters,omitempty"`
 }
 
 // ListAddonResponse defines the format for addon list response

--- a/pkg/apiserver/rest/webservice/addon.go
+++ b/pkg/apiserver/rest/webservice/addon.go
@@ -22,6 +22,7 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 
+	"github.com/oam-dev/kubevela/apis/types"
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/usecase"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
@@ -172,8 +173,12 @@ func (s *addonWebService) enableAddon(req *restful.Request, res *restful.Respons
 			return
 		}
 	}
+	if createReq.Clusters != nil {
+		createReq.Args[types.ClustersArg] = createReq.Clusters
+	}
 
 	name := req.PathParameter("name")
+
 	err = s.handler.EnableAddon(req.Request.Context(), name, createReq)
 	if err != nil {
 		bcode.ReturnError(req, res, err)
@@ -224,6 +229,9 @@ func (s *addonWebService) updateAddon(req *restful.Request, res *restful.Respons
 			bcode.ReturnError(req, res, err)
 			return
 		}
+	}
+	if createReq.Clusters != nil {
+		createReq.Args[types.ClustersArg] = createReq.Clusters
 	}
 
 	name := req.PathParameter("name")

--- a/references/cli/addon_test.go
+++ b/references/cli/addon_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
@@ -64,12 +65,24 @@ func TestParseMap(t *testing.T) {
 			},
 			nilError: true,
 		},
+		{
+			args: []string{"clusters={c1, c2, c3}", "image.tag=1.1"},
+			res: map[string]interface{}{
+				"clusters": []string{"c1", "c2", "c3"},
+				"image": map[string]interface{}{
+					"tag": "1.1",
+				},
+			},
+			nilError: true,
+		},
 	}
 	for _, s := range testcase {
-		r, err := parseToMap(s.args)
-		assert.DeepEqual(t, s.res, r)
+		r, err := parseAddonArgsToMap(s.args)
 		if s.nilError {
 			assert.NilError(t, err)
+			assert.DeepEqual(t, s.res, r)
+		} else {
+			assert.Error(t, err, fmt.Sprintf("%v should be error case", s.args))
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jianbo Sun <jianbo.sjb@alibaba-inc.com>


### Description of your changes

* Install addon by:
```
vela addon enable <addon-name> --clusters={local,cluster1,cluster2}
```

* Upgrade addon by:
```
vela addon upgrade <addon-name> --clusters={local,cluster1,cluster2}
```

Also add an api for addon install.

request body:
```
{
  "args": {},
  "clusters": ["clustername1","clusternam2",..]
}
```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->