### PR TITLE
Feat: add health check for componentdefinition task

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -244,6 +244,30 @@ spec:
         	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
         	failureThreshold: *3 | int
         }
+  status:
+    customStatus: |-
+      status: {
+      	active:    *0 | int
+      	failed:    *0 | int
+      	succeeded: *0 | int
+      } & {
+      	if context.output.status.active != _|_ {
+      		active: context.output.status.active
+      	}
+      	if context.output.status.failed != _|_ {
+      		failed: context.output.status.failed
+      	}
+      	if context.output.status.succeeded != _|_ {
+      		succeeded: context.output.status.succeeded
+      	}
+      }
+      message: "Active/Failed/Succeeded:\(status.active)/\(status.failed)/\(status.succeeded)"
+    healthPolicy: |-
+      succeeded: *0 | int
+      if context.output.status.succeeded != _|_ {
+      	succeeded: context.output.status.succeeded
+      }
+      isHealth: succeeded == context.output.spec.parallelism
   workload:
     definition:
       apiVersion: batch/v1

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -503,52 +503,35 @@ spec:
         }
   status:
     customStatus: |-
-      import "strconv"
       ready: {
-      	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: 0
-      	}
-
+      	readyReplicas: *0 | int
+      } & {
       	if context.output.status.readyReplicas != _|_ {
       		readyReplicas: context.output.status.readyReplicas
       	}
       }
-
-      message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+      message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
     healthPolicy: |-
       ready: {
-      	if context.output.status.updatedReplicas == _|_  {
-      		updatedReplicas : 0
+      	updatedReplicas:    *0 | int
+      	readyReplicas:      *0 | int
+      	replicas:           *0 | int
+      	observedGeneration: *0 | int
+      } & {
+      	if context.output.status.updatedReplicas != _|_ {
+      		updatedReplicas: context.output.status.updatedReplicas
       	}
-
-      	if context.output.status.updatedReplicas != _|_  {
-      		updatedReplicas : context.output.status.updatedReplicas
-      	}
-
-      	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: 0
-      	}
-
       	if context.output.status.readyReplicas != _|_ {
       		readyReplicas: context.output.status.readyReplicas
-      	}
-
-      	if context.output.status.replicas == _|_ {
-      		replicas: 0
       	}
       	if context.output.status.replicas != _|_ {
       		replicas: context.output.status.replicas
       	}
-
       	if context.output.status.observedGeneration != _|_ {
       		observedGeneration: context.output.status.observedGeneration
       	}
-
-      	if context.output.status.observedGeneration == _|_ {
-      		observedGeneration: 0
-      	}
       }
-      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+      isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
   workload:
     definition:
       apiVersion: apps/v1

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -396,52 +396,35 @@ spec:
         }
   status:
     customStatus: |-
-      import "strconv"
       ready: {
-      	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: 0
-      	}
-
+      	readyReplicas: *0 | int
+      } & {
       	if context.output.status.readyReplicas != _|_ {
       		readyReplicas: context.output.status.readyReplicas
       	}
       }
-
-      message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+      message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
     healthPolicy: |-
       ready: {
-      	if context.output.status.updatedReplicas == _|_  {
-      		updatedReplicas : 0
+      	updatedReplicas:    *0 | int
+      	readyReplicas:      *0 | int
+      	replicas:           *0 | int
+      	observedGeneration: *0 | int
+      } & {
+      	if context.output.status.updatedReplicas != _|_ {
+      		updatedReplicas: context.output.status.updatedReplicas
       	}
-
-      	if context.output.status.updatedReplicas != _|_  {
-      		updatedReplicas : context.output.status.updatedReplicas
-      	}
-
-      	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: 0
-      	}
-
       	if context.output.status.readyReplicas != _|_ {
       		readyReplicas: context.output.status.readyReplicas
-      	}
-
-      	if context.output.status.replicas == _|_ {
-      		replicas: 0
       	}
       	if context.output.status.replicas != _|_ {
       		replicas: context.output.status.replicas
       	}
-
       	if context.output.status.observedGeneration != _|_ {
       		observedGeneration: context.output.status.observedGeneration
       	}
-
-      	if context.output.status.observedGeneration == _|_ {
-      		observedGeneration: 0
-      	}
       }
-      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+      isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
   workload:
     definition:
       apiVersion: apps/v1

--- a/charts/vela-minimal/templates/defwithtemplate/task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/task.yaml
@@ -244,6 +244,30 @@ spec:
         	// +usage=Number of consecutive failures required to determine the container is not alive (liveness probe) or not ready (readiness probe).
         	failureThreshold: *3 | int
         }
