### PR TITLE
Feat: vela def gen-api command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,6 +110,7 @@ require (
 )
 
 require (
+	github.com/fatih/camelcase v1.0.0
 	cloud.google.com/go v0.81.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -163,7 +164,6 @@ require (
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.1.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
-	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,6 @@ require (
 )
 
 require (
-	github.com/fatih/camelcase v1.0.0
 	cloud.google.com/go v0.81.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
@@ -164,6 +163,7 @@ require (
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.1.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
+	github.com/fatih/camelcase v1.0.0
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect

--- a/pkg/definition/go_gen.go
+++ b/pkg/definition/go_gen.go
@@ -159,6 +159,7 @@ func parseParameters(paraValue cue.Value, paramKey string) error {
 	return nil
 }
 
+// GenGoCodeFromParams generates go code from parameters
 func GenGoCodeFromParams(parameters []StructParameter) (string, error) {
 	var buf bytes.Buffer
 
@@ -203,10 +204,9 @@ func genField(param StructParameter, buffer *bytes.Buffer) {
 	} else {
 		fmt.Fprintf(buffer, "type %s %s\n", fieldName, param.GoType)
 	}
-	return
 }
 
-// trimIncompleteKind allows 2 types of incomplete kind, return the non-null kind, more than two types of incomplete kind will return error
+// trimIncompleteKind allows 2 types of incomplete kind, return the non-null one, more than two types of incomplete kind will return error
 // 1. (null|someKind)
 // 2. someKind
 func trimIncompleteKind(mask string) (string, error) {

--- a/pkg/definition/go_gen.go
+++ b/pkg/definition/go_gen.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package definition
 
 import (

--- a/pkg/definition/go_gen.go
+++ b/pkg/definition/go_gen.go
@@ -1,0 +1,272 @@
+package definition
+
+import (
+	"bytes"
+	"cuelang.org/go/cue"
+	"fmt"
+	"go/format"
+	"strings"
+	"unicode"
+
+	"github.com/fatih/camelcase"
+	"github.com/oam-dev/kubevela/apis/types"
+	velacue "github.com/oam-dev/kubevela/pkg/cue"
+	"github.com/pkg/errors"
+)
+
+type StructParameter struct {
+	types.Parameter
+	// GoType is the same to parameter.Type but can be print in Go
+	GoType string
+	Fields []Field
+}
+
+type Field struct {
+	Name   string
+	Type   string
+	GoType string
+}
+
+//nolint:gochecknoglobals
+var (
+	WellKnownAbbreviations = map[string]bool{
+		"API":   true,
+		"DB":    true,
+		"HTTP":  true,
+		"HTTPS": true,
+		"ID":    true,
+		"JSON":  true,
+		"OS":    true,
+		"SQL":   true,
+		"SSH":   true,
+		"URI":   true,
+		"URL":   true,
+		"XML":   true,
+		"YAML":  true,
+
+		"CPU": true,
+		"PVC": true,
+	}
+
+	dm = &AbbreviationHandlingFieldNamer{
+		Abbreviations: WellKnownAbbreviations,
+	}
+)
+
+// A FieldNamer generates a Go field name from a CUE label.
+type FieldNamer interface {
+	FieldName(label string) string
+}
+
+var structs []StructParameter
+
+func GeneratorParameterStructs(param cue.Value) ([]StructParameter,error) {
+	structs = []StructParameter{}
+	err := parseParameters(param, "Parameter")
+	return structs,err
+}
+
+func NewStructParameter() StructParameter {
+	return StructParameter{
+		Parameter: types.Parameter{},
+		GoType:    "",
+		Fields:    []Field{},
+	}
+}
+
+func parseParameters(paraValue cue.Value, paramKey string) error {
+	param := NewStructParameter()
+	param.Name = paramKey
+	param.Type = paraValue.IncompleteKind()
+	param.Short, param.Usage, param.Alias, param.Ignore = velacue.RetrieveComments(paraValue)
+	if def, ok := paraValue.Default(); ok && def.IsConcrete() {
+		param.Default = velacue.GetDefault(def)
+	}
+
+	switch param.Type {
+	case cue.StructKind:
+		arguments, err := paraValue.Struct()
+		if err != nil {
+			return fmt.Errorf("augument not as struct %w", err)
+		}
+		if arguments.Len() == 0 {
+			var SubParam StructParameter
+			SubParam.Name = "-"
+			SubParam.Required = true
+			tl := paraValue.Template()
+			if tl != nil { // is map type
+				kind, err := trimIncompleteKind(tl("").IncompleteKind().String())
+				if err != nil {
+					return errors.Wrap(err, "invalid parameter kind")
+				}
+				SubParam.GoType = kind
+				// TODO: better way to name to subParam
+				SubParam.Name = "Item"
+				param.GoType = fmt.Sprintf("map[string]%s", SubParam.Name)
+				structs = append(structs, SubParam)
+			}
+		}
+		for i := 0; i < arguments.Len(); i++ {
+			var subParam Field
+			fi := arguments.Field(i)
+			if fi.IsDefinition {
+				continue
+			}
+			val := fi.Value
+			name := fi.Name
+			subParam.Name = name
+			switch val.IncompleteKind() {
+			case cue.StructKind:
+				if subField, err := val.Struct(); err == nil && subField.Len() == 0 { // err cannot be not nil,so ignore it
+					if mapValue, ok := val.Elem(); ok {
+						// In the future we could recursively call to support complex map-value(struct or list)
+						subParam.GoType = fmt.Sprintf("map[string]%s", mapValue.IncompleteKind().String())
+					} else {
+						return fmt.Errorf("failed to got Map kind from %s", subParam.Name)
+					}
+				} else {
+					if err := parseParameters(val, name); err != nil {
+						return err
+					}
+					subParam.GoType = dm.FieldName(name)
+				}
+			case cue.ListKind:
+				elem, success := val.Elem()
+				if !success {
+					// fail to get elements, use the value of ListKind to be the type
+					subParam.GoType = val.IncompleteKind().String()
+					break
+				}
+				switch elem.Kind() {
+				case cue.StructKind:
+					subParam.GoType = fmt.Sprintf("[]%s", dm.FieldName(name))
+					if err := parseParameters(elem, name); err != nil {
+						return err
+					}
+				default:
+					subParam.GoType = fmt.Sprintf("[]%s", elem.IncompleteKind().String())
+				}
+			default:
+				subParam.GoType = val.IncompleteKind().String()
+			}
+			param.Fields = append(param.Fields, Field{
+				Name:   subParam.Name,
+				GoType: subParam.GoType,
+			})
+		}
+	}
+	structs = append(structs, param)
+	return nil
+}
+
+// PrintParamGosStruct prints the StructParameter in Golang struct format
+func PrintParamGosStruct(parameters []StructParameter) {
+	for _, parameter := range parameters {
+		if parameter.Usage == "" {
+			parameter.Usage = "-"
+		}
+		fmt.Printf("// %s %s\n", dm.FieldName(parameter.Name), parameter.Usage)
+		printField(parameter)
+	}
+}
+
+func printField(param StructParameter) {
+	buffer := &bytes.Buffer{}
+	fieldName := dm.FieldName(param.Name)
+	switch param.Type {
+	case cue.StructKind:
+		// struct in cue can be map or struct
+		if strings.HasPrefix(param.GoType, "map[string]") {
+			fmt.Fprintf(buffer, "type %s %s", fieldName, param.GoType)
+		} else {
+			fmt.Fprintf(buffer, "type %s struct {\n", fieldName)
+			for _, f := range param.Fields {
+				fmt.Fprintf(buffer, "    %s %s `json:\"%s\"`\n", dm.FieldName(f.Name), f.GoType, f.Name)
+			}
+
+			fmt.Fprintf(buffer, "}\n")
+		}
+	case cue.StringKind:
+		fmt.Fprintf(buffer, "type %s string\n", fieldName)
+	case cue.IntKind:
+		fmt.Fprintf(buffer, "type %s int\n", fieldName)
+	case cue.BoolKind:
+		fmt.Fprintf(buffer, "type %s bool\n", fieldName)
+	case cue.FloatKind:
+		fmt.Fprintf(buffer, "type %s float64\n", fieldName)
+	case cue.ListKind:
+		fmt.Fprintf(buffer, "type %s []%s\n", fieldName, param.GoType)
+	default:
+		fmt.Fprintf(buffer, "type %s %s\n", fieldName, param.GoType)
+	}
+	source, err := format.Source(buffer.Bytes())
+	if err != nil {
+		fmt.Println("Failed to format source:", err)
+	}
+	//fmt.Println(buffer.String())
+	fmt.Println(string(source))
+}
+
+func trimIncompleteKind(mask string) (string, error) {
+	mask = strings.Trim(mask, "()")
+	ks := strings.Split(mask, "|")
+	if len(ks) == 1 {
+		return ks[0], nil
+	}
+	if len(ks) == 2 && ks[0] == "null" {
+		return ks[1], nil
+	}
+	return "", fmt.Errorf("invalid incomplete kind: %s", mask)
+
+}
+
+
+// An AbbreviationHandlingFieldNamer generates Go field names from JSON
+// properties while keeping abbreviations uppercased.
+type AbbreviationHandlingFieldNamer struct {
+	Abbreviations map[string]bool
+}
+
+// FieldName implements FieldNamer.FieldName.
+func (a *AbbreviationHandlingFieldNamer) FieldName(property string) string {
+	components := SplitComponents(property)
+	for i, component := range components {
+		switch {
+		case component == "":
+			// do nothing
+		case a.Abbreviations[strings.ToUpper(component)]:
+			components[i] = strings.ToUpper(component)
+		case component == strings.ToUpper(component):
+			runes := []rune(component)
+			components[i] = string(runes[0]) + strings.ToLower(string(runes[1:]))
+		default:
+			runes := []rune(component)
+			runes[0] = unicode.ToUpper(runes[0])
+			components[i] = string(runes)
+		}
+	}
+	runes := []rune(strings.Join(components, ""))
+	for i, r := range runes {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			runes[i] = '_'
+		}
+	}
+	fieldName := string(runes)
+	if !unicode.IsLetter(runes[0]) && runes[0] != '_' {
+		fieldName = "_" + fieldName
+	}
+	return fieldName
+}
+
+// SplitComponents splits name into components. name may be kebab case, snake
+// case, or camel case.
+func SplitComponents(name string) []string {
+	switch {
+	case strings.ContainsRune(name, '-'):
+		return strings.Split(name, "-")
+	case strings.ContainsRune(name, '_'):
+		return strings.Split(name, "_")
+	default:
+		return camelcase.Split(name)
+	}
+}

--- a/pkg/definition/go_gen.go
+++ b/pkg/definition/go_gen.go
@@ -77,6 +77,7 @@ type FieldNamer interface {
 	SetPrefix(string)
 }
 
+// NewFieldNamer returns a new FieldNamer.
 func NewFieldNamer(prefix string) FieldNamer {
 	return &AbbrFieldNamer{Prefix: prefix, Abbreviations: WellKnownAbbreviations}
 }

--- a/pkg/definition/go_gen.go
+++ b/pkg/definition/go_gen.go
@@ -2,18 +2,21 @@ package definition
 
 import (
 	"bytes"
-	"cuelang.org/go/cue"
 	"fmt"
 	"go/format"
 	"strings"
 	"unicode"
 
+	"cuelang.org/go/cue"
+
 	"github.com/fatih/camelcase"
+	"github.com/pkg/errors"
+
 	"github.com/oam-dev/kubevela/apis/types"
 	velacue "github.com/oam-dev/kubevela/pkg/cue"
-	"github.com/pkg/errors"
 )
 
+// StructParameter is a parameter that can be printed as a struct.
 type StructParameter struct {
 	types.Parameter
 	// GoType is the same to parameter.Type but can be print in Go
@@ -21,6 +24,7 @@ type StructParameter struct {
 	Fields []Field
 }
 
+// Field is a field of a struct.
 type Field struct {
 	Name   string
 	Type   string
@@ -60,12 +64,14 @@ type FieldNamer interface {
 
 var structs []StructParameter
 
-func GeneratorParameterStructs(param cue.Value) ([]StructParameter,error) {
+// GeneratorParameterStructs generates structs for parameters in cue.
+func GeneratorParameterStructs(param cue.Value) ([]StructParameter, error) {
 	structs = []StructParameter{}
 	err := parseParameters(param, "Parameter")
-	return structs,err
+	return structs, err
 }
 
+// NewStructParameter creates a StructParameter
 func NewStructParameter() StructParameter {
 	return StructParameter{
 		Parameter: types.Parameter{},
@@ -83,8 +89,7 @@ func parseParameters(paraValue cue.Value, paramKey string) error {
 		param.Default = velacue.GetDefault(def)
 	}
 
-	switch param.Type {
-	case cue.StructKind:
+	if param.Type == cue.StructKind {
 		arguments, err := paraValue.Struct()
 		if err != nil {
 			return fmt.Errorf("augument not as struct %w", err)
@@ -203,7 +208,6 @@ func printField(param StructParameter) {
 	if err != nil {
 		fmt.Println("Failed to format source:", err)
 	}
-	//fmt.Println(buffer.String())
 	fmt.Println(string(source))
 }
 
@@ -219,7 +223,6 @@ func trimIncompleteKind(mask string) (string, error) {
 	return "", fmt.Errorf("invalid incomplete kind: %s", mask)
 
 }
-
 
 // An AbbreviationHandlingFieldNamer generates Go field names from JSON
 // properties while keeping abbreviations uppercased.

--- a/pkg/definition/go_gen.go
+++ b/pkg/definition/go_gen.go
@@ -109,11 +109,11 @@ func parseParameters(paraValue cue.Value, paramKey string) error {
 	if param.Type == cue.StructKind {
 		arguments, err := paraValue.Struct()
 		if err != nil {
-			return fmt.Errorf("augument not as struct %w", err)
+			return fmt.Errorf("augument not as struct: %w", err)
 		}
-		if arguments.Len() == 0 { // in cue, struct like: foo: map[string]int
+		if arguments.Len() == 0 { // in cue, empty struct like: foo: map[string]int
 			tl := paraValue.Template()
-			if tl != nil { // is map type
+			if tl != nil { // map type
 				// TODO: kind maybe not simple type like string/int, if it is a struct, parseParameters should be called
 				kind, err := trimIncompleteKind(tl("").IncompleteKind().String())
 				if err != nil {
@@ -138,7 +138,8 @@ func parseParameters(paraValue cue.Value, paramKey string) error {
 						// In the future we could recursively call to support complex map-value(struct or list)
 						subParam.GoType = fmt.Sprintf("map[string]%s", mapValue.IncompleteKind().String())
 					} else {
-						return fmt.Errorf("failed to got Map kind from %s", subParam.Name)
+						// element in struct not defined, use interface{}
+						subParam.GoType = "map[string]interface{}"
 					}
 				} else {
 					if err := parseParameters(val, name); err != nil {

--- a/pkg/definition/go_gen_test.go
+++ b/pkg/definition/go_gen_test.go
@@ -301,6 +301,7 @@ func TestGenAllDef(t *testing.T) {
 				err = def.FromCUEString(string(file), nil)
 				assert.NoError(t, err)
 				templateString, _, err := unstructured.NestedString(def.Object, DefinitionTemplateKeys...)
+				assert.NoError(t, err)
 				value, err := common.GetCUEParameterValue(templateString, nil)
 				assert.NoError(t, err)
 				_, err = GeneratorParameterStructs(value)

--- a/pkg/definition/go_gen_test.go
+++ b/pkg/definition/go_gen_test.go
@@ -106,6 +106,12 @@ func TestGeneratorParameterStructs(t *testing.T) {
 			err:      false,
 			expected: structsWithMap,
 		},
+		{
+			name:     "map element not defined",
+			cue:      defWithEmptyMap,
+			err:      false,
+			expected: structWithInterface,
+		},
 	}
 	for _, tc := range testCases {
 		value, err := common.GetCUEParameterValue(tc.cue, nil)
@@ -129,6 +135,7 @@ func TestGenGoCodeFromParams(t *testing.T) {
 		{structs: structsWithList, result: resultWithList},
 		{structs: structsWithStructList, result: resultWithStructList},
 		{structs: structsWithMap, result: resultWithMap},
+		{structs: structWithInterface, result: resultWithInterface},
 	}
 	for _, tc := range testCases {
 		actual, err := GenGoCodeFromParams(tc.structs)
@@ -159,8 +166,11 @@ var (
 				medium:    *"" | "Memory"
 			}]
 	}`
-	defWithMap = `parameter: [string]: string | null
-`
+	defWithMap      = `parameter: [string]: string | null`
+	defWithEmptyMap = `
+	parameter: {
+		data: {}
+	}`
 
 	structsWithStruct = []StructParameter{
 		{
@@ -238,9 +248,22 @@ var (
 			Fields: []Field{},
 		},
 	}
+	structWithInterface = []StructParameter{
+		{
+			Parameter: types.Parameter{
+				Type: cue.StructKind,
+				Name: "Parameter",
+			},
+			GoType: "",
+			Fields: []Field{
+				{Name: "data", GoType: "map[string]interface{}"},
+			},
+		},
+	}
 
 	resultWithStruct     = "// HTTP Specify the mapping relationship between the http path and the workload port\ntype HTTP struct {\n\tPath int `json:\"path\"`\n}\n\n// Parameter -\ntype Parameter struct {\n\tHTTP HTTP `json:\"http\"`\n}\n"
 	resultWithList       = "// Parameter -\ntype Parameter struct {\n\tHTTP map[string]int `json:\"http\"`\n}\n"
 	resultWithStructList = "// EmptyDir -\ntype EmptyDir struct {\n\tName      string `json:\"name\"`\n\tMountPath string `json:\"mountPath\"`\n\tMedium    string `json:\"medium\"`\n}\n\n// Parameter -\ntype Parameter struct {\n\tEmptyDir []EmptyDir `json:\"emptyDir\"`\n}\n"
 	resultWithMap        = "// Parameter -\ntype Parameter map[string]string"
+	resultWithInterface  = "// Parameter -\ntype Parameter struct {\n\tData map[string]interface{} `json:\"data\"`\n}\n"
 )

--- a/pkg/definition/go_gen_test.go
+++ b/pkg/definition/go_gen_test.go
@@ -1,0 +1,22 @@
+package definition
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultFieldNamer(t *testing.T) {
+	for name, expected := range map[string]string{
+		"id":         "ID",
+		"foo":        "Foo",
+		"foo_bar":    "FooBar",
+		"fooBar":     "FooBar",
+		"FOO_BAR":    "FooBar",
+		"FOO_BAR_ID": "FooBarID",
+		"123":        "_123",
+		"A|B":        "A_B",
+	} {
+		assert.Equal(t, expected, dm.FieldName(name))
+	}
+}

--- a/pkg/definition/go_gen_test.go
+++ b/pkg/definition/go_gen_test.go
@@ -130,9 +130,9 @@ func TestGeneratorParameterStructs(t *testing.T) {
 			expected: structWithInterface,
 		},
 		{
-			name: "omitempty",
-			cue:  defWithOptional,
-			err:  false,
+			name:     "omitempty",
+			cue:      defWithOptional,
+			err:      false,
 			expected: structWithOptional,
 		},
 	}

--- a/pkg/definition/go_gen_test.go
+++ b/pkg/definition/go_gen_test.go
@@ -3,6 +3,12 @@ package definition
 import (
 	"testing"
 
+	"cuelang.org/go/cue"
+	assert2 "gotest.tools/assert"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,3 +26,205 @@ func TestDefaultFieldNamer(t *testing.T) {
 		assert.Equal(t, expected, dm.FieldName(name))
 	}
 }
+
+func TestTrimIncompleteKind(t *testing.T) {
+	incompleteKinds := []struct {
+		kind     string
+		expected string
+		err      bool
+	}{
+		{
+			kind:     "string",
+			expected: "string",
+			err:      false,
+		},
+		{
+			kind:     "(null|string)",
+			expected: "string",
+			err:      false,
+		},
+		{
+			kind: "(null|string|int)",
+			err:  true,
+		},
+	}
+	for _, k := range incompleteKinds {
+		actual, err := trimIncompleteKind(k.kind)
+		if k.err {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, k.expected, actual)
+		}
+	}
+}
+
+func TestGeneratorParameterStructs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cue      string
+		expected []StructParameter
+		err      bool
+	}{
+		{
+			name:     "go struct",
+			cue:      defWithStruct,
+			err:      false,
+			expected: structsWithStruct,
+		},
+		{
+			name:     "go list",
+			cue:      defWithList,
+			err:      false,
+			expected: structsWithList,
+		},
+		{
+			name:     "go struct list",
+			cue:      defWithStructList,
+			err:      false,
+			expected: structsWithStructList,
+		},
+		{
+			name:     "go map",
+			cue:      defWithMap,
+			err:      false,
+			expected: structsWithMap,
+		},
+	}
+	for _, tc := range testCases {
+		value, err := common.GetCUEParameterValue(tc.cue, nil)
+		assert.NoError(t, err)
+		actual, err := GeneratorParameterStructs(value)
+		if tc.err {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert2.DeepEqual(t, tc.expected, actual)
+		}
+	}
+}
+
+func TestGenGoCodeFromParams(t *testing.T) {
+	testCases := []struct {
+		structs []StructParameter
+		result  string
+	}{
+		{structs: structsWithStruct, result: resultWithStruct},
+		{structs: structsWithList, result: resultWithList},
+		{structs: structsWithStructList, result: resultWithStructList},
+		{structs: structsWithMap, result: resultWithMap},
+	}
+	for _, tc := range testCases {
+		actual, err := GenGoCodeFromParams(tc.structs)
+		if err != nil {
+			return
+		}
+		assert.Equal(t, tc.result, actual)
+	}
+}
+
+var (
+	defWithStruct = `
+	parameter: {
+		// +usage=Specify the mapping relationship between the http path and the workload port
+		http: {
+			path: int
+		}
+	}`
+	defWithList = `
+	parameter: {
+		http: [string]: int
+	}`
+	defWithStructList = `
+	parameter: {
+		emptyDir?: [...{
+				name:      string
+				mountPath: string
+				medium:    *"" | "Memory"
+			}]
+	}`
+	defWithMap = `parameter: [string]: string | null
+`
+
+	structsWithStruct = []StructParameter{
+		{
+			Parameter: types.Parameter{
+				Name:  "http",
+				Type:  cue.StructKind,
+				Usage: "Specify the mapping relationship between the http path and the workload port",
+			},
+			Fields: []Field{
+				{
+					Name:   "path",
+					GoType: "int",
+				},
+			},
+		},
+		{
+			Parameter: types.Parameter{
+				Type: cue.StructKind,
+				Name: "Parameter",
+			},
+			Fields: []Field{
+				{
+					Name:   "http",
+					GoType: "HTTP",
+				},
+			},
+		},
+	}
+	structsWithList = []StructParameter{
+		{
+			Parameter: types.Parameter{
+				Type: cue.StructKind,
+				Name: "Parameter",
+			},
+			Fields: []Field{
+				{
+					Name:   "http",
+					GoType: "map[string]int",
+				},
+			},
+		},
+	}
+	structsWithStructList = []StructParameter{
+		{
+			Parameter: types.Parameter{
+				Type: cue.StructKind,
+				Name: "emptyDir",
+			},
+			Fields: []Field{
+				{Name: "name", GoType: "string"},
+				{Name: "mountPath", GoType: "string"},
+				{Name: "medium", GoType: "string"},
+			},
+		},
+		{
+			Parameter: types.Parameter{
+				Type: cue.StructKind,
+				Name: "Parameter",
+			},
+			Fields: []Field{
+				{
+					Name:   "emptyDir",
+					GoType: "[]EmptyDir",
+				},
+			},
+		},
+	}
+	structsWithMap = []StructParameter{
+		{
+			Parameter: types.Parameter{
+				Type: cue.StructKind,
+				Name: "Parameter",
+			},
+			GoType: "map[string]string",
+			Fields: []Field{},
+		},
+	}
+
+	resultWithStruct     = "// HTTP Specify the mapping relationship between the http path and the workload port\ntype HTTP struct {\n\tPath int `json:\"path\"`\n}\n\n// Parameter -\ntype Parameter struct {\n\tHTTP HTTP `json:\"http\"`\n}\n"
+	resultWithList       = "// Parameter -\ntype Parameter struct {\n\tHTTP map[string]int `json:\"http\"`\n}\n"
+	resultWithStructList = "// EmptyDir -\ntype EmptyDir struct {\n\tName      string `json:\"name\"`\n\tMountPath string `json:\"mountPath\"`\n\tMedium    string `json:\"medium\"`\n}\n\n// Parameter -\ntype Parameter struct {\n\tEmptyDir []EmptyDir `json:\"emptyDir\"`\n}\n"
+	resultWithMap        = "// Parameter -\ntype Parameter map[string]string"
+)

--- a/pkg/definition/go_gen_test.go
+++ b/pkg/definition/go_gen_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package definition
 
 import (

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -83,7 +83,7 @@ func DefinitionCommandGroup(c common.Args, order string) *cobra.Command {
 		NewDefinitionInitCommand(c),
 		NewDefinitionValidateCommand(c),
 		NewDefinitionGenDocCommand(c),
-		NewDefinitionGoGenerateCommand(c),
+		NewDefinitionGenAPICommand(c),
 	)
 	return cmd
 }
@@ -934,20 +934,21 @@ func NewDefinitionValidateCommand(c common.Args) *cobra.Command {
 	return cmd
 }
 
-// NewDefinitionGoGenerateCommand create the `vela def go-gen` command to help user generate Go code from the definition
-func NewDefinitionGoGenerateCommand(c common.Args) *cobra.Command {
+// NewDefinitionGenAPICommand create the `vela def gen-api` command to help user generate Go code from the definition
+func NewDefinitionGenAPICommand(c common.Args) *cobra.Command {
 	var (
 		skipPackageName bool
 		packageName     string
+		prefix          string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "go-gen DEFINITION.cue",
+		Use:   "gen-api DEFINITION.cue",
 		Short: "Generate Go struct of Parameter from X-Definition.",
 		Long: "Generate Go struct of Parameter from definition file.\n" +
 			"* Currently, this function is still working in progress and not all formats of parameter in X-definition are supported yet.",
 		Example: "# Command below will generate the Go struct for the my-def.cue file.\n" +
-			"> vela def go-gen my-def.cue",
+			"> vela def gen-api my-def.cue",
 		Args: cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cueBytes, err := os.ReadFile(args[0])
@@ -975,6 +976,7 @@ func NewDefinitionGoGenerateCommand(c common.Args) *cobra.Command {
 				return err
 			}
 
+			pkgdef.DefaultNamer.SetPrefix(prefix)
 			structs, err := pkgdef.GeneratorParameterStructs(value)
 			if err != nil {
 				return errors.Wrapf(err, "failed to generate Go code")
@@ -989,5 +991,6 @@ func NewDefinitionGoGenerateCommand(c common.Args) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&skipPackageName, "skip-package-name", false, "Skip package name in generated Go code.")
 	cmd.Flags().StringVar(&packageName, "package-name", "main", "Specify the package name in generated Go code.")
+	cmd.Flags().StringVar(&prefix, "prefix", "", "Specify the prefix of the generated Go struct.")
 	return cmd
 }

--- a/references/cli/def.go
+++ b/references/cli/def.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/oam-dev/kubevela/pkg/cue/packages"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -30,6 +29,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/oam-dev/kubevela/pkg/cue/packages"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/encoding/gocode/gocodec"
@@ -933,6 +934,7 @@ func NewDefinitionValidateCommand(c common.Args) *cobra.Command {
 	return cmd
 }
 
+// NewDefinitionGoGenerateCommand create the `vela def go-gen` command to help user generate Go code from the definition
 func NewDefinitionGoGenerateCommand(c common.Args) *cobra.Command {
 	var (
 		skipPackageName bool
@@ -961,11 +963,17 @@ func NewDefinitionGoGenerateCommand(c common.Args) *cobra.Command {
 				return errors.Wrapf(err, "failed to parse CUE")
 			}
 			templateString, _, err := unstructured.NestedString(def.Object, pkgdef.DefinitionTemplateKeys...)
+			if err != nil {
+				return err
+			}
 			pd, err := packages.NewPackageDiscover(config)
 			if err != nil {
-				fmt.Println(err)
+				return err
 			}
 			value, err := common.GetCUEParameterValue(templateString, pd)
+			if err != nil {
+				return err
+			}
 
 			structs, err := pkgdef.GeneratorParameterStructs(value)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>


### Description of your changes

Add `vela def gen-api` command to generate Go struct for X-definition, example: 

```shell
$ vela def go-gen vela-templates/definitions/internal/trait/resource.cue
package main

// Requests Specify the resources in requests
type Requests struct {
        CPU    number `json:"cpu"`
        Memory string `json:"memory"`
}

// Limits Specify the resources in limits
type Limits struct {
        CPU    number `json:"cpu"`
        Memory string `json:"memory"`
}

// Parameter -
type Parameter struct {
        CPU      number   `json:"cpu"`
        Memory   string   `json:"memory"`
        Requests Requests `json:"requests"`
        Limits   Limits   `json:"limits"`
}

```

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Partially fixes #3606 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

1. A lot tests with different types of parameter in go_gen_test.go
2. Test almost every X-definition in `vela-templates/definitions/`. Some of them are skipped now because it need more investigation about how to convert them to Go struct.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->