### PR TITLE
Feat: add api of listing configs for project when creating a target

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -143,4 +143,8 @@ const (
 	TerraformProvider = "terraform-provider"
 	// DexConnector is the config type for dex connector
 	DexConnector = "config-dex-connector"
+	// ImageRegistry is the config type for image registry
+	ImageRegistry = "config-image-registry"
+	// HelmRepository is the config type for Helm chart repository
+	HelmRepository = "config-helm-repository"
 )

--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -71,6 +71,10 @@ const (
 	LabelConfigProject = "config.oam.dev/project"
 	// LabelConfigSyncToMultiCluster is the label to decide whether a config will be synchronized to multi-cluster
 	LabelConfigSyncToMultiCluster = "config.oam.dev/multi-cluster"
+	// LabelConfigIdentifier is the label for config identifier
+	LabelConfigIdentifier = "config.oam.dev/identifier"
+	// LabelConfigDescription is the label for config description
+	LabelConfigDescription = "config.oam.dev/description"
 	// AnnotationConfigAlias is the annotation for config alias
 	AnnotationConfigAlias = "config.oam.dev/alias"
 )

--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -3337,6 +3337,284 @@
 				}
 			}
 		},
+		"/api/v1/config_types": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"config"
+				],
+				"summary": "list all config types",
+				"operationId": "listConfigTypes",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Fuzzy search based on name and description.",
+						"name": "query",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/v1.ConfigType"
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/config_types/{configType}": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"config"
+				],
+				"summary": "get a config type",
+				"operationId": "getConfigType",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the config type",
+						"name": "configType",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ConfigType"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			},
+			"post": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"config"
+				],
+				"summary": "create or update a config",
+				"operationId": "createConfig",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the config type",
+						"name": "configType",
+						"in": "path",
+						"required": true
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/v1.CreateConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.EmptyResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					},
+					"404": {
+						"description": "Not Found",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/config_types/{configType}/configs": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"config"
+				],
+				"summary": "get configs from a config type",
+				"operationId": "getConfigs",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the config",
+						"name": "configType",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/*v1.Config"
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/config_types/{configType}/configs/{name}": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"config"
+				],
+				"summary": "get a config from a config type",
+				"operationId": "getConfig",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the config type",
+						"name": "configType",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "identifier of the config",
+						"name": "name",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/*v1.Config"
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			},
+			"delete": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"config"
+				],
+				"summary": "delete a config",
+				"operationId": "deleteConfig",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the config type",
+						"name": "configType",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "identifier of the config",
+						"name": "name",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.EmptyResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					},
+					"404": {
+						"description": "Not Found",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
 		"/api/v1/definitions": {
 			"get": {
 				"consumes": [
@@ -3857,6 +4135,55 @@
 						"description": "OK",
 						"schema": {
 							"$ref": "#/definitions/v1.EmptyResponse"
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/projects/{projectName}/configs": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"project"
+				],
+				"summary": "get configs which are in a project",
+				"operationId": "getConfigs",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "config type",
+						"name": "configType",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"description": "identifier of the project",
+						"name": "projectName",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/*v1.Config"
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
 						}
 					}
 				}
@@ -5302,6 +5629,7 @@
 	},
 	"definitions": {
 		"*v1.ApplicationTriggerBase": {},
+		"*v1.Config": {},
 		"*v1.EmptyResponse": {},
 		"addon.Dependency": {
 			"properties": {
@@ -5344,6 +5672,22 @@
 		"addon.GiteeAddonSource": {
 			"properties": {
 				"path": {
+					"type": "string"
+				},
+				"token": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				}
+			}
+		},
+		"addon.GitlabAddonSource": {
+			"properties": {
+				"path": {
+					"type": "string"
+				},
+				"repo": {
 					"type": "string"
 				},
 				"token": {
@@ -6623,34 +6967,6 @@
 				}
 			}
 		},
-		"model.SystemInfo": {
-			"required": [
-				"createTime",
-				"updateTime",
-				"installID",
-				"enableCollection",
-				"loginType"
-			],
-			"properties": {
-				"createTime": {
-					"type": "string",
-					"format": "date-time"
-				},
-				"enableCollection": {
-					"type": "boolean"
-				},
-				"installID": {
-					"type": "string"
-				},
-				"loginType": {
-					"type": "string"
-				},
-				"updateTime": {
-					"type": "string",
-					"format": "date-time"
-				}
-			}
-		},
 		"model.WorkflowStepStatus": {
 			"required": [
 				"id",
@@ -7039,6 +7355,9 @@
 				"gitee": {
 					"$ref": "#/definitions/addon.GiteeAddonSource"
 				},
+				"gitlab": {
+					"$ref": "#/definitions/addon.GitlabAddonSource"
+				},
 				"helm": {
 					"$ref": "#/definitions/addon.HelmSource"
 				},
@@ -7209,12 +7528,12 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
-				"version",
-				"status",
 				"note",
-				"createTime",
 				"envName",
-				"triggerType"
+				"triggerType",
+				"createTime",
+				"version",
+				"status"
 			],
 			"properties": {
 				"codeInfo": {
@@ -7748,6 +8067,31 @@
 				}
 			}
 		},
+		"v1.ConfigType": {
+			"required": [
+				"definitions",
+				"alias",
+				"name",
+				"description"
+			],
+			"properties": {
+				"alias": {
+					"type": "string"
+				},
+				"definitions": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"description": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				}
+			}
+		},
 		"v1.ConnectCloudClusterRequest": {
 			"required": [
 				"accessKeyID",
@@ -7796,6 +8140,9 @@
 				},
 				"gitee": {
 					"$ref": "#/definitions/addon.GiteeAddonSource"
+				},
+				"gitlab": {
+					"$ref": "#/definitions/addon.GitlabAddonSource"
 				},
 				"helm": {
 					"$ref": "#/definitions/addon.HelmSource"
@@ -8093,6 +8440,31 @@
 				}
 			}
 		},
+		"v1.CreateConfigRequest": {
+			"required": [
+				"name",
+				"alias",
+				"project",
+				"componentType"
+			],
+			"properties": {
+				"alias": {
+					"type": "string"
+				},
+				"componentType": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"project": {
+					"type": "string"
+				},
+				"properties": {
+					"type": "string"
+				}
+			}
+		},
 		"v1.CreateEnvRequest": {
 			"required": [
 				"name",
@@ -8304,11 +8676,11 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"name",
-				"description",
-				"icon",
 				"version",
+				"description",
 				"invisible",
+				"name",
+				"icon",
 				"schema",
 				"uiSchema",
 				"definitions",
@@ -8388,12 +8760,12 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
-				"alias",
+				"icon",
 				"project",
 				"description",
-				"icon",
-				"name",
 				"createTime",
+				"name",
+				"alias",
 				"updateTime",
 				"policies",
 				"envBindings",
@@ -8455,20 +8827,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"status",
-				"apiServerURL",
-				"dashboardURL",
-				"kubeConfigSecret",
-				"icon",
-				"labels",
-				"kubeConfig",
-				"updateTime",
+				"reason",
+				"provider",
 				"name",
 				"alias",
-				"description",
-				"reason",
+				"icon",
+				"dashboardURL",
 				"createTime",
-				"provider",
+				"description",
+				"status",
+				"updateTime",
+				"apiServerURL",
+				"kubeConfig",
+				"labels",
+				"kubeConfigSecret",
 				"resourceInfo"
 			],
 			"properties": {
@@ -8526,14 +8898,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
-				"createTime",
-				"updateTime",
-				"appPrimaryKey",
-				"type",
-				"main",
 				"name",
+				"updateTime",
+				"createTime",
 				"creator",
 				"alias",
+				"type",
+				"main",
+				"appPrimaryKey",
 				"definition"
 			],
 			"properties": {
@@ -8635,13 +9007,13 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
+				"name",
 				"type",
 				"description",
 				"creator",
 				"properties",
 				"createTime",
-				"updateTime",
-				"name"
+				"updateTime"
 			],
 			"properties": {
 				"createTime": {
@@ -8671,17 +9043,17 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"updateTime",
 				"triggerType",
+				"updateTime",
 				"version",
-				"deployUser",
+				"reason",
 				"createTime",
 				"status",
+				"deployUser",
+				"note",
 				"workflowName",
 				"envName",
-				"appPrimaryKey",
-				"reason",
-				"note"
+				"appPrimaryKey"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -8737,8 +9109,8 @@
 			"required": [
 				"project",
 				"createTime",
-				"name",
-				"updateTime"
+				"updateTime",
+				"name"
 			],
 			"properties": {
 				"alias": {
@@ -8778,11 +9150,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
-				"disabled",
-				"createTime",
 				"lastLoginTime",
 				"name",
 				"email",
+				"disabled",
+				"createTime",
 				"projects",
 				"roles"
 			],
@@ -8823,12 +9195,12 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"status",
 				"name",
 				"namespace",
 				"workflowName",
 				"workflowAlias",
 				"applicationRevision",
+				"status",
 				"deployTime",
 				"deployUser",
 				"note",
@@ -8880,14 +9252,14 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"envName",
-				"createTime",
 				"updateTime",
+				"name",
 				"enable",
 				"default",
-				"description",
-				"name",
-				"alias"
+				"envName",
+				"createTime",
+				"alias",
+				"description"
 			],
 			"properties": {
 				"alias": {
@@ -9466,11 +9838,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
-				"disabled",
 				"createTime",
 				"lastLoginTime",
 				"name",
 				"email",
+				"disabled",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"
@@ -9778,6 +10150,24 @@
 				}
 			}
 		},
+		"v1.SystemInfo": {
+			"required": [
+				"installID",
+				"enableCollection",
+				"loginType"
+			],
+			"properties": {
+				"enableCollection": {
+					"type": "boolean"
+				},
+				"installID": {
+					"type": "string"
+				},
+				"loginType": {
+					"type": "string"
+				}
+			}
+		},
 		"v1.SystemInfoRequest": {
 			"required": [
 				"enableCollection",
@@ -9789,6 +10179,9 @@
 				},
 				"loginType": {
 					"type": "string"
+				},
+				"velaAddress": {
+					"type": "string"
 				}
 			}
 		},
@@ -9797,15 +10190,9 @@
 				"installID",
 				"enableCollection",
 				"loginType",
-				"createTime",
-				"updateTime",
 				"systemVersion"
 			],
 			"properties": {
-				"createTime": {
-					"type": "string",
-					"format": "date-time"
-				},
 				"enableCollection": {
 					"type": "boolean"
 				},
@@ -9817,10 +10204,6 @@
 				},
 				"systemVersion": {
 					"$ref": "#/definitions/v1.SystemVersion"
-				},
-				"updateTime": {
-					"type": "string",
-					"format": "date-time"
 				}
 			}
 		},
@@ -9888,6 +10271,9 @@
 				},
 				"gitee": {
 					"$ref": "#/definitions/addon.GiteeAddonSource"
+				},
+				"gitlab": {
+					"$ref": "#/definitions/addon.GitlabAddonSource"
 				},
 				"helm": {
 					"$ref": "#/definitions/addon.HelmSource"

--- a/pkg/apiserver/rest/usecase/project.go
+++ b/pkg/apiserver/rest/usecase/project.go
@@ -539,7 +539,7 @@ func (p *projectUsecaseImpl) GetConfigs(ctx context.Context, projectName, config
 		configs = append(configs, legacyTerraformProviders...)
 		return configs, nil
 	case types.DexConnector, types.HelmRepository, types.ImageRegistry:
-		t := strings.Replace(configType, "config-", "", -1)
+		t := strings.ReplaceAll(configType, "config-", "")
 		for _, a := range apps.Items {
 			appProject := a.Labels[types.LabelConfigProject]
 			if a.Status.Phase != common.ApplicationRunning || (appProject != "" && appProject != projectName) {

--- a/pkg/apiserver/rest/usecase/project_test.go
+++ b/pkg/apiserver/rest/usecase/project_test.go
@@ -18,14 +18,21 @@ package usecase
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 	velatypes "github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/apiserver/datastore"
 	"github.com/oam-dev/kubevela/pkg/apiserver/model"
@@ -244,3 +251,111 @@ var _ = Describe("Test project usecase functions", func() {
 		Expect(roles.Total).Should(BeEquivalentTo(0))
 	})
 })
+
+func TestProjectGetConfigs(t *testing.T) {
+	s := runtime.NewScheme()
+	v1beta1.AddToScheme(s)
+	corev1.AddToScheme(s)
+
+	createdTime, _ := time.Parse(time.UnixDate, "Wed Apr 7 11:06:39 PST 2022")
+
+	app1 := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "a1",
+			Namespace: velatypes.DefaultKubeVelaNS,
+			Labels: map[string]string{
+				model.LabelSourceOfTruth:     model.FromInner,
+				velatypes.LabelConfigCatalog: velaCoreConfig,
+				velatypes.LabelConfigType:    "terraform-provider",
+				"config.oam.dev/project":     "p1",
+			},
+			CreationTimestamp: metav1.NewTime(createdTime),
+		},
+		Status: common.AppStatus{Phase: common.ApplicationRunning},
+	}
+
+	app2 := &v1beta1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "a2",
+			Namespace: velatypes.DefaultKubeVelaNS,
+			Labels: map[string]string{
+				model.LabelSourceOfTruth:     model.FromInner,
+				velatypes.LabelConfigCatalog: velaCoreConfig,
+				velatypes.LabelConfigType:    "terraform-provider",
+			},
+			CreationTimestamp: metav1.NewTime(createdTime),
+		},
+		Status: common.AppStatus{Phase: common.ApplicationRunning},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(s).WithObjects(app1, app2).Build()
+
+	h := &projectUsecaseImpl{k8sClient: k8sClient}
+
+	type args struct {
+		projectName string
+		configType  string
+		h           ProjectUsecase
+	}
+
+	type want struct {
+		configs []*apisv1.Config
+		errMsg  string
+	}
+
+	ctx := context.Background()
+
+	testcases := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "label is matched",
+			args: args{
+				projectName: "p1",
+				configType:  "terraform-provider",
+				h:           h,
+			},
+			want: want{
+				configs: []*apisv1.Config{{
+					ConfigType:  "terraform-provider",
+					Name:        "a1",
+					Project:     "p1",
+					CreatedTime: &createdTime,
+				}, {
+					ConfigType:  "terraform-provider",
+					Name:        "a2",
+					Project:     "",
+					CreatedTime: &createdTime,
+				}},
+			},
+		},
+		{
+			name: "label is not matched",
+			args: args{
+				projectName: "p999",
+				configType:  "terraform-provider",
+				h:           h,
+			},
+			want: want{
+				configs: []*apisv1.Config{{
+					ConfigType:  "terraform-provider",
+					Name:        "a2",
+					Project:     "",
+					CreatedTime: &createdTime,
+				}},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.args.h.GetConfigs(ctx, tc.args.projectName, tc.args.configType)
+			if tc.want.errMsg != "" || err != nil {
+				assert.ErrorContains(t, err, tc.want.errMsg)
+			}
+			assert.DeepEqual(t, got, tc.want.configs)
+		})
+	}
+}

--- a/pkg/apiserver/rest/usecase/rbac.go
+++ b/pkg/apiserver/rest/usecase/rbac.go
@@ -182,6 +182,9 @@ var ResourceMaps = map[string]resourceMetadata{
 				pathName: "userName",
 			},
 			"applicationTemplate": {},
+			"configType": {
+				pathName: "configType",
+			},
 		},
 		pathName: "projectName",
 	},

--- a/pkg/apiserver/rest/usecase/rbac.go
+++ b/pkg/apiserver/rest/usecase/rbac.go
@@ -182,9 +182,7 @@ var ResourceMaps = map[string]resourceMetadata{
 				pathName: "userName",
 			},
 			"applicationTemplate": {},
-			"configType": {
-				pathName: "configType",
-			},
+			"configs":             {},
 		},
 		pathName: "projectName",
 	},

--- a/pkg/apiserver/rest/webservice/project.go
+++ b/pkg/apiserver/rest/webservice/project.go
@@ -176,7 +176,7 @@ func (n *projectWebService) GetWebService() *restful.WebService {
 		Returns(200, "OK", []apis.PermissionBase{}).
 		Writes([]apis.PermissionBase{}))
 
-	ws.Route(ws.GET("/{projectName}/configs/").To(n.getConfigs).
+	ws.Route(ws.GET("/{projectName}/configs").To(n.getConfigs).
 		Doc("get configs which are in a project").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(n.rbacUsecase.CheckPerm("project", "list")).

--- a/pkg/apiserver/rest/webservice/project.go
+++ b/pkg/apiserver/rest/webservice/project.go
@@ -176,12 +176,11 @@ func (n *projectWebService) GetWebService() *restful.WebService {
 		Returns(200, "OK", []apis.PermissionBase{}).
 		Writes([]apis.PermissionBase{}))
 
-	ws.Route(ws.GET("/{projectName}/config_types/{configType}/configs/").To(n.getConfigs).
-		Doc("get configs from a config type").
+	ws.Route(ws.GET("/{projectName}/configs/").To(n.getConfigs).
+		Doc("get configs which are in a project").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
-		Filter(n.rbacUsecase.CheckPerm("project/configType", "list")).
+		Filter(n.rbacUsecase.CheckPerm("project", "list")).
 		Param(ws.PathParameter("projectName", "identifier of the project").DataType("string")).
-		Param(ws.PathParameter("configType", "identifier of the config").DataType("string")).
 		Returns(200, "OK", []*apis.Config{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
 		Writes([]*apis.Config{}))
@@ -515,7 +514,7 @@ func (n *projectWebService) listProjectPermissions(req *restful.Request, res *re
 }
 
 func (n *projectWebService) getConfigs(req *restful.Request, res *restful.Response) {
-	configs, err := n.projectUsecase.GetConfigs(req.Request.Context(), req.PathParameter("projectName"), req.PathParameter("configType"))
+	configs, err := n.projectUsecase.GetConfigs(req.Request.Context(), req.PathParameter("projectName"), req.QueryParameter("configType"))
 	if err != nil {
 		bcode.ReturnError(req, res, err)
 		return

--- a/pkg/apiserver/rest/webservice/project.go
+++ b/pkg/apiserver/rest/webservice/project.go
@@ -180,6 +180,7 @@ func (n *projectWebService) GetWebService() *restful.WebService {
 		Doc("get configs which are in a project").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(n.rbacUsecase.CheckPerm("project", "list")).
+		Param(ws.QueryParameter("configType", "config type").DataType("string")).
 		Param(ws.PathParameter("projectName", "identifier of the project").DataType("string")).
 		Returns(200, "OK", []*apis.Config{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).


### PR DESCRIPTION
When creating a target,  list configs by the config type and the project.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->