### PR TITLE
Fix: fix migrate data duplicate in list API and add cluster info in addon status

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -235,6 +235,19 @@
 					{
 						"type": "string",
 						"description": "addon name to query detail",
+						"name": "name",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "specify addon version to enable",
+						"name": "version",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"description": "addon name to query detail",
 						"name": "addonName",
 						"in": "path",
 						"required": true
@@ -5280,6 +5293,13 @@
 				}
 			}
 		},
+		"addon.HelmSource": {
+			"properties": {
+				"url": {
+					"type": "string"
+				}
+			}
+		},
 		"addon.Meta": {
 			"required": [
 				"name",
@@ -6958,6 +6978,9 @@
 				"gitee": {
 					"$ref": "#/definitions/addon.GiteeAddonSource"
 				},
+				"helm": {
+					"$ref": "#/definitions/addon.HelmSource"
+				},
 				"name": {
 					"type": "string"
 				},
@@ -6973,6 +6996,12 @@
 				"args"
 			],
 			"properties": {
+				"allClusters": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/v1.NameAlias"
+					}
+				},
 				"appStatus": {
 					"$ref": "#/definitions/common.AppStatus"
 				},
@@ -6987,6 +7016,9 @@
 				},
 				"enabling_progress": {
 					"$ref": "#/definitions/v1.EnablingProgress"
+				},
+				"installedVersion": {
+					"type": "string"
 				},
 				"name": {
 					"type": "string"
@@ -7116,12 +7148,12 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
+				"createTime",
 				"version",
+				"note",
 				"status",
 				"envName",
-				"triggerType",
-				"createTime",
-				"note"
+				"triggerType"
 			],
 			"properties": {
 				"codeInfo": {
@@ -7704,6 +7736,9 @@
 				"gitee": {
 					"$ref": "#/definitions/addon.GiteeAddonSource"
 				},
+				"helm": {
+					"$ref": "#/definitions/addon.HelmSource"
+				},
 				"name": {
 					"type": "string"
 				},
@@ -8208,16 +8243,23 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"version",
-				"description",
+				"name",
 				"icon",
 				"invisible",
-				"name",
+				"version",
+				"description",
 				"schema",
 				"uiSchema",
-				"definitions"
+				"definitions",
+				"availableVersions"
 			],
 			"properties": {
+				"availableVersions": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"definitions": {
 					"type": "array",
 					"items": {
@@ -8285,12 +8327,12 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
-				"name",
 				"alias",
-				"project",
-				"createTime",
-				"updateTime",
 				"description",
+				"createTime",
+				"name",
+				"project",
+				"updateTime",
 				"icon",
 				"policies",
 				"envBindings",
@@ -8352,20 +8394,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"status",
+				"updateTime",
 				"kubeConfig",
-				"createTime",
-				"labels",
+				"name",
+				"icon",
 				"reason",
 				"provider",
-				"kubeConfigSecret",
-				"icon",
-				"name",
-				"alias",
-				"description",
 				"apiServerURL",
 				"dashboardURL",
-				"updateTime",
+				"createTime",
+				"alias",
+				"description",
+				"labels",
+				"status",
+				"kubeConfigSecret",
 				"resourceInfo"
 			],
 			"properties": {
@@ -8423,14 +8465,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
-				"appPrimaryKey",
-				"main",
-				"creator",
-				"name",
-				"type",
-				"createTime",
 				"updateTime",
+				"appPrimaryKey",
+				"creator",
 				"alias",
+				"name",
+				"main",
+				"createTime",
+				"type",
 				"definition"
 			],
 			"properties": {
@@ -8568,17 +8610,17 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
+				"envName",
 				"reason",
 				"deployUser",
-				"workflowName",
-				"createTime",
 				"updateTime",
-				"appPrimaryKey",
-				"version",
 				"status",
 				"note",
 				"triggerType",
-				"envName"
+				"workflowName",
+				"createTime",
+				"appPrimaryKey",
+				"version"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -8632,10 +8674,10 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
+				"name",
 				"createTime",
-				"updateTime",
 				"project",
-				"name"
+				"updateTime"
 			],
 			"properties": {
 				"alias": {
@@ -8675,11 +8717,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
-				"createTime",
-				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
+				"createTime",
+				"lastLoginTime",
 				"projects",
 				"roles"
 			],
@@ -8777,13 +8819,13 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"name",
+				"description",
 				"enable",
-				"default",
 				"createTime",
 				"updateTime",
+				"name",
 				"alias",
-				"description",
+				"default",
 				"envName"
 			],
 			"properties": {
@@ -8854,6 +8896,9 @@
 					"items": {
 						"type": "string"
 					}
+				},
+				"version": {
+					"type": "string"
 				}
 			}
 		},
@@ -9360,11 +9405,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
+				"name",
+				"email",
 				"disabled",
 				"createTime",
 				"lastLoginTime",
-				"name",
-				"email",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"
@@ -9688,11 +9733,11 @@
 		},
 		"v1.SystemInfoResponse": {
 			"required": [
+				"createTime",
 				"updateTime",
 				"installID",
 				"enableCollection",
 				"loginType",
-				"createTime",
 				"systemVersion"
 			],
 			"properties": {
@@ -9782,6 +9827,9 @@
 				},
 				"gitee": {
 					"$ref": "#/definitions/addon.GiteeAddonSource"
+				},
+				"helm": {
+					"$ref": "#/definitions/addon.HelmSource"
 				},
 				"oss": {
 					"$ref": "#/definitions/addon.OSSAddonSource"

--- a/pkg/apiserver/datastore/kubeapi/kubeapi.go
+++ b/pkg/apiserver/datastore/kubeapi/kubeapi.go
@@ -330,7 +330,7 @@ func _filterConfigMapByFuzzyQueryOptions(items []corev1.ConfigMap, queries []dat
 	return _items
 }
 
-// TableName() can't return zero value.
+// List will list all database records by select labels according to table name
 func (m *kubeapi) List(ctx context.Context, entity datastore.Entity, op *datastore.ListOptions) ([]datastore.Entity, error) {
 	if entity.TableName() == "" {
 		return nil, datastore.ErrTableNameEmpty
@@ -340,6 +340,10 @@ func (m *kubeapi) List(ctx context.Context, entity datastore.Entity, op *datasto
 	if err != nil {
 		return nil, datastore.NewDBError(err)
 	}
+
+	rq, _ := labels.NewRequirement(MigrateKey, selection.DoesNotExist, []string{"ok"})
+	selector = selector.Add(*rq)
+
 	for k, v := range entity.Index() {
 		rq, err := labels.NewRequirement(k, selection.Equals, []string{v})
 		if err != nil {

--- a/pkg/apiserver/datastore/kubeapi/migrate_test.go
+++ b/pkg/apiserver/datastore/kubeapi/migrate_test.go
@@ -1,0 +1,60 @@
+/*
+ Copyright 2022 The KubeVela Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ 	http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package kubeapi
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/pkg/apiserver/clients"
+	"github.com/oam-dev/kubevela/pkg/apiserver/model"
+)
+
+var _ = Describe("Test Migrate", func() {
+
+	It("Test migrate labels", func() {
+		clients.SetKubeClient(k8sClient)
+
+		nsName := "test-migrate"
+		ds := &kubeapi{kubeclient: k8sClient, namespace: nsName}
+		ns := &v1.Namespace{}
+		ns.Name = nsName
+		Expect(k8sClient.Create(context.Background(), ns)).Should(BeNil())
+		entity := &model.Application{Name: "my-app"}
+		cm := ds.generateConfigMap(entity)
+		name := fmt.Sprintf("veladatabase-%s-%s", entity.TableName(), entity.PrimaryKey())
+		cm.Name = strings.ReplaceAll(name, "_", "-")
+		cm.Namespace = nsName
+		Expect(ds.kubeclient.Create(context.Background(), cm)).Should(BeNil())
+
+		migrate(nsName)
+		cmList := v1.ConfigMapList{}
+		Expect(k8sClient.List(context.Background(), &cmList, client.InNamespace(nsName))).Should(BeNil())
+		Expect(len(cmList.Items)).Should(BeEquivalentTo(2))
+
+		es, err := ds.List(context.Background(), &model.Application{}, nil)
+		Expect(err).Should(BeNil())
+		Expect(len(es)).Should(BeEquivalentTo(1))
+	})
+
+})

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -166,9 +166,11 @@ type AddonStatusResponse struct {
 	Args             map[string]interface{} `json:"args"`
 	EnablingProgress *EnablingProgress      `json:"enabling_progress,omitempty"`
 	AppStatus        common.AppStatus       `json:"appStatus,omitempty"`
+	InstalledVersion string                 `json:"installedVersion,omitempty"`
+
 	// the status of multiple clusters
-	Clusters         map[string]map[string]interface{} `json:"clusters,omitempty"`
-	InstalledVersion string                            `json:"installedVersion,omitempty"`
+	Clusters    map[string]map[string]interface{} `json:"clusters,omitempty"`
+	AllClusters []NameAlias                       `json:"allClusters,omitempty"`
 }
 
 // EnablingProgress defines the progress of enabling an addon

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -44,6 +44,7 @@ import (
 	apis "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils/apply"
 	velaerr "github.com/oam-dev/kubevela/pkg/utils/errors"
@@ -191,6 +192,15 @@ func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*ap
 		}, nil
 	}
 
+	var allClusters []apis.NameAlias
+	clusers, err := multicluster.ListVirtualClusters(ctx, u.kubeClient)
+	if err != nil {
+		log.Logger.Errorf("err while list all clusters: %v", err)
+	}
+
+	for _, c := range clusers {
+		allClusters = append(allClusters, apis.NameAlias{Name: c.Name, Alias: c.Name})
+	}
 	res := apis.AddonStatusResponse{
 		AddonBaseStatus: apis.AddonBaseStatus{
 			Name:  name,
@@ -199,6 +209,7 @@ func (u *defaultAddonHandler) StatusAddon(ctx context.Context, name string) (*ap
 		InstalledVersion: status.InstalledVersion,
 		AppStatus:        *status.AppStatus,
 		Clusters:         status.Clusters,
+		AllClusters:      allClusters,
 	}
 
 	if res.Phase != apis.AddonPhaseEnabled {

--- a/pkg/apiserver/rest/webservice/webservice.go
+++ b/pkg/apiserver/rest/webservice/webservice.go
@@ -91,7 +91,7 @@ func Init(ctx context.Context, ds datastore.DataStore, addonCacheTime time.Durat
 
 	// Extension
 	RegisterWebService(NewDefinitionWebservice(definitionUsecase, rbacUsecase))
-	RegisterWebService(NewAddonWebService(addonUsecase, rbacUsecase))
+	RegisterWebService(NewAddonWebService(addonUsecase, rbacUsecase, clusterUsecase))
 	RegisterWebService(NewEnabledAddonWebService(addonUsecase, rbacUsecase))
 	RegisterWebService(NewAddonRegistryWebService(addonUsecase, rbacUsecase))
 


### PR DESCRIPTION
### Description of your changes

1. fix migrate data duplicate in list API , change migrate key to "db.oam.dev/migrated", so the clean up command changed to:
    ```
     kubectl -n kubevela delete cm -l db.oam.dev/migrated=ok
   ```

2. add cluster info in addon status

```
GET  /addons/{addonName}/status

{
  "clusters":{
      "cluster-name1":{},
      "cluster-name2":{}
   },
   "allClusters": [{ "name": "cluster-name1", "alias":"my-clustername"},{"name":"cluster-name2","alias":"cluster-name2"}]
}

```

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->