### PR TITLE
Fix: embed.FS filepath that follow the unix style file path when running on windows

### DIFF
--- a/pkg/workflow/tasks/template/load.go
+++ b/pkg/workflow/tasks/template/load.go
@@ -19,8 +19,7 @@ package template
 import (
 	"context"
 	"embed"
-	"path/filepath"
-
+	"fmt"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +59,8 @@ func (loader *WorkflowStepLoader) LoadTaskTemplate(ctx context.Context, name str
 	staticFilename := name + ".cue"
 	for _, file := range files {
 		if staticFilename == file.Name() {
-			content, err := templateFS.ReadFile(filepath.Join(templateDir, file.Name()))
+			fileName := fmt.Sprintf("%s/%s", templateDir, file.Name())
+			content, err := templateFS.ReadFile(fileName)
 			return string(content), err
 		}
 	}

--- a/pkg/workflow/tasks/template/load.go
+++ b/pkg/workflow/tasks/template/load.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
Signed-off-by: clarechu [1062186165@qq.com](mailto:1062186165@qq.com)

### Description of your changes



Fixes #

In Windows 10， When running vela-core

```log
"msg"="Reconciler error" "error"="object level reconcile error, type: \"Workflow\", msg: \"open static\\\\builtin-apply-compon
ent.cue: file does not exist\"
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

### Special notes for your reviewer
