### PR TITLE
Fix: bind env to system namespace

### DIFF
--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -67,9 +66,6 @@ const (
 
 	// DummyTraitMessage is a message for trait which don't have definition found
 	DummyTraitMessage = "No TraitDefinition found, all framework capabilities will work as default"
-
-	// DefinitionNamespaceEnv is env key for specifying a namespace to fetch definition
-	DefinitionNamespaceEnv = "DEFINITION_NAMESPACE"
 )
 
 const (
@@ -329,13 +325,6 @@ func SetServiceAccountInContext(ctx context.Context, namespace, name string) con
 
 // GetDefinition get definition from two level namespace
 func GetDefinition(ctx context.Context, cli client.Reader, definition client.Object, definitionName string) error {
-	if dns := os.Getenv(DefinitionNamespaceEnv); dns != "" {
-		if err := cli.Get(ctx, types.NamespacedName{Name: definitionName, Namespace: dns}, definition); err == nil {
-			return nil
-		} else if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
 	appNs := GetDefinitionNamespaceWithCtx(ctx)
 	if err := cli.Get(ctx, types.NamespacedName{Name: definitionName, Namespace: appNs}, definition); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/oam/util/helper_test.go
+++ b/pkg/oam/util/helper_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/adler32"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -1659,13 +1658,6 @@ func TestGetDefinition(t *testing.T) {
 	err := util.GetDefinition(ctx, &cli, appTd, "mockTrait")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, &appTraitDefinition, appTd)
-
-	err = os.Setenv(util.DefinitionNamespaceEnv, env)
-	assert.Equal(t, nil, err)
-	envTd := new(v1alpha2.TraitDefinition)
-	err = util.GetDefinition(ctx, &cli, envTd, "mockTrait")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, &envTraitDefinition, envTd)
 }
 
 func TestGetScopeDefiniton(t *testing.T) {

--- a/pkg/utils/system/system.go
+++ b/pkg/utils/system/system.go
@@ -21,6 +21,9 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/oam"
 )
 
 const defaultVelaHome = ".vela"
@@ -141,4 +144,28 @@ func CreateIfNotExist(dir string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+const (
+	// LegacyKubeVelaSystemNamespaceEnv the legacy environment variable for kubevela system namespace
+	LegacyKubeVelaSystemNamespaceEnv = "DEFAULT_VELA_NS"
+	// KubeVelaSystemNamespaceEnv the environment variable for kubevela system namespace
+	KubeVelaSystemNamespaceEnv = "KUBEVELA_SYSTEM_NAMESPACE"
+	// KubeVelaDefinitionNamespaceEnv the environment variable for kubevela definition namespace
+	KubeVelaDefinitionNamespaceEnv = "KUBEVELA_DEFINITION_NAMESPACE"
+)
+
+func bindEnv(variable *string, keys ...string) {
+	for _, key := range keys {
+		if val := os.Getenv(key); val != "" {
+			*variable = val
+			return
+		}
+	}
+}
+
+// BindEnvironmentVariables bind
+func BindEnvironmentVariables() {
+	bindEnv(&types.DefaultKubeVelaNS, KubeVelaSystemNamespaceEnv, LegacyKubeVelaSystemNamespaceEnv)
+	bindEnv(&oam.SystemDefinitonNamespace, KubeVelaDefinitionNamespaceEnv, KubeVelaSystemNamespaceEnv)
 }

--- a/references/cmd/cli/main.go
+++ b/references/cmd/cli/main.go
@@ -23,7 +23,7 @@ import (
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
-	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/utils/system"
 	"github.com/oam-dev/kubevela/references/a/preimport"
 	"github.com/oam-dev/kubevela/references/cli"
 )
@@ -32,10 +32,7 @@ func main() {
 	preimport.ResumeLogging()
 	rand.Seed(time.Now().UnixNano())
 	_ = utilfeature.DefaultMutableFeatureGate.Set("AllAlpha=true")
-
-	if ns := os.Getenv("DEFAULT_VELA_NS"); len(ns) != 0 {
-		types.DefaultKubeVelaNS = ns
-	}
+	system.BindEnvironmentVariables()
 
 	command := cli.NewCommand()
 


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

CLI could use `KUBEVELA_SYSTEM_NAMESPACE` and `KUBEVELA_DEFINITION_NAMESPACE` environment variables for override default `vela-system` for use. 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->