### PR TITLE
Feat: print details on workflow step error

### DIFF
--- a/pkg/workflow/hooks/data_passing.go
+++ b/pkg/workflow/hooks/data_passing.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -81,6 +82,9 @@ func Output(ctx wfContext.Context, taskValue *value.Value, step v1beta1.Workflow
 				return err
 			}
 			if err := ctx.SetVar(v, output.Name); err != nil {
+				if errv, _ := taskValue.LookupValue("output", "err"); errv != nil {
+					return fmt.Errorf("%w: %v", err, errv.CueValue())
+				}
 				return err
 			}
 		}

--- a/pkg/workflow/hooks/data_passing_test.go
+++ b/pkg/workflow/hooks/data_passing_test.go
@@ -94,6 +94,25 @@ output: score: 99
 `)
 }
 
+func TestOutputWithErr(t *testing.T) {
+	wfCtx := mockContext(t)
+	taskValue, err := value.NewValue("", nil, "")
+	require.NoError(t, err)
+	err = taskValue.FillObject("test-error", "output", "err")
+	require.NoError(t, err)
+	err = Output(wfCtx, taskValue, v1beta1.WorkflowStep{
+		Properties: &runtime.RawExtension{
+			Raw: []byte("{\"name\":\"mystep\"}"),
+		},
+		Outputs: common.StepOutputs{{
+			ValueFrom: "output.score",
+			Name:      "myscore",
+		}},
+	}, common.WorkflowStepPhaseSucceeded)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "\"test-error\"")
+}
+
 func mockContext(t *testing.T) wfContext.Context {
 	cli := &test.MockClient{
 		MockCreate: func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {


### PR DESCRIPTION
### Description of your changes

Fixes #3516

Some WorkflowStepDefinition fill error to the value instead of returning it. In this case, users may have difficulty finding what causes the failure.

This commit updates the Output hook to print a detailed error message if the value contains it.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Creating an Application that contains workflow step, which tries to read object from the restricted namespace.

<details>
<summary>app.yaml</summary>

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: read-object
  namespace: demo-service
  annotations:
    app.oam.dev/service-account-name: default
spec:
  components:
    - name: express-server
      type: webservice
      properties:
        image: crccheck/hello-world
        port: 8000
  workflow:
    steps:
      - name: read-object
        type: read-object
        outputs:
          - name: cpu
            valueFrom: output.value.data["cpu"]
          - name: memory
            valueFrom: output.value.data["memory"]
        properties:
          apiVersion: v1
          kind: ConfigMap
          name: my-cm-name
          namespace: restricted-namespace
      - name: apply
        type: apply-component
        inputs:
          - from: cpu
            parameterKey: cpu
          - from: memory
            parameterKey: memory
        properties:
          component: express-server
```
</details>

<details>
<summary>app-status.yaml</summary>

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  annotations:
    app.oam.dev/service-account-name: default
    oam.dev/kubevela-version: undefined
  creationTimestamp: "2022-03-25T16:45:39Z"
  finalizers:
    - app.oam.dev/resource-tracker-finalizer
  generation: 1
  name: read-object
  namespace: demo-service
  resourceVersion: "681855717"
  uid: 8ebb806f-b425-4060-b1c6-bfea147a665b
spec:
  components:
    - name: express-server
      properties:
        image: crccheck/hello-world
        port: 8000
      type: webservice
  workflow:
    steps:
      - name: read-object
        outputs:
          - name: cpu
            valueFrom: output.value.data["cpu"]
          - name: memory
            valueFrom: output.value.data["memory"]
        properties:
          apiVersion: v1
          kind: ConfigMap
          name: my-cm-name
          namespace: restricted-namespace
        type: read-object
      - inputs:
          - from: cpu
            parameterKey: cpu
          - from: memory
            parameterKey: memory
        name: apply
        properties:
          component: express-server
        type: apply-component
status:
  conditions:
    - lastTransitionTime: "2022-03-25T16:45:41Z"
      reason: Available
      status: "True"
      type: Parsed
    - lastTransitionTime: "2022-03-25T16:45:42Z"
      reason: Available
      status: "True"
      type: Revision
    - lastTransitionTime: "2022-03-25T16:45:42Z"
      reason: Available
      status: "True"
      type: Policy
    - lastTransitionTime: "2022-03-25T16:45:42Z"
      reason: Available
      status: "True"
      type: Render
  latestRevision:
    name: read-object-v1
    revision: 1
    revisionHash: b0f61900f80181c7
  observedGeneration: 1
  status: runningWorkflow
  workflow:
    appRevision: read-object-v1:b6b5bd2fc231bf0e
    contextBackend:
      name: workflow-read-object-context
      uid: 555b92d0-7950-447a-ac50-67ca4131922e
    finished: false
    message: executing
    mode: StepByStep
    startTime: "2022-03-25T16:45:42Z"
    steps:
      - firstExecuteTime: "2022-03-25T16:45:43Z"
        id: ochb8pged1
        lastExecuteTime: "2022-03-25T16:45:45Z"
        message:
          'from source: "configmaps \"my-cm-name\" is forbidden: User \"system:serviceaccount:demo-service:default\"
          cannot get resource \"configmaps\" in API group \"\" in the namespace \"restricted-namespace\""'
        name: read-object
        phase: failed
        reason: Output
        type: read-object
    suspend: false
    terminated: false
```
</details>

### Special notes for your reviewer

- I'm not sure if the `output.err` is reserved field or not. 🤔 I think it's okay to lookup the `output.err` as fallback by default (for now).
- Could somebody share the information about why the [`Apply`](https://github.com/oam-dev/kubevela/blob/c2f5175fd1ecd435d1ae340ab2e4bfc5269a5524/pkg/workflow/providers/kube/handle.go#L93-L96) in Kubernetes handler returns the error instead of filling the object, unlike the others?