### PR TITLE
Feat: support with metadata as context render cue file in the addon

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -567,7 +567,7 @@ func renderResources(addon *InstallPackage, args map[string]interface{}) ([]comm
 	}
 
 	for _, tmpl := range addon.CUETemplates {
-		comp, err := renderCUETemplate(tmpl, addon.Parameters, args)
+		comp, err := renderCUETemplate(tmpl, addon.Parameters, args, addon.Meta)
 		if err != nil {
 			return nil, NewAddonError(fmt.Sprintf("fail to render cue template %s", err.Error()))
 		}
@@ -932,17 +932,28 @@ func renderSchemaConfigmap(elem ElementFile) (*unstructured.Unstructured, error)
 }
 
 // renderCUETemplate will return a component from cue template
-func renderCUETemplate(elem ElementFile, parameters string, args map[string]interface{}) (*common2.ApplicationComponent, error) {
+func renderCUETemplate(elem ElementFile, parameters string, args map[string]interface{}, metadata Meta) (*common2.ApplicationComponent, error) {
 	bt, err := json.Marshal(args)
 	if err != nil {
 		return nil, err
 	}
+	var contextFile = strings.Builder{}
 	var paramFile = cuemodel.ParameterFieldName + ": {}"
 	if string(bt) != "null" {
 		paramFile = fmt.Sprintf("%s: %s", cuemodel.ParameterFieldName, string(bt))
 	}
-	param := fmt.Sprintf("%s\n%s", paramFile, parameters)
-	v, err := value.NewValue(param, nil, "")
+	// addon metadata context
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, err
+	}
+	contextFile.WriteString(fmt.Sprintf("context: metadata: %s\n", string(metadataJSON)))
+	// parameter definition
+	contextFile.WriteString(paramFile + "\n")
+	// user custom parameter
+	contextFile.WriteString(parameters + "\n")
+
+	v, err := value.NewValue(contextFile.String(), nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -880,3 +880,20 @@ func TestReadDefFile(t *testing.T) {
 	// verify
 	assert.True(t, len(uiData.Definitions) == 1)
 }
+
+func TestRenderCUETemplate(t *testing.T) {
+	fileDate, err := os.ReadFile("./testdata/example/resources/configmap.cue")
+	assert.NoError(t, err)
+	component, err := renderCUETemplate(ElementFile{Data: string(fileDate), Name: "configmap.cue"}, "{\"example\": \"\"}", map[string]interface{}{
+		"example": "render",
+	}, Meta{
+		Version: "1.0.1",
+	})
+	assert.NoError(t, err)
+	assert.True(t, component.Type == "raw")
+	var config = make(map[string]interface{})
+	err = json.Unmarshal(component.Properties.Raw, &config)
+	assert.NoError(t, err)
+	assert.True(t, component.Type == "raw")
+	assert.True(t, config["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["version"] == "1.0.1")
+}

--- a/pkg/addon/testdata/example/metadata.yaml
+++ b/pkg/addon/testdata/example/metadata.yaml
@@ -1,5 +1,5 @@
 name: example
-version: 1.0.0
+version: 1.0.1
 description: Extended workload to do continuous and progressive delivery
 icon: https://raw.githubusercontent.com/fluxcd/flux/master/docs/_files/weave-flux.png
 url: https://fluxcd.io

--- a/pkg/addon/testdata/example/resources/configmap.cue
+++ b/pkg/addon/testdata/example/resources/configmap.cue
@@ -6,6 +6,9 @@ output: {
 		metadata: {
 			name:      "exampleinput"
 			namespace: "default"
+			labels: {
+			  version: context.metadata.version
+			}
 		}
 		data: input: parameter.example
 	}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>


### Description of your changes

When building the addon, we will get metadata info from context. such as:

```
output: {
	type: "webservice"
	properties: {
		if parameter["repo"] == _|_ {
			image: "oamdev/velaux:" + context.metadata.version
		}
                 ...
        }
        ...
}
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->