### PR TITLE
Feat: enhance storage trait to support multi-mountToEnv config

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-core/templates/defwithtemplate/storage.yaml
@@ -87,6 +87,17 @@ spec:
         		}
         	},
         ] | []
+        configMountToEnvsList: *[
+        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: configMapKeyRef: {
+        				name: v.name
+        				key:  k.configMapKey
+        			}
+        		}
+        	},
+        ] | []
         secretVolumeMountsList: *[
         			for v in parameter.secret if v.mountPath != _|_ {
         		{
@@ -102,6 +113,17 @@ spec:
         			valueFrom: secretKeyRef: {
         				name: v.name
         				key:  v.mountToEnv.secretKey
+        			}
+        		}
+        	},
+        ] | []
+        secretMountToEnvsList: *[
+        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: secretKeyRef: {
+        				name: v.name
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -128,7 +150,7 @@ spec:
 
         	containers: [{
         		// +patchKey=name
-        		env: configMapEnvMountsList + secretEnvMountsList
+        		env: configMapEnvMountsList + secretEnvMountsList + configMountToEnvsList + secretMountToEnvsList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name
@@ -248,6 +270,10 @@ spec:
         			envName:      string
         			configMapKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:      string
+        			configMapKey: string
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -267,6 +293,10 @@ spec:
         			envName:   string
         			secretKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:   string
+        			secretKey: string
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/charts/vela-minimal/templates/defwithtemplate/storage.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/storage.yaml
@@ -87,6 +87,17 @@ spec:
         		}
         	},
         ] | []
+        configMountToEnvsList: *[
+        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: configMapKeyRef: {
+        				name: v.name
+        				key:  k.configMapKey
+        			}
+        		}
+        	},
+        ] | []
         secretVolumeMountsList: *[
         			for v in parameter.secret if v.mountPath != _|_ {
         		{
@@ -102,6 +113,17 @@ spec:
         			valueFrom: secretKeyRef: {
         				name: v.name
         				key:  v.mountToEnv.secretKey
+        			}
+        		}
+        	},
+        ] | []
+        secretMountToEnvsList: *[
+        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: secretKeyRef: {
+        				name: v.name
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -128,7 +150,7 @@ spec:
 
         	containers: [{
         		// +patchKey=name
-        		env: configMapEnvMountsList + secretEnvMountsList
+        		env: configMapEnvMountsList + secretEnvMountsList + configMountToEnvsList + secretMountToEnvsList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name
@@ -248,6 +270,10 @@ spec:
         			envName:      string
         			configMapKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:      string
+        			configMapKey: string
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -267,6 +293,10 @@ spec:
         			envName:   string
         			secretKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:   string
+        			secretKey: string
+        		}]
         		mountPath?:  string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/docs/examples/core-definitions/trait/storage.yaml
+++ b/docs/examples/core-definitions/trait/storage.yaml
@@ -32,6 +32,9 @@ spec:
                 mountToEnv:
                   envName: TEST_ENV
                   configMapKey: key1
+                mountToEnvs:
+                  - envName: TEST_CM_ENV
+                    configMapKey: key2
                 data:
                   key1: value1
                   key2: value2
@@ -49,9 +52,15 @@ spec:
                 mountToEnv:
                   envName: TEST_SECRET
                   secretKey: key1
+                mountToEnvs:
+                  - envName: TEST_SECRET_ENV_2
+                    secretKey: key2
+                  - envName: TEST_SECRET_ENV_3
+                    secretKey: key3
                 data:
                   key1: dmFsdWUx
                   key2: dmFsdWUy
+                  key3: dmFsdWUz
             emptyDir:
               - name: test1
                 mountPath: /test/mount/emptydir

--- a/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/application_controller_test.go
@@ -292,6 +292,35 @@ var _ = Describe("Test Application Controller", func() {
 		},
 	}
 
+	appWithMountToEnvs := &v1beta1.Application{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Application",
+			APIVersion: "core.oam.dev/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-with-mount-to-envs",
+		},
+		Spec: v1beta1.ApplicationSpec{
+			Components: []common.ApplicationComponent{
+				{
+					Name:       "myweb",
+					Type:       "worker",
+					Properties: &runtime.RawExtension{Raw: []byte("{\"cmd\":[\"sleep\",\"1000\"],\"image\":\"busybox\"}")},
+				},
+			},
+		},
+	}
+	appWithMountToEnvs.Spec.Components[0].Traits = []common.ApplicationTrait{
+		{
+			Type:       "storage",
+			Properties: &runtime.RawExtension{Raw: []byte("{\"secret\": [{\"name\": \"myweb-secret\",\"mountToEnv\": {\"envName\": \"firstEnv\",\"secretKey\": \"firstKey\"},\"mountToEnvs\": [{\"envName\": \"secondEnv\",\"secretKey\": \"secondKey\"}],\"data\": {\"firstKey\": \"dmFsdWUwMQo=\",\"secondKey\": \"dmFsdWUwMgo=\"}}]}")},
+		},
+		{
+			Type:       "storage",
+			Properties: &runtime.RawExtension{Raw: []byte("{\"configMap\": [{\"name\": \"myweb-cm\",\"mountToEnvs\": [{\"envName\":\"thirdEnv\",\"configMapKey\":\"thirdKey\"},{\"envName\":\"fourthEnv\",\"configMapKey\":\"fourthKey\"}],\"data\": {\"thirdKey\": \"Value03\",\"fourthKey\": \"Value04\"}}]}")},
+		},
+	}
+
 	cd := &v1beta1.ComponentDefinition{}
 	cDDefJson, _ := yaml.YAMLToJSON([]byte(componentDefYaml))
 	k8sObjectsCDJson, _ := yaml.YAMLToJSON([]byte(k8sObjectsComponentDefinitionYaml))
@@ -2568,6 +2597,66 @@ var _ = Describe("Test Application Controller", func() {
 		Expect(k8sClient.Delete(ctx, secret)).Should(BeNil())
 		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
 	})
+
+	It("test application with multi-mountToEnv will create application", func() {
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-with-mount-to-envs",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(BeNil())
+
+		appWithMountToEnvs.SetNamespace(ns.Name)
+		app := appWithMountToEnvs.DeepCopy()
+		Expect(k8sClient.Create(ctx, app)).Should(BeNil())
+
+		appKey := client.ObjectKey{
+			Name:      app.Name,
+			Namespace: app.Namespace,
+		}
+		testutil.ReconcileOnceAfterFinalizer(reconciler, reconcile.Request{NamespacedName: appKey})
+
+		By("Check App running successfully")
+		curApp := &v1beta1.Application{}
+		Expect(k8sClient.Get(ctx, appKey, curApp)).Should(BeNil())
+		Expect(curApp.Status.Phase).Should(Equal(common.ApplicationRunning))
+
+		appRevision := &v1beta1.ApplicationRevision{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: app.Namespace,
+			Name:      curApp.Status.LatestRevision.Name,
+		}, appRevision)).Should(BeNil())
+		By("Check affiliated resource tracker is created")
+		expectRTName := fmt.Sprintf("%s-%s", appRevision.GetName(), appRevision.GetNamespace())
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Name: expectRTName}, &v1beta1.ResourceTracker{})
+		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+		By("Check AppRevision Created with the expected workload spec")
+		appRev := &v1beta1.ApplicationRevision{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Name: app.Name + "-v1", Namespace: app.GetNamespace()}, appRev)
+		}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+		By("Check secret Created with the expected trait-storage spec")
+		secret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      app.Spec.Components[0].Name + "-secret",
+		}, secret)).Should(BeNil())
+
+		By("Check configMap Created with the expected trait-storage spec")
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      app.Spec.Components[0].Name + "-cm",
+		}, cm)).Should(BeNil())
+
+		Expect(k8sClient.Delete(ctx, cm)).Should(BeNil())
+		Expect(k8sClient.Delete(ctx, secret)).Should(BeNil())
+		Expect(k8sClient.Delete(ctx, app)).Should(BeNil())
+	})
 })
 
 const (
@@ -3604,6 +3693,17 @@ spec:
         		}
         	},
         ] | []
