### PR TITLE
Fix: vela logs without specified resource name

### DIFF
--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -368,4 +369,57 @@ func TestFilterClusterObjectRefFromAddonObservability(t *testing.T) {
 	assert.Equal(t, 1, len(res))
 	assert.Equal(t, "Service", res[0].Kind)
 	assert.Equal(t, "v1", res[0].APIVersion)
+}
+
+func TestResourceNameClusterObjectReferenceFilter(t *testing.T) {
+	fooRef := common.ClusterObjectReference{
+		ObjectReference: corev1.ObjectReference{
+			Name: "foo",
+		}}
+	barRef := common.ClusterObjectReference{
+		ObjectReference: corev1.ObjectReference{
+			Name: "bar",
+		}}
+	bazRef := common.ClusterObjectReference{
+		ObjectReference: corev1.ObjectReference{
+			Name: "baz",
+		}}
+	var refs = []common.ClusterObjectReference{
+		fooRef, barRef, bazRef,
+	}
+
+	testCases := []struct {
+		caseName     string
+		filter       clusterObjectReferenceFilter
+		filteredRefs []common.ClusterObjectReference
+	}{
+		{
+			caseName:     "filter one resource",
+			filter:       resourceNameClusterObjectReferenceFilter([]string{"foo"}),
+			filteredRefs: []common.ClusterObjectReference{fooRef},
+		},
+		{
+			caseName:     "not filter resources",
+			filter:       resourceNameClusterObjectReferenceFilter([]string{}),
+			filteredRefs: []common.ClusterObjectReference{fooRef, barRef, bazRef},
+		},
+		{
+			caseName:     "filter multi resources",
+			filter:       resourceNameClusterObjectReferenceFilter([]string{"foo", "bar"}),
+			filteredRefs: []common.ClusterObjectReference{fooRef, barRef},
+		},
+	}
+	for _, c := range testCases {
+		filteredResource := filterResource(refs, c.filter)
+		assert.Equal(t, c.filteredRefs, filteredResource, c.caseName)
+	}
+}
+
+func TestRemoveEmptyString(t *testing.T) {
+	withEmpty := []string{"foo", "bar", "", "baz", ""}
+	noEmpty := removeEmptyString(withEmpty)
+	assert.Equal(t, len(noEmpty), 3)
+	for _, s := range noEmpty {
+		assert.NotEmpty(t, s)
+	}
 }

--- a/pkg/utils/common/common_test.go
+++ b/pkg/utils/common/common_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -33,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/types"


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>


### Description of your changes

Fix this case: run `vela logs` without `--name`, all resources are filtered and can not print logs.
cc @Somefive 

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->