### PR TITLE
Fix: velaux addon hint after enable

### DIFF
--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -179,7 +179,7 @@ Enable addon for specific clusters, (local means control plane):
 				}
 			}
 			fmt.Printf("Addon: %s enabled Successfully.\n", name)
-			AdditionalEndpointPrinter(ctx, c, k8sClient, name)
+			AdditionalEndpointPrinter(ctx, c, k8sClient, name, false)
 			return nil
 		},
 	}
@@ -190,7 +190,7 @@ Enable addon for specific clusters, (local means control plane):
 }
 
 // AdditionalEndpointPrinter will print endpoints
-func AdditionalEndpointPrinter(ctx context.Context, c common.Args, k8sClient client.Client, name string) {
+func AdditionalEndpointPrinter(ctx context.Context, c common.Args, k8sClient client.Client, name string, isUpgrade bool) {
 	fmt.Printf("Please access the %s from the following endpoints:\n", name)
 	err := printAppEndpoints(ctx, k8sClient, pkgaddon.Convert2AppName(name), types.DefaultKubeVelaNS, Filter{}, c)
 	if err != nil {
@@ -198,8 +198,10 @@ func AdditionalEndpointPrinter(ctx context.Context, c common.Args, k8sClient cli
 		return
 	}
 	if name == "velaux" {
-		fmt.Println(`To check the initialized admin user name and password by:`)
-		fmt.Println(`    vela logs -n vela-system --name apiserver addon-velaux | grep "initialized admin username"`)
+		if !isUpgrade {
+			fmt.Println(`To check the initialized admin user name and password by:`)
+			fmt.Println(`    vela logs -n vela-system --name apiserver addon-velaux | grep "initialized admin username"`)
+		}
 		fmt.Println(`To open the dashboard directly by port-forward:`)
 		fmt.Println(`    vela port-forward -n vela-system addon-velaux 9082:80`)
 		fmt.Println(`Select "Cluster: local | Namespace: vela-system | Kind: Service | Name: velaux" from the prompt.`)
@@ -276,7 +278,7 @@ Upgrade addon for specific clusters, (local means control plane):
 			}
 
 			fmt.Printf("Addon: %s\n enabled Successfully.", name)
-			AdditionalEndpointPrinter(ctx, c, k8sClient, name)
+			AdditionalEndpointPrinter(ctx, c, k8sClient, name, true)
 			return nil
 		},
 	}

--- a/references/cli/addon.go
+++ b/references/cli/addon.go
@@ -202,7 +202,7 @@ func AdditionalEndpointPrinter(ctx context.Context, c common.Args, k8sClient cli
 		fmt.Println(`    vela logs -n vela-system --name apiserver addon-velaux | grep "initialized admin username"`)
 		fmt.Println(`To open the dashboard directly by port-forward:`)
 		fmt.Println(`    vela port-forward -n vela-system addon-velaux 9082:80`)
-		fmt.Println(`Select "Cluster: local | Namespace: vela-system | Component: velaux | Kind: Service" from the prompt.`)
+		fmt.Println(`Select "Cluster: local | Namespace: vela-system | Kind: Service | Name: velaux" from the prompt.`)
 		fmt.Println(`Please refer to https://kubevela.io/docs/reference/addons/velaux for more VelaUX addon installation and visiting method.`)
 	}
 }


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>


### Description of your changes

There are some changes in `vela port-forward`, this PR fix the legacy prompt when enable velaux addon.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->