### PR TITLE
Feat: check whether a project matched a config's project

### DIFF
--- a/pkg/utils/config/project.go
+++ b/pkg/utils/config/project.go
@@ -17,9 +17,8 @@ limitations under the License.
 package config
 
 import (
-	"k8s.io/api/core/v1"
-
 	"github.com/oam-dev/kubevela/apis/types"
+	"k8s.io/api/core/v1"
 )
 
 // ProjectMatched will check whether a config secret can be used in a given project

--- a/pkg/utils/config/project.go
+++ b/pkg/utils/config/project.go
@@ -18,7 +18,7 @@ package config
 
 import (
 	"github.com/oam-dev/kubevela/apis/types"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // ProjectMatched will check whether a config secret can be used in a given project

--- a/pkg/utils/config/project.go
+++ b/pkg/utils/config/project.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oam-dev/kubevela/apis/types"
 )
 
+// ProjectMatched will check whether a config secret can be used in a given project
 func ProjectMatched(s *v1.Secret, project string) bool {
 	if s.Labels[types.LabelConfigProject] == "" || s.Labels[types.LabelConfigProject] == project {
 		return true

--- a/pkg/utils/config/project.go
+++ b/pkg/utils/config/project.go
@@ -17,8 +17,9 @@ limitations under the License.
 package config
 
 import (
-	"github.com/oam-dev/kubevela/apis/types"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/oam-dev/kubevela/apis/types"
 )
 
 // ProjectMatched will check whether a config secret can be used in a given project

--- a/pkg/utils/config/project.go
+++ b/pkg/utils/config/project.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"k8s.io/api/core/v1"
+
+	"github.com/oam-dev/kubevela/apis/types"
+)
+
+func ProjectMatched(s *v1.Secret, project string) bool {
+	if s.Labels[types.LabelConfigProject] == "" || s.Labels[types.LabelConfigProject] == project {
+		return true
+	}
+	return false
+}

--- a/pkg/utils/config/project_test.go
+++ b/pkg/utils/config/project_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package config
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/oam-dev/kubevela/apis/types"
 )

--- a/pkg/utils/config/project_test.go
+++ b/pkg/utils/config/project_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/oam-dev/kubevela/apis/types"
+)
+
+var ResponseString = "Hello HTTP Get."
+
+func TestMatchProject(t *testing.T) {
+	s := runtime.NewScheme()
+	corev1.AddToScheme(s)
+	secret1 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s1",
+			Namespace: types.DefaultKubeVelaNS,
+			Labels: map[string]string{
+				types.LabelConfigProject: "p1",
+			},
+		},
+	}
+
+	secret2 := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s2",
+			Namespace: types.DefaultKubeVelaNS,
+			Labels: map[string]string{
+				types.LabelConfigProject: "",
+			},
+		},
+	}
+
+	type args struct {
+		secret  *corev1.Secret
+		project string
+	}
+
+	type want struct {
+		matched bool
+	}
+
+	testcases := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "matched",
+			args: args{
+				project: "p99",
+				secret:  secret1,
+			},
+			want: want{
+				matched: false,
+			},
+		},
+		{
+			name: "not matched",
+			args: args{
+				project: "p99",
+				secret:  secret2,
+			},
+			want: want{
+				matched: true,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ProjectMatched(tc.args.secret, tc.args.project)
+			assert.Equal(t, tc.want.matched, got)
+		})
+	}
+}


### PR DESCRIPTION
If the config project is not nil, it's matched whether the project
matched the target project.
If the config project is nil, the target project matched the config.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->