### PR TITLE
Fix: custom providerRef could not be passed to Configuration

### DIFF
--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -695,14 +695,14 @@ func generateTerraformConfigurationWorkload(wl *Workload, ns string) (*unstructu
 	if err := json.Unmarshal(params, &spec); err != nil {
 		return nil, errors.Wrap(err, errConvertTerraformBaseConfigurationSpec)
 	}
-	if spec.ProviderReference != nil && !reflect.DeepEqual(configuration.Spec.ProviderReference, spec.ProviderReference) {
-		configuration.Spec.ProviderReference = spec.ProviderReference
-	} else if wl.FullTemplate != nil && wl.FullTemplate.ComponentDefinition != nil &&
+	if wl.FullTemplate != nil && wl.FullTemplate.ComponentDefinition != nil &&
 		wl.FullTemplate.ComponentDefinition.Spec.Schematic != nil &&
 		wl.FullTemplate.ComponentDefinition.Spec.Schematic.Terraform != nil &&
 		wl.FullTemplate.ComponentDefinition.Spec.Schematic.Terraform.ProviderReference != nil {
 		// Check whether the provider reference is set in ComponentDefinition
 		configuration.Spec.ProviderReference = wl.FullTemplate.ComponentDefinition.Spec.Schematic.Terraform.ProviderReference
+	} else if spec.ProviderReference != nil && !reflect.DeepEqual(configuration.Spec.ProviderReference, spec.ProviderReference) {
+		configuration.Spec.ProviderReference = spec.ProviderReference
 	}
 
 	if spec.Region != "" && configuration.Spec.Region != spec.Region {


### PR DESCRIPTION
Fix the issuing of passing custom provider to Configuration

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->