### PR TITLE
Fix: api-server fail to start, when multi-cluster is disabled

### DIFF
--- a/pkg/multicluster/errors.go
+++ b/pkg/multicluster/errors.go
@@ -30,6 +30,8 @@ var (
 	ErrClusterNotExists = ClusterManagementError(fmt.Errorf("no such cluster"))
 	// ErrReservedLocalClusterName reserved cluster name is used
 	ErrReservedLocalClusterName = ClusterManagementError(fmt.Errorf("cluster name `local` is reserved for kubevela hub cluster"))
+	// ErrDetectClusterGateway fail to wait for ClusterGateway service ready
+	ErrDetectClusterGateway = ClusterManagementError(fmt.Errorf("failed to wait for cluster gateway, unable to use multi-cluster"))
 )
 
 // ClusterManagementError multicluster management error

--- a/pkg/multicluster/utils.go
+++ b/pkg/multicluster/utils.go
@@ -143,7 +143,7 @@ func Initialize(restConfig *rest.Config, autoUpgrade bool) (client.Client, error
 	}
 	svc, err := WaitUntilClusterGatewayReady(context.Background(), c, 60, 5*time.Second)
 	if err != nil {
-		return nil, errors2.Wrapf(err, "failed to wait for cluster gateway, unable to use multi-cluster")
+		return nil, ErrDetectClusterGateway
 	}
 	ClusterGatewaySecretNamespace = svc.Namespace
 	klog.Infof("find cluster gateway service %s/%s:%d", svc.Namespace, svc.Name, *svc.Port)


### PR DESCRIPTION
Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

How to fix it?
1. api-server try to create multicluster k8s client
2. if create fails and error is "failed to wait cluster gateway service " , roll back to create singlecluster client


```
│ I0323 09:51:17.916606       1 utils.go:128] waiting for cluster gateway service: ClusterGateway APIService v1alpha1.cluster.core.oam.dev is not found
│ I0323 09:51:22.921861       1 utils.go:128] waiting for cluster gateway service: ClusterGateway APIService v1alpha1.cluster.core.oam.dev is not found
│ I0323 09:51:27.892016       1 utils.go:128] waiting for cluster gateway service: ClusterGateway APIService v1alpha1.cluster.core.oam.dev is not found
│ I0323 09:51:32.899635       1 utils.go:128] waiting for cluster gateway service: ClusterGateway APIService v1alpha1.cluster.core.oam.dev is not found
│ I0323 09:51:37.905383       1 utils.go:128] waiting for cluster gateway service: ClusterGateway APIService v1alpha1.cluster.core.oam.dev is not found
│ I0323 09:51:43.786014       1 leaderelection.go:248] attempting to acquire leader lease vela-system/apiserver-lock...
│ {"level":"info","ts":1648029103.7857037,"caller":"rest/rest_server.go:256","msg":"HTTP APIs are being served on: 0.0.0.0:8000, ctx: context.Background.WithCancel"}
│ I0323 09:51:43.800407       1 rest_server.go:154] new leader elected: 4e12fbbe-dac4-49d3-b1aa-530b6f87949a
│ I0323 09:51:59.083310       1 leaderelection.go:258] successfully acquired lease vela-system/apiserver-lock
│ I0323 09:51:59.084870       1 rest_server.go:162] start to syncing workflow record
│ I0323 09:51:59.091771       1 worker.go:101] app syncing started
│ I0323 09:51:59.105854       1 worker.go:77] watched add app event, namespace: vela-system, name: addon-velaux
```




To avoid conflict and confusion, I think it is better to keep global unique swith "multicluster.enabled" for vela-core. 
api-server just try/autodect if multicluster is enabled without any parameter for multicluster


Fixes #3500 

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->