### PR TITLE
Fix: clear info when addon version cannot meet require

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1080,7 +1080,7 @@ func (h *Installer) enableAddon(addon *InstallPackage) error {
 	h.addon = addon
 	err = checkAddonVersionMeetRequired(h.ctx, addon.SystemRequirements, h.cli, h.dc)
 	if err != nil {
-		return ErrVersionMismatch
+		return VersionUnMatchError{addonName: addon.Name, err: err}
 	}
 
 	if err = h.installDependency(addon); err != nil {
@@ -1354,7 +1354,7 @@ func checkAddonVersionMeetRequired(ctx context.Context, require *SystemRequireme
 			return err
 		}
 		if !res {
-			return fmt.Errorf("vela cli/ux version: %s cannot meet requirement", version2.VelaVersion)
+			return fmt.Errorf("vela cli/ux version: %s  require: %s", version2.VelaVersion, require.VelaVersion)
 		}
 	}
 
@@ -1371,7 +1371,7 @@ func checkAddonVersionMeetRequired(ctx context.Context, require *SystemRequireme
 			return err
 		}
 		if !res {
-			return fmt.Errorf("the vela core controller: %s cannot meet requirement ", imageVersion)
+			return fmt.Errorf("the vela core controller: %s require: %s", imageVersion, require.VelaVersion)
 		}
 	}
 
@@ -1392,7 +1392,7 @@ func checkAddonVersionMeetRequired(ctx context.Context, require *SystemRequireme
 		}
 
 		if !res {
-			return fmt.Errorf("the kubernetes version %s cannot meet requirement", k8sVersion.GitVersion)
+			return fmt.Errorf("the kubernetes version %s requir: %s", k8sVersion.GitVersion, require.KubernetesVersion)
 		}
 	}
 

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1392,7 +1392,7 @@ func checkAddonVersionMeetRequired(ctx context.Context, require *SystemRequireme
 		}
 
 		if !res {
-			return fmt.Errorf("the kubernetes version %s requir: %s", k8sVersion.GitVersion, require.KubernetesVersion)
+			return fmt.Errorf("the kubernetes version %s require: %s", k8sVersion.GitVersion, require.KubernetesVersion)
 		}
 	}
 

--- a/pkg/addon/error.go
+++ b/pkg/addon/error.go
@@ -48,6 +48,7 @@ func WrapErrRateLimit(err error) error {
 	return err
 }
 
+// VersionUnMatchError means addon system requirement cannot meet requirement
 type VersionUnMatchError struct {
 	err       error
 	addonName string

--- a/pkg/addon/error.go
+++ b/pkg/addon/error.go
@@ -17,6 +17,8 @@ limitations under the License.
 package addon
 
 import (
+	"fmt"
+
 	"github.com/google/go-github/v32/github"
 	"github.com/pkg/errors"
 )
@@ -35,9 +37,6 @@ var (
 
 	// ErrNotExist  means addon not exists
 	ErrNotExist = NewAddonError("addon not exist")
-
-	// ErrVersionMismatch  means addon version requirement mismatch
-	ErrVersionMismatch = NewAddonError("addon version requirements mismatch")
 )
 
 // WrapErrRateLimit return ErrRateLimit if is the situation, or return error directly
@@ -47,4 +46,13 @@ func WrapErrRateLimit(err error) error {
 		return ErrRateLimit
 	}
 	return err
+}
+
+type VersionUnMatchError struct {
+	err       error
+	addonName string
+}
+
+func (v VersionUnMatchError) Error() string {
+	return fmt.Sprintf("addon %s system requirement miss match: %v", v.addonName, v.err)
 }

--- a/pkg/apiserver/rest/usecase/addon.go
+++ b/pkg/apiserver/rest/usecase/addon.go
@@ -401,7 +401,8 @@ func (u *defaultAddonHandler) EnableAddon(ctx context.Context, name string, args
 		}
 
 		// wrap this error with special bcode
-		if errors.Is(err, pkgaddon.ErrVersionMismatch) {
+		if errors.As(err, &pkgaddon.VersionUnMatchError{}) {
+			log.Logger.Error(err)
 			return bcode.ErrAddonSystemVersionMismatch
 		}
 		// except `addon not found`, other errors should return directly
@@ -467,7 +468,7 @@ func (u *defaultAddonHandler) UpdateAddon(ctx context.Context, name string, args
 		}
 
 		// wrap this error with special bcode
-		if errors.Is(err, pkgaddon.ErrVersionMismatch) {
+		if errors.As(err, &pkgaddon.VersionUnMatchError{}) {
 			return bcode.ErrAddonSystemVersionMismatch
 		}
 		// except `addon not found`, other errors should return directly


### PR DESCRIPTION
clear info when addon version cannot meet require

![image](https://user-images.githubusercontent.com/77846369/163171817-dbbe9f68-c938-4be4-837f-e3cf8a44821f.png)



### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->