+  status:
+    customStatus: |-
+      status: {
+      	active:    *0 | int
+      	failed:    *0 | int
+      	succeeded: *0 | int
+      } & {
+      	if context.output.status.active != _|_ {
+      		active: context.output.status.active
+      	}
+      	if context.output.status.failed != _|_ {
+      		failed: context.output.status.failed
+      	}
+      	if context.output.status.succeeded != _|_ {
+      		succeeded: context.output.status.succeeded
+      	}
+      }
+      message: "Active/Failed/Succeeded:\(status.active)/\(status.failed)/\(status.succeeded)"
+    healthPolicy: |-
+      succeeded: *0 | int
+      if context.output.status.succeeded != _|_ {
+      	succeeded: context.output.status.succeeded
+      }
+      isHealth: succeeded == context.output.spec.parallelism
   workload:
     definition:
       apiVersion: batch/v1

--- a/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
@@ -503,52 +503,35 @@ spec:
         }
   status:
     customStatus: |-
-      import "strconv"
       ready: {
-      	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: 0
-      	}
-
+      	readyReplicas: *0 | int
+      } & {
       	if context.output.status.readyReplicas != _|_ {
       		readyReplicas: context.output.status.readyReplicas
       	}
       }
-
-      message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+      message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
     healthPolicy: |-
       ready: {
-      	if context.output.status.updatedReplicas == _|_  {
-      		updatedReplicas : 0
+      	updatedReplicas:    *0 | int
+      	readyReplicas:      *0 | int
+      	replicas:           *0 | int
+      	observedGeneration: *0 | int
+      } & {
+      	if context.output.status.updatedReplicas != _|_ {
+      		updatedReplicas: context.output.status.updatedReplicas
       	}
-
-      	if context.output.status.updatedReplicas != _|_  {
-      		updatedReplicas : context.output.status.updatedReplicas
-      	}
-
-      	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: 0
-      	}
-
       	if context.output.status.readyReplicas != _|_ {
       		readyReplicas: context.output.status.readyReplicas
-      	}
-
-      	if context.output.status.replicas == _|_ {
-      		replicas: 0
       	}
       	if context.output.status.replicas != _|_ {
       		replicas: context.output.status.replicas
       	}
-
       	if context.output.status.observedGeneration != _|_ {
       		observedGeneration: context.output.status.observedGeneration
       	}
-
-      	if context.output.status.observedGeneration == _|_ {
-      		observedGeneration: 0
-      	}
       }
-      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+      isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
   workload:
     definition:
       apiVersion: apps/v1

--- a/charts/vela-minimal/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/worker.yaml
@@ -396,52 +396,35 @@ spec:
         }
   status:
     customStatus: |-
-      import "strconv"
       ready: {
-      	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: 0
-      	}
-
+      	readyReplicas: *0 | int
+      } & {
       	if context.output.status.readyReplicas != _|_ {
       		readyReplicas: context.output.status.readyReplicas
       	}
       }
