### PR TITLE
Fix: optimize the user-experience  of addon

### DIFF
--- a/references/cli/addon_test.go
+++ b/references/cli/addon_test.go
@@ -18,7 +18,12 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/fatih/color"
+
+	pkgaddon "github.com/oam-dev/kubevela/pkg/addon"
 
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/util"
@@ -149,5 +154,64 @@ func TestTransCluster(t *testing.T) {
 	}
 	for _, s := range testcase {
 		assert.DeepEqual(t, transClusters(s.str), s.res)
+	}
+}
+
+func TestGenerateStatusIn(t *testing.T) {
+	testcases := []struct {
+		c   pkgaddon.Status
+		res []string
+	}{
+		{
+			c:   pkgaddon.Status{InstalledVersion: "1.2.1", Clusters: map[string]map[string]interface{}{"cluster1": nil, "cluster2": nil}, AddonPhase: statusEnabled},
+			res: []string{"installedVersion: 1.2.1", "installedClusters: [cluster1 cluster2]", fmt.Sprintf("status is %s", color.New(color.FgGreen).Sprintf(statusEnabled))},
+		},
+		{
+			c:   pkgaddon.Status{InstalledVersion: "1.2.3", AddonPhase: statusSuspend},
+			res: []string{"installedVersion: 1.2.3", fmt.Sprintf("status is %s", color.New(color.FgRed).Sprintf(statusSuspend))},
+		},
+	}
+	for _, testcase := range testcases {
+		res := generateAddonInfo("test", testcase.c)
+		for _, re := range testcase.res {
+			assert.Equal(t, strings.Contains(res, re), true)
+		}
+	}
+}
+
+func TestGenerateAvailableVersions(t *testing.T) {
+	type testcase struct {
+		inVersion string
+		versions  []string
+	}
+	testcases := []struct {
+		c   testcase
+		res string
+	}{
+		{
+			c: testcase{
+				inVersion: "1.2.1",
+				versions:  []string{"1.2.1"},
+			},
+			res: fmt.Sprintf("[%s]", color.New(color.Bold, color.FgGreen).Sprintf("1.2.1")),
+		},
+		{
+			c: testcase{
+				inVersion: "1.2.1",
+				versions:  []string{"1.2.3", "1.2.2", "1.2.1"},
+			},
+			res: fmt.Sprintf("[%s, 1.2.3, 1.2.2]", color.New(color.Bold, color.FgGreen).Sprintf("1.2.1")),
+		},
+		{
+			c: testcase{
+				inVersion: "1.2.1",
+				versions:  []string{"1.2.3", "1.2.2", "1.2.1", "1.2.0"},
+			},
+			res: fmt.Sprintf("[%s, 1.2.3, 1.2.2, ...]", color.New(color.Bold, color.FgGreen).Sprintf("1.2.1")),
+		},
+	}
+	for _, s := range testcases {
+		re := genAvailableVersionInfo(s.c.versions, pkgaddon.Status{InstalledVersion: s.c.inVersion})
+		assert.Equal(t, re, s.res)
 	}
 }


### PR DESCRIPTION
1. list addon put installedVersion as the first one and avoid too many versions cause print info  too long.
![808CF965-68E1-41CE-BAF1-24EC89DCDB26](https://user-images.githubusercontent.com/77846369/160824255-479bced1-c9c4-4a5f-8e38-31d345adde74.png)

2. addon status more info

![B040AFC1-70CE-4247-A38F-9F8E8C8D5B76](https://user-images.githubusercontent.com/77846369/160824359-6c348cbe-ef56-47fd-9b40-11df2686c404.png)

Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->