### PR TITLE
Fix: vela-cli does not print cluster name, if application installed i…

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -37,8 +37,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/gosuri/uitable"
-	"github.com/olekukonko/tablewriter"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	types2 "k8s.io/apimachinery/pkg/types"
@@ -193,16 +191,10 @@ Enable addon for specific clusters, (local means control plane):
 
 // AdditionalEndpointPrinter will print endpoints
 func AdditionalEndpointPrinter(ctx context.Context, c common.Args, k8sClient client.Client, name string) {
-	endpoints, _ := GetServiceEndpoints(ctx, k8sClient, pkgaddon.Convert2AppName(name), types.DefaultKubeVelaNS, c, Filter{})
-	if len(endpoints) > 0 {
-		table := tablewriter.NewWriter(os.Stdout)
-		table.SetColWidth(100)
-		table.SetHeader([]string{"Cluster", "Component", "Ref(Kind/Namespace/Name)", "Endpoint"})
-		for _, endpoint := range endpoints {
-			table.Append([]string{endpoint.Cluster, endpoint.Component, fmt.Sprintf("%s/%s/%s", endpoint.Ref.Kind, endpoint.Ref.Namespace, endpoint.Ref.Name), endpoint.String()})
-		}
-		fmt.Printf("Please access the %s from the following endpoints:\n", name)
-		table.Render()
+	fmt.Printf("Please access the %s from the following endpoints:\n", name)
+	err := printAppEndpoints(ctx, k8sClient, pkgaddon.Convert2AppName(name), types.DefaultKubeVelaNS, Filter{}, c)
+	if err != nil {
+		fmt.Println("Get application endpoints error:", err)
 		return
 	}
 	if name == "velaux" {

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -172,6 +172,9 @@ func printAppEndpoints(ctx context.Context, client client.Client, appName string
 	table.SetColWidth(100)
 	table.SetHeader([]string{"Cluster", "Component", "Ref(Kind/Namespace/Name)", "Endpoint"})
 	for _, endpoint := range endpoints {
+		if endpoint.Cluster == "" {
+			endpoint.Cluster = multicluster.ClusterLocalName
+		}
 		table.Append([]string{endpoint.Cluster, endpoint.Component, fmt.Sprintf("%s/%s/%s", endpoint.Ref.Kind, endpoint.Ref.Namespace, endpoint.Ref.Name), endpoint.String()})
 	}
 	table.Render()


### PR DESCRIPTION
Fix vela-cli does not print cluster name, if application installed in default cluster

Signed-off-by: StevenLeiZhang <zhangleiic@163.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #3690 


How to fix it?
1. show default name of cluster as what `vela addon status` did

```
➜  bin git:(fix-clus) ✗  ./vela addon enable velaux --version=v1.3.1   serviceType=NodePort

#ignore something here
Please access the velaux from the following endpoints:
+---------+-----------+----------------------------+---------------------------+
| CLUSTER | COMPONENT |  REF(KIND/NAMESPACE/NAME)  |         ENDPOINT          |
+---------+-----------+----------------------------+---------------------------+
| local   | velaux    | Service/vela-system/velaux | http://192.168.65.4:30256 |
+---------+-----------+----------------------------+---------------------------+
To check the initialized admin user name and password by:
    vela logs -n vela-system --name apiserver addon-velaux | grep "initialized admin username"
To open the dashboard directly by port-forward:
    vela port-forward -n vela-system addon-velaux 9082:80
Select "Cluster: local | Namespace: vela-system | Component: velaux | Kind: Service" from the prompt.
Please refer to https://kubevela.io/docs/reference/addons/velaux for more VelaUX addon installation and visiting method.


```


```
➜  bin git:(fix-clus) ✗  ./vela -n vela-system status addon-velaux --endpoint=true
+---------+-----------+----------------------------+---------------------------+
| CLUSTER | COMPONENT |  REF(KIND/NAMESPACE/NAME)  |         ENDPOINT          |
+---------+-----------+----------------------------+---------------------------+
| local   | velaux    | Service/vela-system/velaux | http://192.168.65.4:30256 |
+---------+-----------+----------------------------+---------------------------+

```

```
➜  bin git:(fix-clus) ✗ ./vela addon status  velaux
addon velaux status is enabled 
installedVersion: v1.3.1 
installedClusters: [local] 

```


2. reuse code
since [func printAppEndpoints(ctx context.Context, client client.Client, appName string, namespace string, f Filter, velaC common.Args)](https://github.com/oam-dev/kubevela/blob/eb60d94a0638ed9132b1c4590f255d6fe00a4c19/references/cli/status.go#L166) already exists, just reuse it to avoid duplicate code


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->