+        configMapMountToEnvsList: *[
+        			for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: configMapKeyRef: {
+        				name: v.name
+        				key:  k.configMapKey
+        			}
+        		}
+        	},
+        ] | []
         secretVolumeMountsList: *[
         			for v in parameter.secret if v.mountPath != _|_ {
         		{
@@ -3619,6 +3719,17 @@ spec:
         			valueFrom: secretKeyRef: {
         				name: v.name
         				key:  v.mountToEnv.secretKey
+        			}
+        		}
+        	},
+        ] | []
+        secretMountToEnvsList: *[
+        			for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+        		{
+        			name: k.envName
+        			valueFrom: secretKeyRef: {
+        				name: v.name
+        				key:  k.secretKey
         			}
         		}
         	},
@@ -3645,7 +3756,7 @@ spec:
 
         	containers: [{
         		// +patchKey=name
-        		env: configMapEnvMountsList + secretEnvMountsList
+        		env: configMapEnvMountsList + secretEnvMountsList + configMapMountToEnvsList + secretMountToEnvsList
         		// +patchKey=name
         		volumeDevices: volumeDevicesList
         		// +patchKey=name
@@ -3765,6 +3876,10 @@ spec:
         			envName:      string
         			configMapKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:      string
+        			configMapKey: string
+        		}]
         		mountPath?:   string
         		defaultMode: *420 | int
         		readOnly:    *false | bool
