### PR TITLE
Chore: fix e2e test check tag exist and set matrix

### DIFF
--- a/.github/workflows/apiserver-test.yaml
+++ b/.github/workflows/apiserver-test.yaml
@@ -44,18 +44,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-k8s-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: mukunku/tag-exists-action@v1.0.0
-        id: checkTag
-        with:
-          tag: 'v1'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - id: set-k8s-matrix
         run: |
-          echo ${{ steps.checkTag.outputs.exists }}
-          if [ "${{ steps.checkTag.outputs.exists }}" = "true" ]; then
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "pushing tag: ${{ github.ref_name }}"
             echo "::set-output name=matrix::${{ env.KIND_IMAGE_VERSIONS }}"
           else
             echo "::set-output name=matrix::${{ env.KIND_IMAGE_VERSION }}"

--- a/.github/workflows/e2e-multicluster-test.yml
+++ b/.github/workflows/e2e-multicluster-test.yml
@@ -42,18 +42,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-k8s-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: mukunku/tag-exists-action@v1.0.0
-        id: checkTag
-        with:
-          tag: 'v1'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - id: set-k8s-matrix
         run: |
-          echo ${{ steps.checkTag.outputs.exists }}
-          if [ "${{ steps.checkTag.outputs.exists }}" = "true" ]; then
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "pushing tag: ${{ github.ref_name }}"
             echo "::set-output name=matrix::${{ env.KIND_IMAGE_VERSIONS }}"
           else
             echo "::set-output name=matrix::${{ env.KIND_IMAGE_VERSION }}"

--- a/.github/workflows/e2e-rollout-test.yml
+++ b/.github/workflows/e2e-rollout-test.yml
@@ -42,18 +42,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-k8s-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: mukunku/tag-exists-action@v1.0.0
-        id: checkTag
-        with:
-          tag: 'v1'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - id: set-k8s-matrix
         run: |
-          echo ${{ steps.checkTag.outputs.exists }}
-          if [ "${{ steps.checkTag.outputs.exists }}" = "true" ]; then
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "pushing tag: ${{ github.ref_name }}"
             echo "::set-output name=matrix::${{ env.KIND_IMAGE_VERSIONS }}"
           else
             echo "::set-output name=matrix::${{ env.KIND_IMAGE_VERSION }}"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -42,18 +42,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-k8s-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: mukunku/tag-exists-action@v1.0.0
-        id: checkTag
-        with:
-          tag: 'v1'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - id: set-k8s-matrix
         run: |
-          echo ${{ steps.checkTag.outputs.exists }}
-          if [ "${{ steps.checkTag.outputs.exists }}" = "true" ]; then
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "pushing tag: ${{ github.ref_name }}"
             echo "::set-output name=matrix::${{ env.KIND_IMAGE_VERSIONS }}"
           else
             echo "::set-output name=matrix::${{ env.KIND_IMAGE_VERSION }}"


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>

### Description of your changes

Using simpler method to check if tag exist when releasing or push tags and set the test Kubernetes version matrix.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->