### PR TITLE
Chore: fix missing trigger for e2e tests 

### DIFF
--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -6,6 +6,8 @@ on:
       - master
       - release-*
       - apiserver
+    tags:
+      - v*
   workflow_dispatch: { }
   pull_request:
     branches:

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - release-*
+    tags:
+      - v*
   workflow_dispatch: {}
   pull_request:
     branches:

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - release-*
+    tags:
+      - v*
   workflow_dispatch: {}
   pull_request:
     branches:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - release-*
+    tags:
+      - v*
   workflow_dispatch: {}
   pull_request:
     branches:


### PR DESCRIPTION
This PR add missing triggers in #3714. With these triggers, GitHub will launch e2e-tests with multi-versions of Kubernetes. 

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->