### PR TITLE
Feat: enhance storage trait to support multi-mountToEnv config

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -87,6 +87,17 @@ spec:
         		}
         	},
         ] | []
+        configMountToEnvsList: *[
+        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: configMapKeyRef: {
+        				name: v.name
+        				key:  k.configMapKey
+        			}
+        		}
+        	},
+        ] | []
         secretVolumeMountsList: *[
         			for v in parameter.secret if v.mountPath != _|_ {
         		{
@@ -102,6 +113,17 @@ spec:
         			valueFrom: secretKeyRef: {
         				name: v.name
         				key:  v.mountToEnv.secretKey
+        			}
+        		}
+        	},
+        ] | []
+        secretMountToEnvsList: *[
+        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: secretKeyRef: {
+        				name: v.name
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -128,7 +150,7 @@ spec:
 
         	containers: [{
         		// +patchKey=name
-        		env: configMapEnvMountsList + secretEnvMountsList
+        		env: configMapEnvMountsList + secretEnvMountsList + configMountToEnvsList + secretMountToEnvsList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name
@@ -248,6 +270,10 @@ spec:
         			envName:      string
         			configMapKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:      string
+        			configMapKey: string
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -267,6 +293,10 @@ spec:
         			envName:   string
         			secretKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:   string
+        			secretKey: string
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -87,6 +87,17 @@ spec:
         		}
         	},
         ] | []
+        configMountToEnvsList: *[
+        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: configMapKeyRef: {
+        				name: v.name
+        				key:  k.configMapKey
+        			}
+        		}
+        	},
+        ] | []
         secretVolumeMountsList: *[
         			for v in parameter.secret if v.mountPath != _|_ {
         		{
@@ -102,6 +113,17 @@ spec:
         			valueFrom: secretKeyRef: {
         				name: v.name
         				key:  v.mountToEnv.secretKey
+        			}
+        		}
+        	},
+        ] | []
+        secretMountToEnvsList: *[
+        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: secretKeyRef: {
+        				name: v.name
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -128,7 +150,7 @@ spec:
 
         	containers: [{
         		// +patchKey=name
-        		env: configMapEnvMountsList + secretEnvMountsList
+        		env: configMapEnvMountsList + secretEnvMountsList + configMountToEnvsList + secretMountToEnvsList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name
@@ -248,6 +270,10 @@ spec:
         			envName:      string
         			configMapKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:      string
+        			configMapKey: string
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -267,6 +293,10 @@ spec:
         			envName:   string
         			secretKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:   string
+        			secretKey: string
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/docs/examples/core-definitions/trait/storage.yaml
+++ b/docs/examples/core-definitions/trait/storage.yaml
@@ -32,6 +32,9 @@ spec:
                 mountToEnv:
                   envName: TEST_ENV
                   configMapKey: key1
+                mountToEnvs:
+                  - envName: TEST_CM_ENV
+                    configMapKey: key2
                 data:
                   key1: value1
                   key2: value2
@@ -49,9 +52,15 @@ spec:
                 mountToEnv:
                   envName: TEST_SECRET
                   secretKey: key1
+                mountToEnvs:
+                  - envName: TEST_SECRET_ENV_2
+                    secretKey: key2
+                  - envName: TEST_SECRET_ENV_3
+                    secretKey: key3
                 data:
                   key1: dmFsdWUx
                   key2: dmFsdWUy
+                  key3: dmFsdWUz
             emptyDir:
               - name: test1
                 mountPath: /test/mount/emptydir

--- a/pkg/addon/cache.go
+++ b/pkg/addon/cache.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/oam-dev/kubevela/pkg/utils"
+
 	"github.com/oam-dev/kubevela/pkg/apiserver/log"
 )
 
@@ -106,7 +108,7 @@ func (u *Cache) GetUIData(r Registry, addonName, version string) (*UIData, error
 		versionedRegistry := BuildVersionedRegistry(r.Name, r.Helm.URL)
 		addon, err = versionedRegistry.GetAddonUIData(context.Background(), addonName, version)
 		if err != nil {
-			log.Logger.Errorf("fail to get addons from registry %s for cache updating, %v", r.Name, err)
+			log.Logger.Errorf("fail to get addons from registry %s for cache updating, %v", utils.Sanitize(r.Name), err)
 			return nil, err
 		}
 	}

--- a/pkg/apiserver/rest/usecase/helm.go
+++ b/pkg/apiserver/rest/usecase/helm.go
@@ -26,6 +26,7 @@ import (
 	v1 "github.com/oam-dev/kubevela/pkg/apiserver/rest/apis/v1"
 	"github.com/oam-dev/kubevela/pkg/apiserver/rest/utils/bcode"
 	"github.com/oam-dev/kubevela/pkg/oam"
+	"github.com/oam-dev/kubevela/pkg/utils"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	"github.com/oam-dev/kubevela/pkg/utils/helm"
 
@@ -62,7 +63,10 @@ type defaultHelmHandler struct {
 	k8sClient client.Client
 }
 
-func (d defaultHelmHandler) ListChartNames(ctx context.Context, url string, secretName string, skipCache bool) ([]string, error) {
+func (d defaultHelmHandler) ListChartNames(ctx context.Context, repoURL string, secretName string, skipCache bool) ([]string, error) {
+	if !utils.IsValidURL(repoURL) {
+		return nil, bcode.ErrRepoInvalidURL
+	}
 	var opts *common.HTTPOption
 	var err error
 	if len(secretName) != 0 {
@@ -71,15 +75,18 @@ func (d defaultHelmHandler) ListChartNames(ctx context.Context, url string, secr
 			return nil, bcode.ErrRepoBasicAuth
 		}
 	}
-	charts, err := d.helper.ListChartsFromRepo(url, skipCache, opts)
+	charts, err := d.helper.ListChartsFromRepo(repoURL, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch charts repo: %s, error: %s", url, err.Error())
+		log.Logger.Errorf("cannot fetch charts repo: %s, error: %s", utils.Sanitize(repoURL), err.Error())
 		return nil, bcode.ErrListHelmChart
 	}
 	return charts, nil
 }
 
-func (d defaultHelmHandler) ListChartVersions(ctx context.Context, url string, chartName string, secretName string, skipCache bool) (repo.ChartVersions, error) {
+func (d defaultHelmHandler) ListChartVersions(ctx context.Context, repoURL string, chartName string, secretName string, skipCache bool) (repo.ChartVersions, error) {
+	if !utils.IsValidURL(repoURL) {
+		return nil, bcode.ErrRepoInvalidURL
+	}
 	var opts *common.HTTPOption
 	var err error
 	if len(secretName) != 0 {
@@ -88,19 +95,22 @@ func (d defaultHelmHandler) ListChartVersions(ctx context.Context, url string, c
 			return nil, bcode.ErrRepoBasicAuth
 		}
 	}
-	chartVersions, err := d.helper.ListVersions(url, chartName, skipCache, opts)
+	chartVersions, err := d.helper.ListVersions(repoURL, chartName, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch chart versions repo: %s, chart: %s error: %s", url, chartName, err.Error())
+		log.Logger.Errorf("cannot fetch chart versions repo: %s, chart: %s error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), err.Error())
 		return nil, bcode.ErrListHelmVersions
 	}
 	if len(chartVersions) == 0 {
-		log.Logger.Errorf("cannot fetch chart versions repo: %s, chart: %s", url, chartName)
+		log.Logger.Errorf("cannot fetch chart versions repo: %s, chart: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName))
 		return nil, bcode.ErrChartNotExist
 	}
 	return chartVersions, nil
 }
 
-func (d defaultHelmHandler) GetChartValues(ctx context.Context, url string, chartName string, version string, secretName string, skipCache bool) (map[string]interface{}, error) {
+func (d defaultHelmHandler) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, skipCache bool) (map[string]interface{}, error) {
+	if !utils.IsValidURL(repoURL) {
+		return nil, bcode.ErrRepoInvalidURL
+	}
 	var opts *common.HTTPOption
 	var err error
 	if len(secretName) != 0 {
@@ -109,9 +119,9 @@ func (d defaultHelmHandler) GetChartValues(ctx context.Context, url string, char
 			return nil, bcode.ErrRepoBasicAuth
 		}
 	}
-	v, err := d.helper.GetValuesFromChart(url, chartName, version, skipCache, opts)
+	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, opts)
 	if err != nil {
-		log.Logger.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s, error: %s", url, chartName, version, err.Error())
+		log.Logger.Errorf("cannot fetch chart values repo: %s, chart: %s, version: %s, error: %s", utils.Sanitize(repoURL), utils.Sanitize(chartName), utils.Sanitize(version), err.Error())
 		return nil, bcode.ErrGetChartValues
 	}
 	res := make(map[string]interface{}, len(v))

--- a/pkg/apiserver/rest/usecase/user.go
+++ b/pkg/apiserver/rest/usecase/user.go
@@ -194,7 +194,7 @@ func (u *userUsecaseImpl) DeleteUser(ctx context.Context, username string) error
 		}
 	}
 	if err := u.ds.Delete(ctx, &model.User{Name: username}); err != nil {
-		log.Logger.Errorf("failed to delete user", username, err.Error())
+		log.Logger.Errorf("failed to delete user %s %v", utils2.Sanitize(username), err.Error())
 		return err
 	}
 	return nil

--- a/pkg/apiserver/rest/utils/bcode/013_repository.go
+++ b/pkg/apiserver/rest/utils/bcode/013_repository.go
@@ -33,3 +33,6 @@ var ErrSkipCacheParameter = NewBcode(400, 13005, "skip cache parameter miss conf
 
 // ErrRepoBasicAuth means extract repo auth info from secret error
 var ErrRepoBasicAuth = NewBcode(400, 13006, "extract repo auth info from secret error")
+
+// ErrRepoInvalidURL means user input url is invalid
+var ErrRepoInvalidURL = NewBcode(400, 13007, "user input repository url is invalid")

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -292,6 +292,35 @@ var _ = Describe("Test Application Controller", func() {
 		},
 	}
 
+	appWithMountToEnvs := &v1beta1.Application{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Application",
+			APIVersion: "core.oam.dev/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-with-mount-to-envs",
+		},
+		Spec: v1beta1.ApplicationSpec{
+			Components: []common.ApplicationComponent{
+				{
+					Name:       "myweb",
+					Type:       "worker",
+					Properties: &runtime.RawExtension{Raw: []byte("{\"cmd\":[\"sleep\",\"1000\"],\"image\":\"busybox\"}")},
+				},
+			},
+		},
+	}
+	appWithMountToEnvs.Spec.Components[0].Traits = []common.ApplicationTrait{
+		{
+			Type:       "storage",
+			Properties: &runtime.RawExtension{Raw: []byte("{\"secret\": [{\"name\": \"myweb-secret\",\"mountToEnv\": {\"envName\": \"firstEnv\",\"secretKey\": \"firstKey\"},\"mountToEnvs\": [{\"envName\": \"secondEnv\",\"secretKey\": \"secondKey\"}],\"data\": {\"firstKey\": \"dmFsdWUwMQo=\",\"secondKey\": \"dmFsdWUwMgo=\"}}]}")},
+		},
+		{
+			Type:       "storage",
+			Properties: &runtime.RawExtension{Raw: []byte("{\"configMap\": [{\"name\": \"myweb-cm\",\"mountToEnvs\": [{\"envName\":\"thirdEnv\",\"configMapKey\":\"thirdKey\"},{\"envName\":\"fourthEnv\",\"configMapKey\":\"fourthKey\"}],\"data\": {\"thirdKey\": \"Value03\",\"fourthKey\": \"Value04\"}}]}")},
+		},
+	}
+
 	cd := &v1beta1.ComponentDefinition{}
 	cDDefJson, _ := yaml.YAMLToJSON([]byte(componentDefYaml))
 	k8sObjectsCDJson, _ := yaml.YAMLToJSON([]byte(k8sObjectsComponentDefinitionYaml))
@@ -2568,6 +2597,66 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Delete(ctx, secret)).Should(BeNil())
 		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
 	})
+
+	It("test application with multi-mountToEnv will create application", func() {
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-mount-to-envs",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(BeNil())
+
+		appWithMountToEnvs.SetNamespace(ns.Name)
+		app := appWithMountToEnvs.DeepCopy()
+		Expect(k8sClient.Create(ctx, app)).Should(BeNil())
+
+		appKey := client.ObjectKey{
+			Name:      app.Name,
+			Namespace: app.Namespace,
+		}
+		testutil.ReconcileOnceAfterFinalizer(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		By("Check App running successfully")
+		curApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, curApp)).Should(BeNil())
+		Expect(curApp.Status.Phase).Should(Equal(common.ApplicationRunning))
+
+		appRevision := &v1beta1.ApplicationRevision{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: app.Namespace,
+			Name:      curApp.Status.LatestRevision.Name,
+		}, appRevision)).Should(BeNil())
+		By("Check affiliated resource tracker is created")
+		expectRTName := fmt.Sprintf("%s-%s", appRevision.GetName(), appRevision.GetNamespace())
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Name: expectRTName}, &v1beta1.ResourceTracker{})
+		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+		By("Check AppRevision Created with the expected workload spec")
+		appRev := &v1beta1.ApplicationRevision{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Name: app.Name + "-v1", Namespace: app.GetNamespace()}, appRev)
+		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+		By("Check secret Created with the expected trait-storage spec")
+		secret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      app.Spec.Components[0].Name + "-secret",
+		}, secret)).Should(BeNil())
+
+		By("Check configMap Created with the expected trait-storage spec")
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      app.Spec.Components[0].Name + "-cm",
+		}, cm)).Should(BeNil())
+
+		Expect(k8sClient.Delete(ctx, cm)).Should(BeNil())
+		Expect(k8sClient.Delete(ctx, secret)).Should(BeNil())
+		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
+	})
 })
 
 const (
@@ -3604,6 +3693,17 @@ spec:
         		}
         	},
         ] | []
