### PR TITLE
Feat: support alias in cluster

### DIFF
--- a/apis/types/multicluster.go
+++ b/apis/types/multicluster.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package types
 
-import "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
+import (
+	"github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
+	"github.com/oam-dev/cluster-gateway/pkg/config"
+)
 
 const (
 	// CredentialTypeInternal identifies the virtual cluster from internal kubevela system
@@ -28,4 +31,9 @@ const (
 
 	// ClustersArg indicates the argument for specific clusters to install addon
 	ClustersArg = "clusters"
+)
+
+var (
+	// AnnotationClusterAlias the annotation key for cluster alias
+	AnnotationClusterAlias = config.MetaApiGroupName + "/cluster-alias"
 )

--- a/pkg/multicluster/cluster_management.go
+++ b/pkg/multicluster/cluster_management.go
@@ -449,6 +449,19 @@ func RenameCluster(ctx context.Context, k8sClient client.Client, oldClusterName 
 	return nil
 }
 
+// AliasCluster alias cluster
+func AliasCluster(ctx context.Context, cli client.Client, clusterName string, aliasName string) error {
+	if clusterName == ClusterLocalName {
+		return ErrReservedLocalClusterName
+	}
+	vc, err := GetVirtualCluster(ctx, cli, clusterName)
+	if err != nil {
+		return err
+	}
+	setClusterAlias(vc.Object, aliasName)
+	return cli.Update(ctx, vc.Object)
+}
+
 // ensureClusterNotExists will check the cluster is not existed in control plane
 func ensureClusterNotExists(ctx context.Context, c client.Client, clusterName string) error {
 	_, err := GetVirtualCluster(ctx, c, clusterName)

--- a/pkg/multicluster/virtual_cluster.go
+++ b/pkg/multicluster/virtual_cluster.go
@@ -18,6 +18,7 @@ package multicluster
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -38,12 +39,37 @@ import (
 // like cluster secret or ocm managed cluster
 type VirtualCluster struct {
 	Name     string
+	Alias    string
 	Type     v1alpha1.CredentialType
 	EndPoint string
 	Accepted bool
 	Labels   map[string]string
 	Metrics  *ClusterMetrics
 	Object   client.Object
+}
+
+// FullName the name with alias if available
+func (vc *VirtualCluster) FullName() string {
+	if vc.Alias != "" {
+		return fmt.Sprintf("%s (%s)", vc.Name, vc.Alias)
+	}
+	return vc.Name
+}
+
+func getClusterAlias(o client.Object) string {
+	if annots := o.GetAnnotations(); annots != nil {
+		return annots[types.AnnotationClusterAlias]
+	}
+	return ""
+}
+
+func setClusterAlias(o client.Object, alias string) {
+	annots := o.GetAnnotations()
+	if annots == nil {
+		annots = map[string]string{}
+	}
+	annots[types.AnnotationClusterAlias] = alias
+	o.SetAnnotations(annots)
 }
 
 // NewVirtualClusterFromLocal return virtual cluster corresponding to local cluster
@@ -74,6 +100,7 @@ func NewVirtualClusterFromSecret(secret *corev1.Secret) (*VirtualCluster, error)
 	}
 	return &VirtualCluster{
 		Name:     secret.Name,
+		Alias:    getClusterAlias(secret),
 		Type:     v1alpha1.CredentialType(credType),
 		EndPoint: endpoint,
 		Accepted: true,
@@ -90,6 +117,7 @@ func NewVirtualClusterFromManagedCluster(managedCluster *clusterv1.ManagedCluste
 	}
 	return &VirtualCluster{
 		Name:     managedCluster.Name,
+		Alias:    getClusterAlias(managedCluster),
 		Type:     types.CredentialTypeOCMManagedCluster,
 		EndPoint: types.ClusterBlankEndpoint,
 		Accepted: managedCluster.Spec.HubAcceptsClient,

--- a/test/e2e-multicluster-test/multicluster_test.go
+++ b/test/e2e-multicluster-test/multicluster_test.go
@@ -111,6 +111,14 @@ var _ = Describe("Test multicluster scenario", func() {
 			Expect(out).ShouldNot(ContainSubstring("purpose"))
 		})
 
+		It("Test alias for cluster", func() {
+			_, err := execCommand("cluster", "alias", WorkerClusterName, "alias-worker")
+			Expect(err).Should(Succeed())
+			out, err := execCommand("cluster", "list")
+			Expect(err).Should(Succeed())
+			Expect(out).Should(ContainSubstring("alias-worker"))
+		})
+
 		It("Test detach cluster with application use", func() {
 			const testClusterName = "test-cluster"
 			_, err := execCommand("cluster", "join", "/tmp/worker.kubeconfig", "--name", testClusterName)


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support vela cluster alias.
1. `vela cluster alias` add alias to cluster.
2. `vela cluster list` show cluster alias explicitly.
3. Other vela cluster commands show cluster alias implicitly.

The underlying annotation is `cluster.core.oam.dev/cluster-alias`.

![image](https://user-images.githubusercontent.com/14019297/162893501-5e6e9a07-68bf-4f5e-8ac8-a9901678add2.png)

![image](https://user-images.githubusercontent.com/14019297/162893850-14efe3f7-423d-4264-b585-98f3c1aad80f.png)

NOTE:
1. Alias is only used for help user identify the cluster. There is no name conflict detection for cluster alias. Therefore, it is possible for two clusters to share the same alias.
2. Alias **CANNOT** be used to select clusters now.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->