### PR TITLE
Fix: enhance ref object to support health check for deployment

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/ref-objects.yaml
+++ b/charts/vela-core/templates/defwithtemplate/ref-objects.yaml
@@ -29,6 +29,47 @@ spec:
         	}
         }
         parameter: objects: [...#K8sObject]
+  status:
+    customStatus: |-
+      if context.output.apiVersion == "apps/v1" && context.output.kind == "Deployment" {
+      	ready: {
+      		readyReplicas: *0 | int
+      	} & {
+      		if context.output.status.readyReplicas != _|_ {
+      			readyReplicas: context.output.status.readyReplicas
+      		}
+      	}
+      	message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
+      }
+      if context.output.apiVersion != "apps/v1" || context.output.kind != "Deployment" {
+      	message: ""
+      }
+    healthPolicy: |-
+      if context.output.apiVersion == "apps/v1" && context.output.kind == "Deployment" {
+      	ready: {
+      		updatedReplicas:    *0 | int
+      		readyReplicas:      *0 | int
+      		replicas:           *0 | int
+      		observedGeneration: *0 | int
+      	} & {
+      		if context.output.status.updatedReplicas != _|_ {
+      			updatedReplicas: context.output.status.updatedReplicas
+      		}
+      		if context.output.status.readyReplicas != _|_ {
+      			readyReplicas: context.output.status.readyReplicas
+      		}
+      		if context.output.status.replicas != _|_ {
+      			replicas: context.output.status.replicas
+      		}
+      		if context.output.status.observedGeneration != _|_ {
+      			observedGeneration: context.output.status.observedGeneration
+      		}
+      	}
+      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+      }
+      if context.output.apiVersion != "apps/v1" || context.output.kind != "Deployment" {
+      	isHealth: true
+      }
   workload:
     type: autodetects.core.oam.dev
 

--- a/charts/vela-minimal/templates/defwithtemplate/ref-objects.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/ref-objects.yaml
@@ -29,6 +29,47 @@ spec:
         	}
         }
         parameter: objects: [...#K8sObject]
+  status:
+    customStatus: |-
+      if context.output.apiVersion == "apps/v1" && context.output.kind == "Deployment" {
+      	ready: {
+      		readyReplicas: *0 | int
+      	} & {
+      		if context.output.status.readyReplicas != _|_ {
+      			readyReplicas: context.output.status.readyReplicas
+      		}
+      	}
+      	message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
+      }
+      if context.output.apiVersion != "apps/v1" || context.output.kind != "Deployment" {
+      	message: ""
+      }
+    healthPolicy: |-
+      if context.output.apiVersion == "apps/v1" && context.output.kind == "Deployment" {
+      	ready: {
+      		updatedReplicas:    *0 | int
+      		readyReplicas:      *0 | int
+      		replicas:           *0 | int
+      		observedGeneration: *0 | int
+      	} & {
+      		if context.output.status.updatedReplicas != _|_ {
+      			updatedReplicas: context.output.status.updatedReplicas
+      		}
+      		if context.output.status.readyReplicas != _|_ {
+      			readyReplicas: context.output.status.readyReplicas
+      		}
+      		if context.output.status.replicas != _|_ {
+      			replicas: context.output.status.replicas
+      		}
+      		if context.output.status.observedGeneration != _|_ {
+      			observedGeneration: context.output.status.observedGeneration
+      		}
+      	}
+      	isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+      }
+      if context.output.apiVersion != "apps/v1" || context.output.kind != "Deployment" {
+      	isHealth: true
+      }
   workload:
     type: autodetects.core.oam.dev
 

--- a/vela-templates/definitions/internal/component/ref-objects.cue
+++ b/vela-templates/definitions/internal/component/ref-objects.cue
@@ -3,7 +3,53 @@
 	annotations: {}
 	labels: {}
 	description: "Ref-objects allow users to specify ref objects to use. Notice that this component type have special handle logic."
-	attributes: workload: type: "autodetects.core.oam.dev"
+	attributes: {
+		workload: type: "autodetects.core.oam.dev"
+		status: {
+			customStatus: #"""
+				if context.output.apiVersion == "apps/v1" && context.output.kind == "Deployment" {
+					ready: {
+						readyReplicas: *0 | int
+					} & {
+						if context.output.status.readyReplicas != _|_ {
+							readyReplicas: context.output.status.readyReplicas
+						}
+					}
+					message: "Ready:\(ready.readyReplicas)/\(context.output.spec.replicas)"
+				}
+				if context.output.apiVersion != "apps/v1" || context.output.kind != "Deployment" {
+					message: ""
+				}
+				"""#
+			healthPolicy: #"""
+				if context.output.apiVersion == "apps/v1" && context.output.kind == "Deployment" {
+					ready: {
+						updatedReplicas:    *0 | int
+						readyReplicas:      *0 | int
+						replicas:           *0 | int
+						observedGeneration: *0 | int
+					} & {
+						if context.output.status.updatedReplicas != _|_ {
+							updatedReplicas: context.output.status.updatedReplicas
+						}
+						if context.output.status.readyReplicas != _|_ {
+							readyReplicas: context.output.status.readyReplicas
+						}
+						if context.output.status.replicas != _|_ {
+							replicas: context.output.status.replicas
+						}
+						if context.output.status.observedGeneration != _|_ {
+							observedGeneration: context.output.status.observedGeneration
+						}
+					}
+					isHealth: (context.output.spec.replicas == ready.readyReplicas) && (context.output.spec.replicas == ready.updatedReplicas) && (context.output.spec.replicas == ready.replicas) && (ready.observedGeneration == context.output.metadata.generation || ready.observedGeneration > context.output.metadata.generation)
+				}
+				if context.output.apiVersion != "apps/v1" || context.output.kind != "Deployment" {
+					isHealth: true
+				}
+				"""#
+		}
+	}
 }
 template: {
 	#K8sObject: {


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Enhance ref-objects typed component by adding healthPolicy and message. If the main workload in the ref-objects typed component is Deployment, the application will wait and show the replica number of the dispatched deployment.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->