+        configMapMountToEnvsList: *[
+        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: configMapKeyRef: {
+        				name: v.name
+        				key:  k.configMapKey
+        			}
+        		}
+        	},
+        ] | []
         secretVolumeMountsList: *[
         			for v in parameter.secret if v.mountPath != _|_ {
         		{
@@ -3619,6 +3719,17 @@ spec:
         			valueFrom: secretKeyRef: {
         				name: v.name
         				key:  v.mountToEnv.secretKey
+        			}
+        		}
+        	},
+        ] | []
+        secretMountToEnvsList: *[
+        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: secretKeyRef: {
+        				name: v.name
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -3645,7 +3756,7 @@ spec:
 
         	containers: [{
         		// +patchKey=name
-        		env: configMapEnvMountsList + secretEnvMountsList
+        		env: configMapEnvMountsList + secretEnvMountsList + configMapMountToEnvsList + secretMountToEnvsList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name
@@ -3765,6 +3876,10 @@ spec:
         			envName:      string
         			configMapKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:      string
+        			configMapKey: string
+        		}]
         		mountPath?:   string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -3784,6 +3899,10 @@ spec:
         			envName:   string
         			secretKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:   string
+        			secretKey: string
+        		}]
         		mountPath?:   string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -91,6 +91,18 @@ template: {
 		},
 	] | []
 