-
-      message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+      message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
     healthPolicy: |-
       ready: {
-      	if context.output.status.updatedReplicas == _|_  {
-      		updatedReplicas : 0
+      	updatedReplicas:    *0 | int
+      	readyReplicas:      *0 | int
+      	replicas:           *0 | int
+      	observedGeneration: *0 | int
+      } & {
+      	if context.output.status.updatedReplicas != _|_ {
+      		updatedReplicas: context.output.status.updatedReplicas
       	}
-
-      	if context.output.status.updatedReplicas != _|_  {
-      		updatedReplicas : context.output.status.updatedReplicas
-      	}
-
-      	if context.output.status.readyReplicas == _|_ {
-      		readyReplicas: 0
-      	}
-
       	if context.output.status.readyReplicas != _|_ {
       		readyReplicas: context.output.status.readyReplicas
-      	}
-
-      	if context.output.status.replicas == _|_ {
-      		replicas: 0
       	}
       	if context.output.status.replicas != _|_ {
       		replicas: context.output.status.replicas
       	}
-
       	if context.output.status.observedGeneration != _|_ {
       		observedGeneration: context.output.status.observedGeneration
       	}
-
-      	if context.output.status.observedGeneration == _|_ {
-      		observedGeneration: 0
-      	}
       }
-      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+      isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
   workload:
     definition:
       apiVersion: apps/v1

--- a/vela-templates/definitions/internal/component/task.cue
+++ b/vela-templates/definitions/internal/component/task.cue
@@ -3,12 +3,41 @@ task: {
 	annotations: {}
 	labels: {}
 	description: "Describes jobs that run code or a script to completion."
-	attributes: workload: {
-		definition: {
-			apiVersion: "batch/v1"
-			kind:       "Job"
+	attributes: {
+		workload: {
+			definition: {
+				apiVersion: "batch/v1"
+				kind:       "Job"
+			}
+			type: "jobs.batch"
 		}
-		type: "jobs.batch"
+		status: {
+			customStatus: #"""
+				status: {
+					active:    *0 | int
+					failed:    *0 | int
+					succeeded: *0 | int
+				} & {
+					if context.output.status.active != _|_ {
+						active: context.output.status.active
+					}
+					if context.output.status.failed != _|_ {
+						failed: context.output.status.failed
+					}
+					if context.output.status.succeeded != _|_ {
+						succeeded: context.output.status.succeeded
+					}
+				}
+				message: "Active/Failed/Succeeded:\(status.active)/\(status.failed)/\(status.succeeded)"
+				"""#
+			healthPolicy: #"""
+				succeeded: *0 | int
+				if context.output.status.succeeded != _|_ {
+					succeeded: context.output.status.succeeded
+				}
+				isHealth: succeeded == context.output.spec.parallelism
+				"""#
+		}
 	}
 }
 template: {

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -17,53 +17,36 @@ webservice: {
 		}
 		status: {
 			customStatus: #"""
-				import "strconv"
 				ready: {
-					if context.output.status.readyReplicas == _|_ {
-						readyReplicas: 0
-					}
-
+					readyReplicas: *0 | int
+				} & {
 					if context.output.status.readyReplicas != _|_ {
 						readyReplicas: context.output.status.readyReplicas
 					}
 				}
-
-				message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+				message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
 				"""#
 			healthPolicy: #"""
 				ready: {
-					if context.output.status.updatedReplicas == _|_  {
-						updatedReplicas : 0
+					updatedReplicas:    *0 | int
+					readyReplicas:      *0 | int
+					replicas:           *0 | int
+					observedGeneration: *0 | int
+				} & {
+					if context.output.status.updatedReplicas != _|_ {
+						updatedReplicas: context.output.status.updatedReplicas
 					}
-
-					if context.output.status.updatedReplicas != _|_  {
-						updatedReplicas : context.output.status.updatedReplicas
-					}
-
-					if context.output.status.readyReplicas == _|_ {
-						readyReplicas: 0
-					}
-
 					if context.output.status.readyReplicas != _|_ {
 						readyReplicas: context.output.status.readyReplicas
-					}
-
-					if context.output.status.replicas == _|_ {
-						replicas: 0
 					}
 					if context.output.status.replicas != _|_ {
 						replicas: context.output.status.replicas
 					}
-
 					if context.output.status.observedGeneration != _|_ {
 						observedGeneration: context.output.status.observedGeneration
 					}
-
-					if context.output.status.observedGeneration == _|_ {
-						observedGeneration: 0
-					}
 				}
-					isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+				isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
 				"""#
 		}
 	}

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -15,53 +15,36 @@ worker: {
 		}
 		status: {
 			customStatus: #"""
-				import "strconv"
 				ready: {
-					if context.output.status.readyReplicas == _|_ {
-						readyReplicas: 0
-					}
-
+					readyReplicas: *0 | int
+				} & {
 					if context.output.status.readyReplicas != _|_ {
 						readyReplicas: context.output.status.readyReplicas
 					}
 				}
-
-				message: "Ready:" + strconv.FormatInt(ready.readyReplicas, 10) + "/" + strconv.FormatInt(context.output.spec.replicas, 10)
+				message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
 				"""#
 			healthPolicy: #"""
 				ready: {
-					if context.output.status.updatedReplicas == _|_  {
-						updatedReplicas : 0
+					updatedReplicas:    *0 | int
+					readyReplicas:      *0 | int
+					replicas:           *0 | int
+					observedGeneration: *0 | int
+				} & {
+					if context.output.status.updatedReplicas != _|_ {
+						updatedReplicas: context.output.status.updatedReplicas
 					}
-
-					if context.output.status.updatedReplicas != _|_  {
-						updatedReplicas : context.output.status.updatedReplicas
-					}
-
-					if context.output.status.readyReplicas == _|_ {
-						readyReplicas: 0
-					}
-
 					if context.output.status.readyReplicas != _|_ {
 						readyReplicas: context.output.status.readyReplicas
-					}
-
-					if context.output.status.replicas == _|_ {
-						replicas: 0
 					}
 					if context.output.status.replicas != _|_ {
 						replicas: context.output.status.replicas
 					}
-
 					if context.output.status.observedGeneration != _|_ {
 						observedGeneration: context.output.status.observedGeneration
 					}
-
-					if context.output.status.observedGeneration == _|_ {
-						observedGeneration: 0
-					}
 				}
-					isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+				isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
 				"""#
 		}
 	}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR add health check and custom the status of ComponentDefinition task.
The PR also simplified the `healthPolicy` and `customStatus` of webservice and worker.

#### Application with task type component
![截屏2022-03-25 下午3 32 53](https://user-images.githubusercontent.com/29531394/160075177-75f9b69f-cd5e-49ee-9f00-d37667cde27b.png)



#### Application with worker type component
![截屏2022-03-25 下午3 31 28](https://user-images.githubusercontent.com/29531394/160075162-2c369cfe-dc94-4506-8269-23ed1627f51c.png)


#### Application with webservice type component
![截屏2022-03-25 下午3 30 49](https://user-images.githubusercontent.com/29531394/160075145-687d675b-69cd-4a9e-b274-f1adc75c39e9.png)



Fixes https://github.com/oam-dev/kubevela/issues/3474

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->