### PR TITLE
Feat: multi-cluster authentication

### DIFF
--- a/apis/core.oam.dev/common/register.go
+++ b/apis/core.oam.dev/common/register.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+const (
+	// Group api group name
+	Group = "core.oam.dev"
+)

--- a/apis/core.oam.dev/v1alpha1/register.go
+++ b/apis/core.oam.dev/v1alpha1/register.go
@@ -19,11 +19,13 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 )
 
 // Package type metadata.
 const (
-	Group   = "core.oam.dev"
+	Group   = common.Group
 	Version = "v1alpha1"
 )
 

--- a/apis/core.oam.dev/v1alpha2/register.go
+++ b/apis/core.oam.dev/v1alpha2/register.go
@@ -21,11 +21,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 )
 
 // Package type metadata.
 const (
-	Group   = "core.oam.dev"
+	Group   = common.Group
 	Version = "v1alpha2"
 )
 

--- a/apis/core.oam.dev/v1beta1/register.go
+++ b/apis/core.oam.dev/v1beta1/register.go
@@ -21,11 +21,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 )
 
 // Package type metadata.
 const (
-	Group   = "core.oam.dev"
+	Group   = common.Group
 	Version = "v1beta1"
 )
 

--- a/apis/types/types.go
+++ b/apis/types/types.go
@@ -19,6 +19,13 @@ package types
 import "github.com/oam-dev/kubevela/pkg/oam"
 
 const (
+	// KubeVelaName name of kubevela
+	KubeVelaName = "kubevela"
+	// VelaCoreName name of vela-core
+	VelaCoreName = "vela-core"
+)
+
+const (
 	// DefaultKubeVelaReleaseName defines the default name of KubeVela Release
 	DefaultKubeVelaReleaseName = "kubevela"
 	// DefaultKubeVelaChartName defines the default chart name of KubeVela, this variable MUST align to the chart name of this repo
@@ -152,4 +159,9 @@ const (
 const (
 	// TerrfaormComponentPrefix is the prefix of component type of terraform-xxx
 	TerrfaormComponentPrefix = "terraform-"
+)
+
+const (
+	// ClusterGatewayAccessorGroup the group to impersonate which allows the access to the cluster-gateway
+	ClusterGatewayAccessorGroup = "cluster-gateway-accessor"
 )

--- a/charts/vela-core/README.md
+++ b/charts/vela-core/README.md
@@ -122,23 +122,27 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wai
 
 ### Common parameters
 
-| Name                         | Description                                                                                                                | Value   |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `imagePullSecrets`           | Image pull secrets                                                                                                         | `[]`    |
-| `nameOverride`               | Override name                                                                                                              | `""`    |
-| `fullnameOverride`           | Fullname override                                                                                                          | `""`    |
-| `serviceAccount.create`      | Specifies whether a service account should be created                                                                      | `true`  |
-| `serviceAccount.annotations` | Annotations to add to the service account                                                                                  | `{}`    |
-| `serviceAccount.name`        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template     | `nil`   |
-| `nodeSelector`               | Node selector                                                                                                              | `{}`    |
-| `tolerations`                | Tolerations                                                                                                                | `[]`    |
-| `affinity`                   | Affinity                                                                                                                   | `{}`    |
-| `rbac.create`                | Specifies whether a RBAC role should be created                                                                            | `true`  |
-| `logDebug`                   | Enable debug logs for development purpose                                                                                  | `false` |
-| `logFilePath`                | If non-empty, write log files in this path                                                                                 | `""`    |
-| `logFileMaxSize`             | Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. | `1024`  |
-| `kubeClient.qps`             | The qps for reconcile clients, default is 50                                                                               | `50`    |
-| `kubeClient.burst`           | The burst for reconcile clients, default is 100                                                                            | `100`   |
+| Name                          | Description                                                                                                                | Value                |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `imagePullSecrets`            | Image pull secrets                                                                                                         | `[]`                 |
+| `nameOverride`                | Override name                                                                                                              | `""`                 |
+| `fullnameOverride`            | Fullname override                                                                                                          | `""`                 |
+| `serviceAccount.create`       | Specifies whether a service account should be created                                                                      | `true`               |
+| `serviceAccount.annotations`  | Annotations to add to the service account                                                                                  | `{}`                 |
+| `serviceAccount.name`         | The name of the service account to use. If not set and create is true, a name is generated using the fullname template     | `nil`                |
+| `nodeSelector`                | Node selector                                                                                                              | `{}`                 |
+| `tolerations`                 | Tolerations                                                                                                                | `[]`                 |
+| `affinity`                    | Affinity                                                                                                                   | `{}`                 |
+| `rbac.create`                 | Specifies whether a RBAC role should be created                                                                            | `true`               |
+| `logDebug`                    | Enable debug logs for development purpose                                                                                  | `false`              |
+| `logFilePath`                 | If non-empty, write log files in this path                                                                                 | `""`                 |
+| `logFileMaxSize`              | Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. | `1024`               |
+| `kubeClient.qps`              | The qps for reconcile clients, default is 50                                                                               | `50`                 |
+| `kubeClient.burst`            | The burst for reconcile clients, default is 100                                                                            | `100`                |
+| `authentication.enabled`      | Enable authentication for application                                                                                      | `false`              |
+| `authentication.withUser`     | Application authentication will impersonate as the request User                                                            | `false`              |
+| `authentication.defaultUser`  | Application authentication will impersonate as the User if no user provided in Application                                 | `kubevela:vela-core` |
+| `authentication.groupPattern` | Application authentication will impersonate as the request Group that matches the pattern                                  | `kubevela:*`         |
 
 
 ## Uninstallation

--- a/charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/vela-core/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -125,6 +125,32 @@ webhooks:
       service:
         name: {{ template "kubevela.name" . }}-webhook
         namespace: {{ .Release.Namespace }}
+        path: /mutating-core-oam-dev-v1beta1-applications
+    {{- if .Values.admissionWebhooks.patch.enabled }}
+    failurePolicy: Ignore
+    {{- else }}
+    failurePolicy: Fail
+    {{- end }}
+    name: mutating.core.oam.dev.v1beta1.applications
+    admissionReviewVersions:
+      - v1beta1
+      - v1
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - core.oam.dev
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - applications
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: {{ template "kubevela.name" . }}-webhook
+        namespace: {{ .Release.Namespace }}
         path: /mutating-core-oam-dev-v1beta1-componentdefinitions
     {{- if .Values.admissionWebhooks.patch.enabled  }}
     failurePolicy: Ignore

--- a/charts/vela-core/templates/cluster-gateway.yaml
+++ b/charts/vela-core/templates/cluster-gateway.yaml
@@ -275,3 +275,29 @@ spec:
         runAsNonRoot: true
         runAsUser: 2000
 {{ end }}
+---
+{{ if and .Values.multicluster.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubevela.fullname" . }}:cluster-gateway-access-role
+rules:
+  - apiGroups: [ "cluster.core.oam.dev" ]
+    resources: [ "clustergateways/proxy" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+{{ end }}
+---
+{{ if and .Values.multicluster.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubevela.fullname" . }}:cluster-gateway-access-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubevela.fullname" . }}:cluster-gateway-access-role
+subjects:
+  - kind: Group
+    name: cluster-gateway-accessor
+    apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/charts/vela-core/templates/kubevela-controller.yaml
+++ b/charts/vela-core/templates/kubevela-controller.yaml
@@ -25,6 +25,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "kubevela.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+  - kind: Group
+    name: core.oam.dev
+    apiGroup: rbac.authorization.k8s.io
 
 ---
 # permissions to do leader election.
@@ -169,6 +172,14 @@ spec:
             - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
             - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
+            - "--feature-gates=AuthenticateApplication={{- .Values.authentication.enabled | toString -}}"
+            {{ if .Values.authentication.enabled }}
+            {{ if .Values.authentication.withUser }}
+            - "--authentication-with-user"
+            {{ end }}
+            - "--authentication-default-user={{ .Values.authentication.defaultUser }}"
+            - "--authentication-group-pattern={{ .Values.authentication.groupPattern }}"
+            {{ end }}
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
           resources:

--- a/charts/vela-core/values.yaml
+++ b/charts/vela-core/values.yaml
@@ -232,3 +232,13 @@ admissionWebhooks:
 kubeClient:
   qps: 50
   burst: 100
+
+## @param authentication.enabled Enable authentication for application
+## @param authentication.withUser Application authentication will impersonate as the request User
+## @param authentication.defaultUser Application authentication will impersonate as the User if no user provided in Application
+## @param authentication.groupPattern Application authentication will impersonate as the request Group that matches the pattern
+authentication:
+  enabled: false
+  withUser: false
+  defaultUser: kubevela:vela-core
+  groupPattern: kubevela:*

--- a/charts/vela-minimal/README.md
+++ b/charts/vela-minimal/README.md
@@ -125,22 +125,26 @@ helm install --create-namespace -n vela-system kubevela kubevela/vela-minimal --
 
 ### Common parameters
 
-| Name                         | Description                                                                                                                | Value   |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `imagePullSecrets`           | Image pull secrets                                                                                                         | `[]`    |
-| `nameOverride`               | Override name                                                                                                              | `""`    |
-| `fullnameOverride`           | Fullname override                                                                                                          | `""`    |
-| `serviceAccount.create`      | Specifies whether a service account should be created                                                                      | `true`  |
-| `serviceAccount.annotations` | Annotations to add to the service account                                                                                  | `{}`    |
-| `serviceAccount.name`        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template     | `nil`   |
-| `nodeSelector`               | Node selector                                                                                                              | `{}`    |
-| `tolerations`                | Tolerations                                                                                                                | `[]`    |
-| `affinity`                   | Affinity                                                                                                                   | `{}`    |
-| `rbac.create`                | Specifies whether a RBAC role should be created                                                                            | `true`  |
-| `logDebug`                   | Enable debug logs for development purpose                                                                                  | `false` |
-| `logFilePath`                | If non-empty, write log files in this path                                                                                 | `""`    |
-| `logFileMaxSize`             | Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. | `1024`  |
-| `kubeClient.qps`             | The qps for reconcile clients, default is 50                                                                               | `50`    |
-| `kubeClient.burst`           | The burst for reconcile clients, default is 100                                                                            | `100`   |
+| Name                          | Description                                                                                                                | Value                |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `imagePullSecrets`            | Image pull secrets                                                                                                         | `[]`                 |
+| `nameOverride`                | Override name                                                                                                              | `""`                 |
+| `fullnameOverride`            | Fullname override                                                                                                          | `""`                 |
+| `serviceAccount.create`       | Specifies whether a service account should be created                                                                      | `true`               |
+| `serviceAccount.annotations`  | Annotations to add to the service account                                                                                  | `{}`                 |
+| `serviceAccount.name`         | The name of the service account to use. If not set and create is true, a name is generated using the fullname template     | `nil`                |
+| `nodeSelector`                | Node selector                                                                                                              | `{}`                 |
+| `tolerations`                 | Tolerations                                                                                                                | `[]`                 |
+| `affinity`                    | Affinity                                                                                                                   | `{}`                 |
+| `rbac.create`                 | Specifies whether a RBAC role should be created                                                                            | `true`               |
+| `logDebug`                    | Enable debug logs for development purpose                                                                                  | `false`              |
+| `logFilePath`                 | If non-empty, write log files in this path                                                                                 | `""`                 |
+| `logFileMaxSize`              | Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. | `1024`               |
+| `kubeClient.qps`              | The qps for reconcile clients, default is 50                                                                               | `50`                 |
+| `kubeClient.burst`            | The burst for reconcile clients, default is 100                                                                            | `100`                |
+| `authentication.enabled`      | Enable authentication for application                                                                                      | `false`              |
+| `authentication.withUser`     | Application authentication will impersonate as the request User                                                            | `false`              |
+| `authentication.defaultUser`  | Application authentication will impersonate as the User if no user provided in Application                                 | `kubevela:vela-core` |
+| `authentication.groupPattern` | Application authentication will impersonate as the request Group that matches the pattern                                  | `kubevela:*`         |
 
 

--- a/charts/vela-minimal/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/vela-minimal/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -97,6 +97,32 @@ webhooks:
       service:
         name: {{ template "kubevela.name" . }}-webhook
         namespace: {{ .Release.Namespace }}
+        path: /mutating-core-oam-dev-v1beta1-applications
+    {{- if .Values.admissionWebhooks.patch.enabled }}
+    failurePolicy: Ignore
+    {{- else }}
+    failurePolicy: Fail
+    {{- end }}
+    name: mutating.core.oam.dev.v1beta1.applications
+    admissionReviewVersions:
+      - v1beta1
+      - v1
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - core.oam.dev
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - applications
+  - clientConfig:
+      caBundle: Cg==
+      service:
+        name: {{ template "kubevela.name" . }}-webhook
+        namespace: {{ .Release.Namespace }}
         path: /mutating-core-oam-dev-v1beta1-componentdefinitions
     {{- if .Values.admissionWebhooks.patch.enabled  }}
     failurePolicy: Ignore

--- a/charts/vela-minimal/templates/cluster-gateway.yaml
+++ b/charts/vela-minimal/templates/cluster-gateway.yaml
@@ -189,3 +189,29 @@ spec:
         runAsNonRoot: true
         runAsUser: 2000
   {{ end }}
+---
+{{ if and .Values.multicluster.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubevela.fullname" . }}:cluster-gateway-access-role
+rules:
+  - apiGroups: [ "cluster.core.oam.dev" ]
+    resources: [ "clustergateways/proxy" ]
+    verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+{{ end }}
+---
+{{ if and .Values.multicluster.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubevela.fullname" . }}:cluster-gateway-access-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubevela.fullname" . }}:cluster-gateway-access-role
+subjects:
+  - kind: Group
+    name: cluster-gateway-accessor
+    apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/charts/vela-minimal/templates/kubevela-controller.yaml
+++ b/charts/vela-minimal/templates/kubevela-controller.yaml
@@ -27,6 +27,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "kubevela.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+  - kind: Group
+    name: core.oam.dev
+    apiGroup: rbac.authorization.k8s.io
 
 ---
 # permissions to do leader election.
@@ -142,6 +145,14 @@ spec:
             - "--max-workflow-wait-backoff-time={{ .Values.workflow.backoff.maxTime.waitState }}"
             - "--max-workflow-failed-backoff-time={{ .Values.workflow.backoff.maxTime.failedState }}"
             - "--max-workflow-step-error-retry-times={{ .Values.workflow.step.errorRetryTimes }}"
+            - "--feature-gates=AuthenticateApplication={{- .Values.authentication.enabled | toString -}}"
+            {{ if .Values.authentication.enabled }}
+            {{ if .Values.authentication.withUser }}
+            - "--authentication-with-user"
+            {{ end }}
+            - "--authentication-default-user={{ .Values.authentication.defaultUser }}"
+            - "--authentication-group-pattern={{ .Values.authentication.groupPattern }}"
+            {{ end }}
           image: {{ .Values.imageRegistry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ quote .Values.image.pullPolicy }}
           resources:

--- a/charts/vela-minimal/values.yaml
+++ b/charts/vela-minimal/values.yaml
@@ -215,3 +215,13 @@ admissionWebhooks:
 kubeClient:
   qps: 50
   burst: 100
+
+## @param authentication.enabled Enable authentication for application
+## @param authentication.withUser Application authentication will impersonate as the request User
+## @param authentication.defaultUser Application authentication will impersonate as the User if no user provided in Application
+## @param authentication.groupPattern Application authentication will impersonate as the request Group that matches the pattern
+authentication:
+  enabled: false
+  withUser: false
+  defaultUser: kubevela:vela-core
+  groupPattern: kubevela:*

--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ require (
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
 	google.golang.org/grpc v1.38.0 // indirect

--- a/pkg/auth/flags.go
+++ b/pkg/auth/flags.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	"github.com/oam-dev/kubevela/apis/types"
+)
+
+const (
+	// DefaultAuthenticateGroupPattern default value of groups patterns for authentication
+	DefaultAuthenticateGroupPattern = types.KubeVelaName + ":*"
+)
+
+var (
+	// AuthenticationWithUser flag for enable the authentication of User in requests
+	AuthenticationWithUser = false
+	// AuthenticationDefaultUser the default user to use while no User is set in application
+	AuthenticationDefaultUser = user.Anonymous
+	// AuthenticationGroupPattern pattern for the authentication of Group in requests
+	AuthenticationGroupPattern = DefaultAuthenticateGroupPattern
+)

--- a/pkg/auth/userinfo.go
+++ b/pkg/auth/userinfo.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/utils/strings/slices"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+const (
+	groupSeparator = ","
+)
+
+// ContextWithUserInfo inject username & group from app annotations into context
+// If serviceAccount is set and username is empty, identity will user the serviceAccount
+func ContextWithUserInfo(ctx context.Context, app *v1beta1.Application) context.Context {
+	if app == nil {
+		return ctx
+	}
+	return request.WithUser(ctx, GetUserInfoInAnnotation(&app.ObjectMeta))
+}
+
+// SetUserInfoInAnnotation set username and group from userInfo into annotations
+// it will clear the existing service account annotation in avoid of permission leak
+func SetUserInfoInAnnotation(obj *metav1.ObjectMeta, userInfo authv1.UserInfo) {
+	if AuthenticationWithUser {
+		metav1.SetMetaDataAnnotation(obj, oam.AnnotationApplicationUsername, userInfo.Username)
+	}
+	re := regexp.MustCompile(strings.ReplaceAll(AuthenticationGroupPattern, "*", ".*"))
+	var groups []string
+	for _, group := range userInfo.Groups {
+		if re.MatchString(group) {
+			groups = append(groups, group)
+		}
+	}
+	metav1.SetMetaDataAnnotation(obj, oam.AnnotationApplicationGroup, strings.Join(groups, groupSeparator))
+}
+
+// GetUserInfoInAnnotation extract user info from annotations
+// support compatibility for serviceAccount when name is empty
+func GetUserInfoInAnnotation(obj *metav1.ObjectMeta) user.Info {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	name := annotations[oam.AnnotationApplicationUsername]
+	if serviceAccountName := annotations[oam.AnnotationApplicationServiceAccountName]; serviceAccountName != "" && name == "" {
+		name = fmt.Sprintf("system:serviceaccount:%s:%s", obj.GetNamespace(), serviceAccountName)
+	}
+
+	if name == "" && utilfeature.DefaultMutableFeatureGate.Enabled(features.AuthenticateApplication) {
+		name = AuthenticationDefaultUser
+	}
+
+	return &user.DefaultInfo{
+		Name: name,
+		Groups: slices.Filter(
+			[]string{},
+			strings.Split(annotations[oam.AnnotationApplicationGroup], groupSeparator),
+			func(s string) bool {
+				return len(strings.TrimSpace(s)) > 0
+			}),
+	}
+}

--- a/pkg/auth/userinfo_test.go
+++ b/pkg/auth/userinfo_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+func TestContextWithUserInfo(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AuthenticateApplication, true)()
+	AuthenticationWithUser = true
+	defer func() {
+		AuthenticationWithUser = false
+	}()
+	testCases := map[string]struct {
+		UserInfo       *authv1.UserInfo
+		ServiceAccount string
+		ExpectUserInfo user.Info
+	}{
+		"empty": {
+			ExpectUserInfo: &user.DefaultInfo{
+				Name:   user.Anonymous,
+				Groups: []string{},
+			},
+		},
+		"service-account": {
+			ServiceAccount: "sa",
+			ExpectUserInfo: &user.DefaultInfo{
+				Name:   "system:serviceaccount:default:sa",
+				Groups: []string{},
+			},
+		},
+		"user-with-groups": {
+			UserInfo: &authv1.UserInfo{
+				Username: "user",
+				Groups:   []string{"group0", "kubevela:group1", "kubevela:group2"},
+			},
+			ServiceAccount: "override",
+			ExpectUserInfo: &user.DefaultInfo{
+				Name:   "user",
+				Groups: []string{"kubevela:group1", "kubevela:group2"},
+			},
+		},
+	}
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			app := &v1beta1.Application{}
+			app.SetNamespace("default")
+			if tt.UserInfo != nil {
+				SetUserInfoInAnnotation(&app.ObjectMeta, *tt.UserInfo)
+			}
+			if tt.ServiceAccount != "" {
+				metav1.SetMetaDataAnnotation(&app.ObjectMeta, oam.AnnotationApplicationServiceAccountName, tt.ServiceAccount)
+			}
+			r.Equal(tt.ExpectUserInfo, GetUserInfoInAnnotation(&app.ObjectMeta))
+		})
+	}
+}

--- a/pkg/controller/flags.go
+++ b/pkg/controller/flags.go
@@ -19,6 +19,8 @@ package controller
 import (
 	flag "github.com/spf13/pflag"
 
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/auth"
 	ctrlClient "github.com/oam-dev/kubevela/pkg/client"
 	"github.com/oam-dev/kubevela/pkg/component"
 	"github.com/oam-dev/kubevela/pkg/controller/core.oam.dev/v1alpha2/application"
@@ -52,4 +54,9 @@ func AddAdmissionFlags() {
 	flag.BoolVar(&resourcekeeper.AllowCrossNamespaceResource, "allow-cross-namespace-resource", true, "If set to false, application can only apply resources within its namespace. Default to be true.")
 	flag.StringVar(&resourcekeeper.AllowResourceTypes, "allow-resource-types", "", "If not empty, application can only apply resources with specified types. For example, --allow-resource-types=whitelist:Deployment.v1.apps,Job.v1.batch")
 	flag.StringVar(&component.RefObjectsAvailableScope, "ref-objects-available-scope", component.RefObjectsAvailableScopeGlobal, "The available scope for ref-objects component to refer objects. Should be one of `namespace`, `cluster`, `global`")
+
+	// auth flags
+	flag.BoolVar(&auth.AuthenticationWithUser, "authentication-with-user", false, "If set to true, User will be carried on application. Resource requests will be impersonated as the User.")
+	flag.StringVar(&auth.AuthenticationDefaultUser, "authentication-default-user", types.KubeVelaName+":"+types.VelaCoreName, "The User to impersonate when the User of application is not set.")
+	flag.StringVar(&auth.AuthenticationGroupPattern, "authentication-group-pattern", auth.DefaultAuthenticateGroupPattern, "During authentication, only groups with specified pattern will be carried on application. Resource requests will be impersonated as these selected groups.")
 }

--- a/pkg/features/controller_features.go
+++ b/pkg/features/controller_features.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	// Compatibility Features
+
 	// DeprecatedPolicySpec enable the use of deprecated policy spec
 	DeprecatedPolicySpec featuregate.Feature = "DeprecatedPolicySpec"
 	// LegacyObjectTypeIdentifier enable the use of legacy object type identifier for selecting ref-object
@@ -31,6 +33,11 @@ const (
 	DeprecatedObjectLabelSelector featuregate.Feature = "DeprecatedObjectLabelSelector"
 	// LegacyResourceTrackerGC enable the gc of legacy resource tracker in managed clusters
 	LegacyResourceTrackerGC featuregate.Feature = "LegacyResourceTrackerGC"
+
+	// Edge Features
+
+	// AuthenticateApplication enable the authentication for application
+	AuthenticateApplication featuregate.Feature = "AuthenticateApplication"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -38,6 +45,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	LegacyObjectTypeIdentifier:    {Default: false, PreRelease: featuregate.Alpha},
 	DeprecatedObjectLabelSelector: {Default: false, PreRelease: featuregate.Alpha},
 	LegacyResourceTrackerGC:       {Default: true, PreRelease: featuregate.Alpha},
+	AuthenticateApplication:       {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/oam/auxiliary.go
+++ b/pkg/oam/auxiliary.go
@@ -36,14 +36,6 @@ func GetCluster(o client.Object) string {
 	return ""
 }
 
-// GetServiceAccountNameFromAnnotations extracts the service account name from the given object's annotations.
-func GetServiceAccountNameFromAnnotations(o client.Object) string {
-	if annotations := o.GetAnnotations(); annotations != nil {
-		return annotations[AnnotationServiceAccountName]
-	}
-	return ""
-}
-
 // GetPublishVersion get PublishVersion from object
 func GetPublishVersion(o client.Object) string {
 	if annotations := o.GetAnnotations(); annotations != nil {

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -199,7 +199,13 @@ const (
 	// AnnotationControllerRequirement indicates the controller version that can process the application.
 	AnnotationControllerRequirement = "app.oam.dev/controller-version-require"
 
-	// AnnotationServiceAccountName indicates the name of the ServiceAccount to use to apply Components and run Workflow.
+	// AnnotationApplicationServiceAccountName indicates the name of the ServiceAccount to use to apply Components and run Workflow.
 	// ServiceAccount will be used in the local cluster only.
-	AnnotationServiceAccountName = "app.oam.dev/service-account-name"
+	AnnotationApplicationServiceAccountName = "app.oam.dev/service-account-name"
+
+	// AnnotationApplicationUsername indicates the username of the Application to use to apply resources
+	AnnotationApplicationUsername = "app.oam.dev/username"
+
+	// AnnotationApplicationGroup indicates the group of the Application to use to apply resources
+	AnnotationApplicationGroup = "app.oam.dev/group"
 )

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -303,26 +303,6 @@ func SetNamespaceInCtx(ctx context.Context, namespace string) context.Context {
 	return ctx
 }
 
-// GetServiceAccountInContext returns the name of the service account which reconciles the app from the context.
-func GetServiceAccountInContext(ctx context.Context) string {
-	if serviceAccount, ok := ctx.Value(ServiceAccountContextKey).(string); ok {
-		return serviceAccount
-	}
-	return ""
-}
-
-// SetServiceAccountInContext sets the name of the service account which reconciles the app.
-func SetServiceAccountInContext(ctx context.Context, namespace, name string) context.Context {
-	if name == "" {
-		// We may set `default` service account when the service account name is omitted.
-		// However, setting `default` service account will break existing cluster-scoped applications,
-		// so it would be better to give users a migration term.
-		// TODO(devholic): Use `default` service account if omitted.
-		return ctx
-	}
-	return context.WithValue(ctx, ServiceAccountContextKey, fmt.Sprintf("system:serviceaccount:%s:%s", namespace, name))
-}
-
 // GetDefinition get definition from two level namespace
 func GetDefinition(ctx context.Context, cli client.Reader, definition client.Object, definitionName string) error {
 	appNs := GetDefinitionNamespaceWithCtx(ctx)

--- a/pkg/resourcekeeper/delete.go
+++ b/pkg/resourcekeeper/delete.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/auth"
 	"github.com/oam-dev/kubevela/pkg/multicluster"
 	"github.com/oam-dev/kubevela/pkg/oam"
-	oamutil "github.com/oam-dev/kubevela/pkg/oam/util"
 	"github.com/oam-dev/kubevela/pkg/resourcetracker"
 )
 
@@ -87,7 +87,7 @@ func (h *resourceKeeper) delete(ctx context.Context, manifest *unstructured.Unst
 	}
 	// 2. delete manifests
 	deleteCtx := multicluster.ContextWithClusterName(ctx, oam.GetCluster(manifest))
-	deleteCtx = oamutil.SetServiceAccountInContext(deleteCtx, h.app.Namespace, oam.GetServiceAccountNameFromAnnotations(h.app))
+	deleteCtx = auth.ContextWithUserInfo(deleteCtx, h.app)
 	if err = h.Client.Delete(deleteCtx, manifest); err != nil && !kerrors.IsNotFound(err) {
 		return errors.Wrapf(err, "cannot delete manifest, name: %s apiVersion: %s kind: %s", manifest.GetName(), manifest.GetAPIVersion(), manifest.GetKind())
 	}

--- a/pkg/utils/jwt.go
+++ b/pkg/utils/jwt.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "github.com/form3tech-oss/jwt-go"
+
+// GetTokenSubject extract the subject field from the jwt token
+func GetTokenSubject(token string) (string, error) {
+	claims := jwt.MapClaims{}
+	if _, err := jwt.ParseWithClaims(token, claims, nil); err != nil {
+		return "", err
+	}
+	sub, _ := claims["sub"].(string)
+	return sub, nil
+}

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/oam-dev/kubevela/pkg/oam/util"
@@ -105,4 +106,10 @@ func UpdateNamespace(ctx context.Context, kubeClient client.Client, name string,
 		}
 	}
 	return kubeClient.Update(ctx, &namespace)
+}
+
+// GetServiceAccountSubjectFromConfig extract ServiceAccount subject from token
+func GetServiceAccountSubjectFromConfig(cfg *rest.Config) string {
+	sub, _ := GetTokenSubject(cfg.BearerToken)
+	return sub
 }

--- a/pkg/webhook/core.oam.dev/register.go
+++ b/pkg/webhook/core.oam.dev/register.go
@@ -47,6 +47,7 @@ func Register(mgr manager.Manager, args controller.Args) {
 		traitdefinition.RegisterValidatingHandler(mgr, args)
 	case "v0.3":
 		application.RegisterValidatingHandler(mgr, args)
+		application.RegisterMutatingHandler(mgr)
 		componentdefinition.RegisterMutatingHandler(mgr, args)
 		componentdefinition.RegisterValidatingHandler(mgr, args)
 		traitdefinition.RegisterValidatingHandler(mgr, args)

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/mutating_handler.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/mutating_handler.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/auth"
+	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+// MutatingHandler adding user info to application annotations
+type MutatingHandler struct {
+	Decoder *admission.Decoder
+}
+
+var _ admission.Handler = &MutatingHandler{}
+
+// Handle mutate application
+func (h *MutatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if !utilfeature.DefaultMutableFeatureGate.Enabled(features.AuthenticateApplication) {
+		return admission.Patched("")
+	}
+
+	if slices.Contains(req.UserInfo.Groups, common.Group) {
+		return admission.Patched("")
+	}
+
+	app := &v1beta1.Application{}
+	if err := h.Decoder.Decode(req, app); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if metav1.HasAnnotation(app.ObjectMeta, oam.AnnotationApplicationServiceAccountName) {
+		return admission.Errored(http.StatusBadRequest, errors.New("service-account annotation is not permitted when authentication enabled"))
+	}
+	auth.SetUserInfoInAnnotation(&app.ObjectMeta, req.UserInfo)
+
+	bs, err := json.Marshal(app)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, bs)
+}
+
+var _ admission.DecoderInjector = &MutatingHandler{}
+
+// InjectDecoder .
+func (h *MutatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.Decoder = d
+	return nil
+}
+
+// RegisterMutatingHandler will register component mutation handler to the webhook
+func RegisterMutatingHandler(mgr manager.Manager) {
+	server := mgr.GetWebhookServer()
+	server.Register("/mutating-core-oam-dev-v1beta1-applications", &webhook.Admission{Handler: &MutatingHandler{}})
+}

--- a/pkg/webhook/core.oam.dev/v1alpha2/application/mutating_handler_test.go
+++ b/pkg/webhook/core.oam.dev/v1alpha2/application/mutating_handler_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/oam"
+)
+
+var _ = Describe("Test Application Mutator", func() {
+
+	var mutatingHandler *MutatingHandler
+
+	BeforeEach(func() {
+		mutatingHandler = &MutatingHandler{}
+		Expect(mutatingHandler.InjectDecoder(decoder)).Should(BeNil())
+	})
+
+	It("Test Application Mutator [no authentication]", func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", features.AuthenticateApplication))).Should(Succeed())
+		resp := mutatingHandler.Handle(ctx, admission.Request{})
+		Expect(resp.Allowed).Should(BeTrue())
+		Expect(resp.Patches).Should(BeNil())
+	})
+
+	It("Test Application Mutator [ignore authentication]", func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=true", features.AuthenticateApplication))).Should(Succeed())
+		resp := mutatingHandler.Handle(ctx, admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UserInfo: authv1.UserInfo{Groups: []string{common.Group}},
+			}})
+		Expect(resp.Allowed).Should(BeTrue())
+		Expect(resp.Patches).Should(BeNil())
+	})
+
+	It("Test Application Mutator [bad request]", func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=true", features.AuthenticateApplication))).Should(Succeed())
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				Object:    runtime.RawExtension{Raw: []byte("bad request")},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeFalse())
+	})
+
+	It("Test Application Mutator [bad request with service-account]", func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=true", features.AuthenticateApplication))).Should(Succeed())
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				Object:    runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example","annotations":{"app.oam.dev/service-account-name":"default"}}}`)},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeFalse())
+		Expect(resp.Result.Message).Should(ContainSubstring("service-account annotation is not permitted when authentication enabled"))
+	})
+
+	It("Test Application Mutator [with patch]", func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=true", features.AuthenticateApplication))).Should(Succeed())
+		req := admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				Resource:  metav1.GroupVersionResource{Group: v1beta1.Group, Version: v1beta1.Version, Resource: "applications"},
+				Object:    runtime.RawExtension{Raw: []byte(`{"apiVersion":"core.oam.dev/v1beta1","kind":"Application","metadata":{"name":"example"}}`)},
+				UserInfo: authv1.UserInfo{
+					Username: "example-user",
+					Groups:   []string{"kubevela:example-group1", "kubevela:example-group2"},
+				},
+			},
+		}
+		resp := mutatingHandler.Handle(ctx, req)
+		Expect(resp.Allowed).Should(BeTrue())
+		Expect(resp.Patches).Should(ContainElement(jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/metadata/annotations",
+			Value: map[string]interface{}{
+				oam.AnnotationApplicationGroup: "kubevela:example-group1,kubevela:example-group2",
+			},
+		}))
+	})
+})