+	configMountToEnvsList: *[
+				for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+			{
+				name: k.envName
+				valueFrom: configMapKeyRef: {
+					name: v.name
+					key:  k.configMapKey
+				}
+			}
+		},
+	] | []
+
 	secretVolumeMountsList: *[
 				for v in parameter.secret if v.mountPath != _|_ {
 			{
@@ -107,6 +119,18 @@ template: {
 				valueFrom: secretKeyRef: {
 					name: v.name
 					key:  v.mountToEnv.secretKey
+				}
+			}
+		},
+	] | []
+
+	secretMountToEnvsList: *[
+				for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+			{
+				name: k.envName
+				valueFrom: secretKeyRef: {
+					name: v.name
+					key:  k.secretKey
 				}
 			}
 		},
@@ -136,7 +160,7 @@ template: {
 
 		containers: [{
 			// +patchKey=name
-			env: configMapEnvMountsList + secretEnvMountsList
+			env: configMapEnvMountsList + secretEnvMountsList + configMountToEnvsList + secretMountToEnvsList
 			// +patchKey=name
 			volumeDevices: volumeDevicesList
 			// +patchKey=name
@@ -260,6 +284,10 @@ template: {
 				envName:      string
 				configMapKey: string
 			}
+			mountToEnvs?: [...{
+				envName:      string
+				configMapKey: string
+			}]
 			mountPath?:  string
 			defaultMode: *420 | int
 			readOnly:    *false | bool
@@ -279,6 +307,10 @@ template: {
 				envName:   string
 				secretKey: string
 			}
+			mountToEnvs?: [...{
+				envName:   string
+				secretKey: string
+			}]
 			mountPath?:  string
 			defaultMode: *420 | int
 			readOnly:    *false | bool


### PR DESCRIPTION
Signed-off-by: Shijie Zhong <zhongsjie@cmbchina.com>


### Description of your changes
Support the multi-mountToEnv parameter of storage trait in secret and configmap. By this feature, we can mount multi-env in container env, without creating multi-secret or multi-configmap resrouces
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->