### PR TITLE
Fix: topology use original resource namespace when not specify

### DIFF
--- a/pkg/workflow/providers/multicluster/multicluster.go
+++ b/pkg/workflow/providers/multicluster/multicluster.go
@@ -180,10 +180,7 @@ func (p *provider) ExpandTopology(ctx wfContext.Context, v *value.Value, act wfT
 				return errors.Wrapf(e, "failed to get cluster %s", cluster)
 			}
 		}
-		if ns == "" {
-			ns = p.app.GetNamespace()
-		}
-		if !resourcekeeper.AllowCrossNamespaceResource && ns != p.app.GetNamespace() {
+		if !resourcekeeper.AllowCrossNamespaceResource && (ns != p.app.GetNamespace() && ns != "") {
 			return errors.Errorf("cannot cross namespace")
 		}
 		placement := v1alpha1.PlacementDecision{Cluster: cluster, Namespace: ns}

--- a/pkg/workflow/providers/multicluster/multicluster_test.go
+++ b/pkg/workflow/providers/multicluster/multicluster_test.go
@@ -576,7 +576,7 @@ func TestExpandTopology(t *testing.T) {
 		},
 		"topology-by-clusters": {
 			Input:   `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusters:["cluster-a"]}}]}}`,
-			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "test"}},
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: ""}},
 		},
 		"topology-by-cluster-selector-404": {
 			Input: `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterSelector:{"key":"bad-value"}}}]}}`,
@@ -584,11 +584,11 @@ func TestExpandTopology(t *testing.T) {
 		},
 		"topology-by-cluster-selector": {
 			Input:   `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterSelector:{"key":"value"}}}]}}`,
-			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "test"}, {Cluster: "cluster-b", Namespace: "test"}},
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: ""}, {Cluster: "cluster-b", Namespace: ""}},
 		},
 		"topology-by-cluster-label-selector": {
 			Input:   `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterLabelSelector:{"key":"value"}}}]}}`,
-			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "test"}, {Cluster: "cluster-b", Namespace: "test"}},
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: ""}, {Cluster: "cluster-b", Namespace: ""}},
 		},
 		"topology-by-cluster-selector-and-namespace-invalid": {
 			Input:                 `{inputs:{policies:[{name:"topology-policy",type:"topology",properties:{clusterSelector:{"key":"value"},namespace:"override"}}]}}`,


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When namespace in topology policy is empty, do not directly override the original resources' namespace with the application's namespace. This is useful for addon applications. 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->