@@ -3784,6 +3899,10 @@ spec:
         			envName:   string
         			secretKey: string
         		}
+        		mountToEnvs?: [...{
+        			envName:   string
+        			secretKey: string
+        		}]
         		mountPath?:   string
         		defaultMode: *420 | int
         		readOnly:    *false | bool

--- a/vela-templates/definitions/internal/trait/storage.cue
+++ b/vela-templates/definitions/internal/trait/storage.cue
@@ -91,6 +91,18 @@ template: {
 		},
 	] | []
 
+	configMountToEnvsList: *[
+				for v in parameter.configMap if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+			{
+				name: k.envName
+				valueFrom: configMapKeyRef: {
+					name: v.name
+					key:  k.configMapKey
+				}
+			}
+		},
+	] | []
+
 	secretVolumeMountsList: *[
 				for v in parameter.secret if v.mountPath != _|_ {
 			{
@@ -107,6 +119,18 @@ template: {
 				valueFrom: secretKeyRef: {
 					name: v.name
 					key:  v.mountToEnv.secretKey
+				}
+			}
+		},
+	] | []
+
+	secretMountToEnvsList: *[
+				for v in parameter.secret if v.mountToEnvs != _|_ for k in v.mountToEnvs {
+			{
+				name: k.envName
+				valueFrom: secretKeyRef: {
+					name: v.name
+					key:  k.secretKey
 				}
 			}
 		},
@@ -136,7 +160,7 @@ template: {
 
 		containers: [{
 			// +patchKey=name
-			env: configMapEnvMountsList + secretEnvMountsList
+			env: configMapEnvMountsList + secretEnvMountsList + configMountToEnvsList + secretMountToEnvsList
 			// +patchKey=name
 			volumeDevices: volumeDevicesList
 			// +patchKey=name
@@ -260,6 +284,10 @@ template: {
 				envName:      string
 				configMapKey: string
 			}
+			mountToEnvs?: [...{
+				envName:      string
+				configMapKey: string
+			}]
 			mountPath?:  string
 			defaultMode: *420 | int
 			readOnly:    *false | bool
@@ -279,6 +307,10 @@ template: {
 				envName:   string
 				secretKey: string
 			}
+			mountToEnvs?: [...{
+				envName:   string
+				secretKey: string
+			}]
 			mountPath?:  string
 			defaultMode: *420 | int
 			readOnly:    *false | bool


### PR DESCRIPTION
Signed-off-by: Shijie Zhong <zhongsjie@cmbchina.com>


### Description of your changes
Support the multi-mountToEnv parameter of storage trait in secret and configmap. By this feature, we can mount multi-env in container env, without creating multi-secret or multi-configmap resrouces
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->