### PR TITLE
Fix: vela status tree show cluster alias & raw format

### DIFF
--- a/pkg/multicluster/virtual_cluster.go
+++ b/pkg/multicluster/virtual_cluster.go
@@ -233,3 +233,37 @@ func FindVirtualClustersByLabels(ctx context.Context, c client.Client, labels ma
 	}
 	return clusters, nil
 }
+
+// ClusterMapper mapper for clusters
+type ClusterMapper interface {
+	GetCluster(string) *VirtualCluster
+	GetClusterFullName(string) string
+}
+
+type clusterMapper map[string]*VirtualCluster
+
+// GetCluster .
+func (cm clusterMapper) GetCluster(cluster string) *VirtualCluster {
+	return cm[cluster]
+}
+
+// GetClusterFullName .
+func (cm clusterMapper) GetClusterFullName(cluster string) string {
+	if vc := cm.GetCluster(cluster); vc != nil {
+		return vc.FullName()
+	}
+	return ""
+}
+
+// NewClusterMapper load all clusters and return the mapper
+func NewClusterMapper(ctx context.Context, c client.Client) (ClusterMapper, error) {
+	cm := clusterMapper(make(map[string]*VirtualCluster))
+	clusters, err := ListVirtualClusters(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	for i := range clusters {
+		cm[clusters[i].Name] = &clusters[i]
+	}
+	return cm, nil
+}

--- a/pkg/resourcetracker/tree.go
+++ b/pkg/resourcetracker/tree.go
@@ -51,6 +51,7 @@ type ResourceDetailRetriever func(*resourceRow, string) error
 // ResourceTreePrintOptions print options for resource tree
 type ResourceTreePrintOptions struct {
 	DetailRetriever ResourceDetailRetriever
+	multicluster.ClusterMapper
 	// MaxWidth if set, the detail part will auto wrap
 	MaxWidth *int
 	// Format for details
@@ -138,7 +139,7 @@ func (options *ResourceTreePrintOptions) fillResourceRows(rows []*resourceRow, c
 		if row.mr.Namespace == "" {
 			row.mr.Namespace = "-"
 		}
-		row.cluster, row.namespace, row.resourceName = row.mr.Cluster, row.mr.Namespace, fmt.Sprintf("%s/%s", row.mr.Kind, row.mr.Name)
+		row.cluster, row.namespace, row.resourceName = options.ClusterMapper.GetClusterFullName(row.mr.Cluster), row.mr.Namespace, fmt.Sprintf("%s/%s", row.mr.Kind, row.mr.Name)
 		if row.status == resourceRowStatusNotDeployed {
 			row.resourceName = "-"
 		}
@@ -201,10 +202,14 @@ func (options *ResourceTreePrintOptions) _wrapDetails(detail string, width int) 
 	for _, row := range strings.Split(detail, "\n") {
 		var sb strings.Builder
 		row = strings.ReplaceAll(row, "\t", " ")
-		for _, token := range strings.Split(row, "  ") {
+		sep := "  "
+		if options.Format == "raw" {
+			sep = "\n"
+		}
+		for _, token := range strings.Split(row, sep) {
 			if sb.Len()+len(token)+2 <= width {
 				if sb.Len() > 0 {
-					sb.WriteString("  ")
+					sb.WriteString(sep)
 				}
 				sb.WriteString(token)
 			} else {

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -392,6 +392,10 @@ func printApplicationTree(c common.Args, cmd *cobra.Command, appName string, app
 		return errors.Wrapf(err, "failed to get cluster secret namespace, please ensure cluster gateway is correctly deployed")
 	}
 	multicluster.ClusterGatewaySecretNamespace = svc.Namespace
+	clusterMapper, err := multicluster.NewClusterMapper(ctx, cli)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get cluster mapper")
+	}
 
 	var placements []v1alpha1.PlacementDecision
 	af, err := pkgappfile.NewApplicationParser(cli, dm, pd).GenerateAppFile(context.Background(), app)
@@ -403,7 +407,7 @@ func printApplicationTree(c common.Args, cmd *cobra.Command, appName string, app
 	if w, _, err := term.GetSize(0); err == nil && w > 0 {
 		maxWidth = pointer.Int(w)
 	}
-	options := resourcetracker.ResourceTreePrintOptions{MaxWidth: maxWidth, Format: format}
+	options := resourcetracker.ResourceTreePrintOptions{MaxWidth: maxWidth, Format: format, ClusterMapper: clusterMapper}
 	printDetails, _ := cmd.Flags().GetBool("detail")
 	if printDetails {
 		msgRetriever, err := resourcetracker.RetrieveKubeCtlGetMessageGenerator(config)

--- a/test/e2e-multicluster-test/multicluster_cli_test.go
+++ b/test/e2e-multicluster-test/multicluster_cli_test.go
@@ -102,10 +102,13 @@ var _ = Describe("Test multicluster CLI commands", func() {
 		})
 
 		It("Test vela status --tree", func() {
+			_, err := execCommand("cluster", "alias", WorkerClusterName, "alias-worker-tree")
+			Expect(err).Should(Succeed())
 			for _, format := range []string{"inline", "wide", "table", "list"} {
 				outputs, err := execCommand("status", app.Name, "-n", namespace, "--tree", "--detail", "--detail-format", format)
 				Expect(err).Should(Succeed())
 				Expect(string(outputs)).Should(SatisfyAll(
+					ContainSubstring("alias-worker-tree"),
 					ContainSubstring("Deployment/exec-podinfo"),
 					ContainSubstring("updated"),
 					ContainSubstring("1/1"),


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1. `vela status --tree` show cluster alias.
2. `vela status --tree --detail --detail-format raw` fix format.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->