### PR TITLE
Fix: rt resource key compare mismatch local cluster

### DIFF
--- a/apis/core.oam.dev/v1beta1/resourcetracker_types.go
+++ b/apis/core.oam.dev/v1beta1/resourcetracker_types.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/apis/interfaces"
+	velatypes "github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils/errors"
 )
@@ -121,7 +122,11 @@ func (in ManagedResource) NamespacedName() types.NamespacedName {
 // ResourceKey computes the key for managed resource, resources with the same key points to the same resource
 func (in ManagedResource) ResourceKey() string {
 	gv, kind := in.GroupVersionKind().ToAPIVersionAndKind()
-	return strings.Join([]string{gv, kind, in.Cluster, in.Namespace, in.Name}, "/")
+	cluster := in.Cluster
+	if cluster == "" {
+		cluster = velatypes.ClusterLocalName
+	}
+	return strings.Join([]string{gv, kind, cluster, in.Namespace, in.Name}, "/")
 }
 
 // ComponentKey computes the key for the component which managed resource belongs to

--- a/apis/types/multicluster.go
+++ b/apis/types/multicluster.go
@@ -22,6 +22,9 @@ import (
 )
 
 const (
+	// ClusterLocalName the name for the hub cluster
+	ClusterLocalName = "local"
+
 	// CredentialTypeInternal identifies the virtual cluster from internal kubevela system
 	CredentialTypeInternal v1alpha1.CredentialType = "Internal"
 	// CredentialTypeOCMManagedCluster identifies the virtual cluster from ocm

--- a/pkg/multicluster/utils.go
+++ b/pkg/multicluster/utils.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	velatypes "github.com/oam-dev/kubevela/apis/types"
 	"github.com/oam-dev/kubevela/pkg/oam"
 	"github.com/oam-dev/kubevela/pkg/utils/common"
 	errors3 "github.com/oam-dev/kubevela/pkg/utils/errors"
@@ -46,7 +47,7 @@ const (
 	// ClusterContextKey is the name of cluster using in client http context
 	ClusterContextKey = contextKey("ClusterName")
 	// ClusterLocalName specifies the local cluster
-	ClusterLocalName = "local"
+	ClusterLocalName = velatypes.ClusterLocalName
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When application is not using multi-cluster, the recorded resources will set cluster to "". But if using multi-cluster, the local cluster will be recorded as "local".

So if one application is upgrading from non-multi-cluster to multi-cluster, the recorded resources will mismatch, which will lead to some in-use resources being mis-recycled. This PR fixes it.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->

Related to #3667 .