--- a/test/e2e-test/application_test.go
+++ b/test/e2e-test/application_test.go
@@ -395,7 +395,7 @@ var _ = Describe("Application Normal tests", func() {
 		Expect(common.ReadYamlToObject("testdata/app/app11.yaml", &newApp)).Should(BeNil())
 		newApp.Namespace = namespaceName
 		annotations := newApp.GetAnnotations()
-		annotations[oam.AnnotationServiceAccountName] = saName
+		annotations[oam.AnnotationApplicationServiceAccountName] = saName
 		newApp.SetAnnotations(annotations)
 		Expect(k8sClient.Create(ctx, &newApp)).Should(BeNil())
 
@@ -414,7 +414,7 @@ var _ = Describe("Application Normal tests", func() {
 		Expect(common.ReadYamlToObject("testdata/app/app11.yaml", &newApp)).Should(BeNil())
 		newApp.Namespace = namespaceName
 		annotations := newApp.GetAnnotations()
-		annotations[oam.AnnotationServiceAccountName] = saName
+		annotations[oam.AnnotationApplicationServiceAccountName] = saName
 		newApp.SetAnnotations(annotations)
 		Expect(k8sClient.Create(ctx, &newApp)).Should(BeNil())
 
@@ -442,7 +442,7 @@ var _ = Describe("Application Normal tests", func() {
 		Expect(common.ReadYamlToObject("testdata/app/app11.yaml", &newApp)).Should(BeNil())
 		newApp.Namespace = namespaceName
 		annotations := newApp.GetAnnotations()
-		annotations[oam.AnnotationServiceAccountName] = saName
+		annotations[oam.AnnotationApplicationServiceAccountName] = saName
 		newApp.SetAnnotations(annotations)
 		Expect(k8sClient.Create(ctx, &newApp)).Should(BeNil())
 


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Support authenticate application. By default, disabled.

1. All request from vela-core controller to KAS (kube-apiserver) will now impersonate as User `vela-core` with Group `core.oam.dev`. Group "core.oam.dev" is binded to ClusterRole `cluster-admin`.
2. When user create or modify application, the request will be processed by the application mutating webhook. If the authentication is enabled, the webhook will inject the user info into the application annotations. *Notice that the requests carries `core.oam.dev` group will not inject user info. These requests are sent by vela-core controller.* Only **Groups** with specified pattern (`kubevela:*` by default) will be injected and User is not. This can be modified by setting bootstrap parameter `--authentication-with-user` and `--authentication-group-pattern`. 
3. When dispatching resources or deleting resources in application controller, the user info in application annotations will be passed into the context. The context will then be consumed by the impersonate roundTripper, where user info will be converted into impersonation headers. *To let all requests be able to be delegated to ClusterGateway, the `cluster-gateway-accessor` group is automatically added to the impersonation group.*
4. The request, carrying impersonation headers, will be handled by KAS and after impersonated, it will then delegated to ClusterGateway.
5. ClusterGateway will recognize the impersonated user and re-carries these information into headers when request is directed to KAS in managed cluster.

Step 4 and 5 is done by KAS and ClusterGateway automatically. This PR mainly handles Step 1~3.

This PR only implements the authentication part and has nothing to do with authorization. We might need convenient authorization tools to assign roles in managed clusters in Vela CLI.

This PR is compatible with the previous ServiceAccount impersonation in #3432 & #3434.
When authentication is disabled, the application's ServiceAccount annotation will be recognized as the impersonation target and reuse the impersonation. The only break change is that in multi-cluster scenario, the ServiceAccount impersonation will also be passed into managed clusters.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Add Test.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->