### PR TITLE
Feat: enhance storage trait to support multi-mountToEnv config

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -77,12 +77,12 @@ spec:
         	},
         ] | []
         configMapEnvMountsList: *[
-        			for v in parameter.configMap if v.mountToEnv != _|_ {
+        			for v in parameter.configMap if v.mountToEnv != _|_ for k in v.mountToEnv {
         		{
-        			name: v.mountToEnv.envName
+        			name: k.envName
         			valueFrom: configMapKeyRef: {
         				name: v.name
-        				key:  v.mountToEnv.configMapKey
+        				key:  k.configMapKey
         			}
         		}
         	},
@@ -96,12 +96,12 @@ spec:
         	},
         ] | []
         secretEnvMountsList: *[
-        			for v in parameter.secret if v.mountToEnv != _|_ {
+        			for v in parameter.secret if v.mountToEnv != _|_ for k in v.mountToEnv {
         		{
-        			name: v.mountToEnv.envName
+        			name: k.envName
         			valueFrom: secretKeyRef: {
         				name: v.name
-        				key:  v.mountToEnv.secretKey
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -244,10 +244,10 @@ spec:
         	configMap?: [...{
         		name:      string
         		mountOnly: *false | bool
-        		mountToEnv?: {
+        		mountToEnv?: [...{
         			envName:      string
         			configMapKey: string
-        		}
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -263,10 +263,10 @@ spec:
         	secret?: [...{
         		name:      string
         		mountOnly: *false | bool
-        		mountToEnv?: {
+        		mountToEnv?: [...{
         			envName:   string
         			secretKey: string
-        		}
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -77,12 +77,12 @@ spec:
         	},
         ] | []
         configMapEnvMountsList: *[
-        			for v in parameter.configMap if v.mountToEnv != _|_ {
+        			for v in parameter.configMap if v.mountToEnv != _|_ for k in v.mountToEnv {
         		{
-        			name: v.mountToEnv.envName
+        			name: k.envName
         			valueFrom: configMapKeyRef: {
         				name: v.name
-        				key:  v.mountToEnv.configMapKey
+        				key:  k.configMapKey
         			}
         		}
         	},
@@ -96,12 +96,12 @@ spec:
         	},
         ] | []
         secretEnvMountsList: *[
-        			for v in parameter.secret if v.mountToEnv != _|_ {
+        			for v in parameter.secret if v.mountToEnv != _|_ for k in v.mountToEnv {
         		{
-        			name: v.mountToEnv.envName
+        			name: k.envName
         			valueFrom: secretKeyRef: {
         				name: v.name
-        				key:  v.mountToEnv.secretKey
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -244,10 +244,10 @@ spec:
         	configMap?: [...{
         		name:      string
         		mountOnly: *false | bool
-        		mountToEnv?: {
+        		mountToEnv?: [...{
         			envName:      string
         			configMapKey: string
-        		}
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -263,10 +263,10 @@ spec:
         	secret?: [...{
         		name:      string
         		mountOnly: *false | bool
-        		mountToEnv?: {
+        		mountToEnv?: [...{
         			envName:   string
         			secretKey: string
-        		}
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -284,11 +284,41 @@ var _ = Describe("Test Application Controller", func() {
 	appWithMountPath.Spec.Components[0].Traits = []common.ApplicationTrait{
 		{
 			Type:       "storage",
-			Properties: &runtime.RawExtension{Raw: []byte("{\"secret\":[{\"name\":\"myworker-secret\",\"mountToEnv\":{\"envName\":\"firstEnv\",\"secretKey\":\"firstKey\"},\"data\":{\"firstKey\":\"dmFsdWUwMQo=\"}}]}")},
+			Properties: &runtime.RawExtension{Raw: []byte("{\"secret\":[{\"name\":\"myworker-secret\",\"mountToEnv\":[{\"envName\":\"firstEnv\",\"secretKey\":\"firstKey\"}],\"data\":{\"firstKey\":\"dmFsdWUwMQo=\"}}]}")},
 		},
 		{
 			Type:       "storage",
-			Properties: &runtime.RawExtension{Raw: []byte("{\"configMap\":[{\"name\": \"myworker-cm\",\"mountToEnv\":{ \"envName\":\"secondEnv\",\"configMapKey\":\"secondKey\"},\"data\": {\"secondKey\":\"secondValue\"}}]}")},
+			Properties: &runtime.RawExtension{Raw: []byte("{\"configMap\":[{\"name\": \"myworker-cm\",\"mountToEnv\":[{ \"envName\":\"secondEnv\",\"configMapKey\":\"secondKey\"}],\"data\": {\"secondKey\":\"secondValue\"}}]}")},
+		},
+	}
+
+	appWithMountToEnv := &v1beta1.Application{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Application",
+			APIVersion: "core.oam.dev/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-with-mount-to-env",
+		},
+		Spec: v1beta1.ApplicationSpec{
+			Components: []common.ApplicationComponent{
+				{
+					Name:       "myweb",
+					Type:       "worker",
+					Properties: &runtime.RawExtension{Raw: []byte("{\"cmd\":[\"sleep\",\"1000\"],\"image\":\"busybox\"}")},
+				},
+			},
+		},
+	}
+
+	appWithMountToEnv.Spec.Components[0].Traits = []common.ApplicationTrait{
+		{
+			Type:       "storage",
+			Properties: &runtime.RawExtension{Raw: []byte("{\"secret\": [{\"name\": \"myweb-secret\",\"mountToEnv\": [{\"envName\": \"firstEnv\",\"secretKey\": \"firstKey\"},{\"envName\": \"secondEnv\",\"secretKey\": \"secondKey\"}],\"data\": {\"firstKey\": \"dmFsdWUwMQo=\",\"secondKey\": \"dmFsdWUwMgo=\"}}]}")},
+		},
+		{
+			Type:       "storage",
+			Properties: &runtime.RawExtension{Raw: []byte("{\"configMap\": [{\"name\": \"myweb-cm\",\"mountToEnv\": [{\"envName\":\"thirdEnv\",\"configMapKey\":\"thirdKey\"},{\"envName\":\"fourthEnv\",\"configMapKey\":\"fourthKey\"}],\"data\": {\"thirdKey\": \"Value03\",\"fourthKey\": \"Value04\"}}]}")},
 		},
 	}
 
@@ -2568,6 +2598,67 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Delete(ctx, secret)).Should(BeNil())
 		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
 	})
+
+	It("test application with multi-mountToEnv will create application", func() {
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-mount-to-env",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(BeNil())
+
+		appWithMountToEnv.SetNamespace(ns.Name)
+		app := appWithMountToEnv.DeepCopy()
+		Expect(k8sClient.Create(ctx, app)).Should(BeNil())
+
+		appKey := client.ObjectKey{
+			Name:      app.Name,
+			Namespace: app.Namespace,
+		}
+		testutil.ReconcileOnceAfterFinalizer(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		By("Check App running successfully")
+		curApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, curApp)).Should(BeNil())
+		Expect(curApp.Status.Phase).Should(Equal(common.ApplicationRunning))
+
+		appRevision := &v1beta1.ApplicationRevision{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: app.Namespace,
+			Name:      curApp.Status.LatestRevision.Name,
+		}, appRevision)).Should(BeNil())
+
+		By("Check affiliated resource tracker is created")
+		expectRTName := fmt.Sprintf("%s-%s", appRevision.GetName(), appRevision.GetNamespace())
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Name: expectRTName}, &v1beta1.ResourceTracker{})
+		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+		By("Check AppRevision Created with the expected workload spec")
+		appRev := &v1beta1.ApplicationRevision{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Name: app.Name + "-v1", Namespace: app.GetNamespace()}, appRev)
+		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+		By("Check secret Created with the expected trait-storage spec")
+		secret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      app.Spec.Components[0].Name + "-secret",
+		}, secret)).Should(BeNil())
+
+		By("Check configMap Created with the expected trait-storage spec")
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      app.Spec.Components[0].Name + "-cm",
+		}, cm)).Should(BeNil())
+
+		Expect(k8sClient.Delete(ctx, cm)).Should(BeNil())
+		Expect(k8sClient.Delete(ctx, secret)).Should(BeNil())
+		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
+	})
 })
 
 const (
@@ -3594,12 +3685,12 @@ spec:
         	},
         ] | []
         configMapEnvMountsList: *[
-        			for v in parameter.configMap if v.mountToEnv != _|_ {
+        			for v in parameter.configMap if v.mountToEnv != _|_ for k in v.mountToEnv {
         		{
-        			name: v.mountToEnv.envName
+        			name: k.envName
         			valueFrom: configMapKeyRef: {
         				name: v.name
-        				key:  v.mountToEnv.configMapKey
+        				key:  k.configMapKey
         			}
         		}
         	},
@@ -3613,12 +3704,12 @@ spec:
         	},
         ] | []
         secretEnvMountsList: *[
-        			for v in parameter.secret if v.mountToEnv != _|_ {
+        			for v in parameter.secret if v.mountToEnv != _|_ for k in v.mountToEnv {
         		{
-        			name: v.mountToEnv.envName
+        			name: k.envName
         			valueFrom: secretKeyRef: {
         				name: v.name
-        				key:  v.mountToEnv.secretKey
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -3761,10 +3852,10 @@ spec:
         	configMap?: [...{
         		name:      string
         		mountOnly: *false | bool
-        		mountToEnv?: {
+        		mountToEnv?: [...{
         			envName:      string
         			configMapKey: string
-        		}
+        		}]
         		mountPath?:   string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -3780,10 +3871,10 @@ spec:
         	secret?: [...{
         		name:      string
         		mountOnly: *false | bool
-        		mountToEnv?: {
+        		mountToEnv?: [...{
         			envName:   string
         			secretKey: string
-        		}
+        		}]
         		mountPath?:   string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -80,12 +80,12 @@ template: {
 	] | []
 
 	configMapEnvMountsList: *[
-				for v in parameter.configMap if v.mountToEnv != _|_ {
+				for v in parameter.configMap if v.mountToEnv != _|_ for k in v.mountToEnv {
 			{
-				name: v.mountToEnv.envName
+				name: k.envName
 				valueFrom: configMapKeyRef: {
 					name: v.name
-					key:  v.mountToEnv.configMapKey
+					key:  k.configMapKey
 				}
 			}
 		},
@@ -101,12 +101,12 @@ template: {
 	] | []
 
 	secretEnvMountsList: *[
-				for v in parameter.secret if v.mountToEnv != _|_ {
+				for v in parameter.secret if v.mountToEnv != _|_ for k in v.mountToEnv {
 			{
-				name: v.mountToEnv.envName
+				name: k.envName
 				valueFrom: secretKeyRef: {
 					name: v.name
-					key:  v.mountToEnv.secretKey
+					key:  k.secretKey
 				}
 			}
 		},
@@ -256,10 +256,10 @@ template: {
 		configMap?: [...{
 			name:      string
 			mountOnly: *false | bool
-			mountToEnv?: {
+			mountToEnv?: [...{
 				envName:      string
 				configMapKey: string
-			}
+			}]
 			mountPath?:  string
 			defaultMode: *420 | int
 			readOnly:    *false | bool
@@ -275,10 +275,10 @@ template: {
 		secret?: [...{
 			name:      string
 			mountOnly: *false | bool
-			mountToEnv?: {
+			mountToEnv?: [...{
 				envName:   string
 				secretKey: string
-			}
+			}]
 			mountPath?:  string
 			defaultMode: *420 | int
 			readOnly:    *false | bool


### PR DESCRIPTION
Signed-off-by: Shijie Zhong <zhongsjie@cmbchina.com>


### Description of your changes
Support the multi-mountToEnv parameter of storage trait in secret and configmap. By this feature, we can mount multi-env in container env, without creating multi-secret or multi-configmap resrouces
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->