### PR TITLE
Fix: failed to deploy application when no config is avaiable

### DIFF
--- a/pkg/apiserver/rest/usecase/config.go
+++ b/pkg/apiserver/rest/usecase/config.go
@@ -262,14 +262,18 @@ func SyncConfigs(ctx context.Context, k8sClient client.Client, project string, t
 	if len(secrets.Items) == 0 {
 		return nil
 	}
-	objects := make([]map[string]string, len(secrets.Items))
-	for i, s := range secrets.Items {
+	var objects []map[string]string
+	for _, s := range secrets.Items {
 		if s.Labels[types.LabelConfigProject] == "" || s.Labels[types.LabelConfigProject] == project {
-			objects[i] = map[string]string{
+			objects = append(objects, map[string]string{
 				"name":     s.Name,
 				"resource": "secret",
-			}
+			})
 		}
+	}
+	if len(objects) == 0 {
+		klog.InfoS("no configs need to sync to working clusters", "project", project)
+		return nil
 	}
 	objectsBytes, err := json.Marshal(map[string][]map[string]string{"objects": objects})
 	if err != nil {

--- a/pkg/apiserver/rest/usecase/config_test.go
+++ b/pkg/apiserver/rest/usecase/config_test.go
@@ -566,6 +566,16 @@ func TestSyncConfigs(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name: "skip config sync",
+			args: args{
+				project: "p3",
+				targets: []*model.ClusterTarget{{
+					ClusterName: "c1",
+					Namespace:   "n1",
+				}},
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
When there are configs, but not in the project where the appliation
is about to deploy, the sync application will hit an issue. It will
lead to block the deploy of an application.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->