### PR TITLE
Fix: set provider name as the config name

### DIFF
--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -73,8 +73,8 @@ const (
 	LabelConfigSyncToMultiCluster = "config.oam.dev/multi-cluster"
 	// LabelConfigIdentifier is the label for config identifier
 	LabelConfigIdentifier = "config.oam.dev/identifier"
-	// LabelConfigDescription is the label for config description
-	LabelConfigDescription = "config.oam.dev/description"
+	// AnnotationConfigDescription is the annotation for config description
+	AnnotationConfigDescription = "config.oam.dev/description"
 	// AnnotationConfigAlias is the annotation for config alias
 	AnnotationConfigAlias = "config.oam.dev/alias"
 )
@@ -147,4 +147,9 @@ const (
 	ImageRegistry = "config-image-registry"
 	// HelmRepository is the config type for Helm chart repository
 	HelmRepository = "config-helm-repository"
+)
+
+const (
+	// TerrfaormComponentPrefix is the prefix of component type of terraform-xxx
+	TerrfaormComponentPrefix = "terraform-"
 )

--- a/pkg/apiserver/rest/apis/v1/types.go
+++ b/pkg/apiserver/rest/apis/v1/types.go
@@ -202,6 +202,7 @@ type Config struct {
 	Name              string                  `json:"name"`
 	Project           string                  `json:"project"`
 	Identifier        string                  `json:"identifier"`
+	Alias             string                  `json:"alias"`
 	Description       string                  `json:"description"`
 	CreatedTime       *time.Time              `json:"createdTime"`
 	UpdatedTime       *time.Time              `json:"updatedTime"`
@@ -411,6 +412,7 @@ type CreateApplicationRequest struct {
 type CreateConfigRequest struct {
 	Name          string `json:"name" validate:"checkname"`
 	Alias         string `json:"alias"`
+	Description   string `json:"description"`
 	Project       string `json:"project"`
 	ComponentType string `json:"componentType" validate:"checkname"`
 	Properties    string `json:"properties,omitempty"`

--- a/pkg/apiserver/rest/usecase/config_test.go
+++ b/pkg/apiserver/rest/usecase/config_test.go
@@ -236,6 +236,11 @@ func TestCreateConfig(t *testing.T) {
 
 	ctx := context.Background()
 
+	properties, err := json.Marshal(map[string]interface{}{
+		"name": "default",
+	})
+	assert.NilError(t, err)
+
 	testcases := []struct {
 		name string
 		args args
@@ -249,6 +254,18 @@ func TestCreateConfig(t *testing.T) {
 					Name:          "a",
 					ComponentType: "b",
 					Project:       "c",
+				},
+			},
+		},
+		{
+			name: "create terraform-alibaba config",
+			args: args{
+				h: h,
+				req: apis.CreateConfigRequest{
+					Name:          "n1",
+					ComponentType: "terraform-alibaba",
+					Project:       "p1",
+					Properties:    string(properties),
 				},
 			},
 		},

--- a/references/cli/provider.go
+++ b/references/cli/provider.go
@@ -193,7 +193,7 @@ func prepareProviderAddSubCommand(c common.Args, ioStreams cmdutil.IOStreams) ([
 				}
 				data, err := json.Marshal(properties)
 				if err != nil {
-					return fmt.Errorf("failed to authentiate Terraform cloud provier %s", providerType)
+					return fmt.Errorf("failed to authenticate Terraform cloud provider %s", providerType)
 				}
 				providerAppName := fmt.Sprintf("config-terraform-provider-%s", name)
 				a := &v1beta1.Application{}
@@ -217,12 +217,12 @@ func prepareProviderAddSubCommand(c common.Args, ioStreams cmdutil.IOStreams) ([
 							},
 						}
 						if err := k8sClient.Create(ctx, a); err != nil {
-							return fmt.Errorf("failed to authentiate Terraform cloud provier %s", providerType)
+							return fmt.Errorf("failed to authenticate Terraform cloud provider %s", providerType)
 						}
-						ioStreams.Infof("Successfully authentiate provider %s for %s\n", name, providerType)
+						ioStreams.Infof("Successfully authenticate provider %s for %s\n", name, providerType)
 						return nil
 					}
-					return fmt.Errorf("failed to authentiate Terraform cloud provier %s", providerType)
+					return fmt.Errorf("failed to authenticate Terraform cloud provider %s", providerType)
 				}
 				return fmt.Errorf("terraform provider %s for %s already exists", name, providerType)
 			}


### PR DESCRIPTION
- For VelaUX, users don't need to manually set the provider name. Used
the application/component name (config name) to be the provider name.
- Store the description of a config to the annotation of the config application

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->