### PR TITLE
Feat: support ref-objects in live-diff

### DIFF
--- a/pkg/appfile/dryrun/diff.go
+++ b/pkg/appfile/dryrun/diff.go
@@ -146,9 +146,19 @@ func (l *LiveDiffOption) RenderlessDiff(ctx context.Context, base, comparor Live
 		}
 		if af.ExternalWorkflow != nil {
 			if bs, err = marshalObject(af.ExternalWorkflow); err == nil {
-				m.Subs = append(m.Subs, &manifest{Name: af.Name, Kind: WorkflowKind, Data: string(bs)})
+				m.Subs = append(m.Subs, &manifest{Name: af.ExternalWorkflow.Name, Kind: WorkflowKind, Data: string(bs)})
 			} else {
-				m.Subs = append(m.Subs, &manifest{Name: af.Name, Kind: WorkflowKind, Data: "Error: " + errors.Wrapf(err, "failed to marshal external workflow %s", af.ExternalWorkflow.Name).Error()})
+				m.Subs = append(m.Subs, &manifest{Name: af.ExternalWorkflow.Name, Kind: WorkflowKind, Data: "Error: " + errors.Wrapf(err, "failed to marshal external workflow %s", af.ExternalWorkflow.Name).Error()})
+			}
+		}
+		if af.ReferredObjects != nil {
+			for _, refObj := range af.ReferredObjects {
+				manifestName := fmt.Sprintf("%s %s %s", refObj.GetAPIVersion(), refObj.GetKind(), client.ObjectKeyFromObject(refObj).String())
+				if bs, err = marshalObject(refObj); err == nil {
+					m.Subs = append(m.Subs, &manifest{Name: manifestName, Kind: ReferredObject, Data: string(bs)})
+				} else {
+					m.Subs = append(m.Subs, &manifest{Name: manifestName, Kind: ReferredObject, Data: "Error: " + errors.Wrapf(err, "failed to marshal referred object").Error()})
+				}
 			}
 		}
 		return m, nil

--- a/pkg/appfile/dryrun/diff_test.go
+++ b/pkg/appfile/dryrun/diff_test.go
@@ -197,20 +197,27 @@ var _ = Describe("Test Live-Diff", func() {
 		applyFile("td-myscaler.yaml", "vela-system")
 		applyFile("cd-myworker.yaml", "vela-system")
 		applyFile("wd-deploy.yaml", "vela-system")
+		applyFile("wd-ref-objects.yaml", "vela-system")
 		Expect(runDiff()).Should(ContainSubstring("\"deploy-livediff-demo\" not found"))
 		applyFile("external-workflow.yaml", "default")
 		Expect(runDiff()).Should(ContainSubstring("topology-local not found"))
 		applyFile("external-policy.yaml", "default")
+		Expect(runDiff()).Should(ContainSubstring("deployments.apps \"livediff-demo\" not found"))
+		applyFile("livediff-demo-deploy.yaml", "default")
+		e := runDiff()
+		_ = e
 		Expect(runDiff()).Should(SatisfyAll(
 			ContainSubstring("Application (livediff-demo) has been modified(*)"),
 			ContainSubstring("External Policy (topology-local) has been added(+)"),
-			ContainSubstring("External Workflow (livediff-demo) has been added(+)"),
+			ContainSubstring("External Workflow (deploy-livediff-demo) has been added(+)"),
+			ContainSubstring("Referred Object (apps/v1 Deployment default/livediff-demo) has been added(+)"),
 		))
 		reverse = true
 		Expect(runDiff()).Should(SatisfyAll(
 			ContainSubstring("Application (livediff-demo) has been modified(*)"),
 			ContainSubstring("External Policy (topology-local) has been removed(-)"),
-			ContainSubstring("External Workflow (livediff-demo) has been removed(-)"),
+			ContainSubstring("External Workflow (deploy-livediff-demo) has been removed(-)"),
+			ContainSubstring("Referred Object (apps/v1 Deployment default/livediff-demo) has been removed(-)"),
 		))
 	})
 

--- a/pkg/appfile/dryrun/testdata/diff-input-app-with-externals.yaml
+++ b/pkg/appfile/dryrun/testdata/diff-input-app-with-externals.yaml
@@ -23,14 +23,10 @@ spec:
         - type: myscaler
           properties:
             replicas: 2
-    - name: myweb-3
-      type: myworker
+    - name: livediff-demo
+      type: ref-objects
       properties:
-        image: "busybox"
-        cmd:
-          - sleep
-          - "1000"
-        lives: "3"
-        enemies: "alien"
+        objects:
+          - resource: deployment
   workflow:
     ref: deploy-livediff-demo

--- a/pkg/appfile/dryrun/testdata/livediff-demo-deploy.yaml
+++ b/pkg/appfile/dryrun/testdata/livediff-demo-deploy.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: livediff-demo
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: livediff-demo
+  template:
+    metadata:
+      labels:
+        app: livediff-demo
+    spec:
+      containers:
+        - image: busybox
+          name: livediff-demo

--- a/pkg/appfile/dryrun/testdata/wd-ref-objects.yaml
+++ b/pkg/appfile/dryrun/testdata/wd-ref-objects.yaml
@@ -1,0 +1,31 @@
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  annotations:
+    definition.oam.dev/description: Ref-objects allow users to specify ref objects to use. Notice that this component type have special handle logic.
+  name: ref-objects
+spec:
+  schematic:
+    cue:
+      template: |
+        #K8sObject: {
+        	apiVersion: string
+        	kind:       string
+        	metadata: {
+        		name: string
+        		...
+        	}
+        	...
+        }
+        output: parameter.objects[0]
+        outputs: {
+        	for i, v in parameter.objects {
+        		if i > 0 {
+        			"objects-\(i)": v
+        		}
+        	}
+        }
+        parameter: objects: [...#K8sObject]
+  workload:
+    type: autodetects.core.oam.dev
+

--- a/pkg/appfile/parser.go
+++ b/pkg/appfile/parser.go
@@ -310,7 +310,7 @@ func (p *Parser) parseReferredObjectsFromRevision(af *Appfile) error {
 func (p *Parser) parseReferredObjects(ctx context.Context, af *Appfile) error {
 	for _, comp := range af.Components {
 		if comp.Type != v1alpha1.RefObjectsComponentType {
-			return nil
+			continue
 		}
 		spec := &v1alpha1.RefObjectsComponentSpec{}
 		if err := utils.StrictUnmarshal(comp.Properties.Raw, spec); err != nil {

--- a/test/e2e-multicluster-test/testdata/app/standalone/app-with-publish-version-busybox.yaml
+++ b/test/e2e-multicluster-test/testdata/app/standalone/app-with-publish-version-busybox.yaml
@@ -11,5 +11,10 @@ spec:
       properties:
         image: busybox
         cmd: [ "sleep", "86400" ]
+    - name: busybox-ref
+      type: ref-objects
+      properties:
+        objects:
+          - resource: deployment
   workflow:
     ref: deploy-worker

--- a/test/e2e-multicluster-test/testdata/app/standalone/deployment-busybox.yaml
+++ b/test/e2e-multicluster-test/testdata/app/standalone/deployment-busybox.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-ref
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+        - image: busybox
+          name: busybox


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

`vela live-diff` command now can show the changes in the referred objects.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

This PR should be accepted after #3446.