### PR TITLE
Feat: support dependsOn in deploy workflowstep

### DIFF
--- a/apis/core.oam.dev/v1beta1/resourcetracker_types.go
+++ b/apis/core.oam.dev/v1beta1/resourcetracker_types.go
@@ -191,10 +191,9 @@ func (in *ResourceTracker) findMangedResourceIndex(mr ManagedResource) int {
 	return -1
 }
 
-// AddManagedResource add object to managed resources, if exists, update
-func (in *ResourceTracker) AddManagedResource(rsc client.Object, metaOnly bool, creator common.ResourceCreatorRole) (updated bool) {
+func newManagedResourceFromResource(rsc client.Object) ManagedResource {
 	gvk := rsc.GetObjectKind().GroupVersionKind()
-	mr := ManagedResource{
+	return ManagedResource{
 		ClusterObjectReference: common.ClusterObjectReference{
 			ObjectReference: v1.ObjectReference{
 				APIVersion: gvk.GroupVersion().String(),
@@ -207,6 +206,17 @@ func (in *ResourceTracker) AddManagedResource(rsc client.Object, metaOnly bool, 
 		OAMObjectReference: common.NewOAMObjectReferenceFromObject(rsc),
 		Deleted:            false,
 	}
+}
+
+// ContainsManagedResource check if resource exists in ResourceTracker
+func (in *ResourceTracker) ContainsManagedResource(rsc client.Object) bool {
+	mr := newManagedResourceFromResource(rsc)
+	return in.findMangedResourceIndex(mr) >= 0
+}
+
+// AddManagedResource add object to managed resources, if exists, update
+func (in *ResourceTracker) AddManagedResource(rsc client.Object, metaOnly bool, creator common.ResourceCreatorRole) (updated bool) {
+	mr := newManagedResourceFromResource(rsc)
 	if !metaOnly {
 		mr.Data = &runtime.RawExtension{Object: rsc}
 	}

--- a/charts/vela-core/templates/defwithtemplate/deploy.yaml
+++ b/charts/vela-core/templates/defwithtemplate/deploy.yaml
@@ -15,41 +15,9 @@ spec:
         	"vela/op"
         )
 
-        deploy: op.#Steps & {
-        	load: op.#Load @step(1)
-        	_components: [ for k, v in load.value {v}]
-        	loadPoliciesInOrder: op.#LoadPoliciesInOrder & {
-        		if parameter.policies != _|_ {
-        					input: parameter.policies
-        				}
-        	}                     @step(2)
-        	_policies:            loadPoliciesInOrder.output
-        	handleDeployPolicies: op.#HandleDeployPolicies & {
-        		inputs: {
-        			components: _components
-        			policies:   _policies
-        		}
-        	}                   @step(3)
-        	_decisions:         handleDeployPolicies.outputs.decisions
-        	_patchedComponents: handleDeployPolicies.outputs.components
-        	deploy:             op.#ApplyComponents & {
-        		parallelism: parameter.parallelism
-        		components: {
-        			for decision in _decisions {
-        				for key, comp in _patchedComponents {
-        					"\(decision.cluster)-\(decision.namespace)-\(key)": {
-        						value: comp
-        						if decision.cluster != _|_ {
-        							cluster: decision.cluster
-        						}
-        						if decision.namespace != _|_ {
-        							namespace: decision.namespace
-        						}
-        					}
-        				}
-        			}
-        		}
-        	} @step(4)
+        deploy: op.#Deploy & {
+        	policies:    parameter.policies
+        	parallelism: parameter.parallelism
         }
         parameter: {
         	auto: *true | bool

--- a/charts/vela-minimal/templates/defwithtemplate/deploy.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/deploy.yaml
@@ -15,41 +15,9 @@ spec:
         	"vela/op"
         )
 
-        deploy: op.#Steps & {
-        	load: op.#Load @step(1)
-        	_components: [ for k, v in load.value {v}]
-        	loadPoliciesInOrder: op.#LoadPoliciesInOrder & {
-        		if parameter.policies != _|_ {
-        					input: parameter.policies
-        				}
-        	}                     @step(2)
-        	_policies:            loadPoliciesInOrder.output
-        	handleDeployPolicies: op.#HandleDeployPolicies & {
-        		inputs: {
-        			components: _components
-        			policies:   _policies
-        		}
-        	}                   @step(3)
-        	_decisions:         handleDeployPolicies.outputs.decisions
-        	_patchedComponents: handleDeployPolicies.outputs.components
-        	deploy:             op.#ApplyComponents & {
-        		parallelism: parameter.parallelism
-        		components: {
-        			for decision in _decisions {
-        				for key, comp in _patchedComponents {
-        					"\(decision.cluster)-\(decision.namespace)-\(key)": {
-        						value: comp
-        						if decision.cluster != _|_ {
-        							cluster: decision.cluster
-        						}
-        						if decision.namespace != _|_ {
-        							namespace: decision.namespace
-        						}
-        					}
-        				}
-        			}
-        		}
-        	} @step(4)
+        deploy: op.#Deploy & {
+        	policies:    parameter.policies
+        	parallelism: parameter.parallelism
         }
         parameter: {
         	auto: *true | bool

--- a/pkg/appfile/dryrun/testdata/wd-deploy.yaml
+++ b/pkg/appfile/dryrun/testdata/wd-deploy.yaml
@@ -12,41 +12,9 @@ spec:
         	"vela/op"
         )
 
-        deploy: op.#Steps & {
-        	load: op.#Load @step(1)
-        	_components: [ for k, v in load.value {v}]
-        	loadPoliciesInOrder: op.#LoadPoliciesInOrder & {
-        		if parameter.policies != _|_ {
-        					input: parameter.policies
-        				}
-        	}                     @step(2)
-        	_policies:            loadPoliciesInOrder.output
-        	handleDeployPolicies: op.#HandleDeployPolicies & {
-        		inputs: {
-        			components: _components
-        			policies:   _policies
-        		}
-        	}                   @step(3)
-        	_decisions:         handleDeployPolicies.outputs.decisions
-        	_patchedComponents: handleDeployPolicies.outputs.components
-        	deploy:             op.#ApplyComponents & {
-        		parallelism: parameter.parallelism
-        		components: {
-        			for decision in _decisions {
-        				for key, comp in _patchedComponents {
-        					"\(decision.cluster)-\(decision.namespace)-\(key)": {
-        						value: comp
-        						if decision.cluster != _|_ {
-        							cluster: decision.cluster
-        						}
-        						if decision.namespace != _|_ {
-        							namespace: decision.namespace
-        						}
-        					}
-        				}
-        			}
-        		}
-        	} @step(4)
+        deploy: op.#Deploy & {
+        	policies:    parameter.policies
+        	parallelism: parameter.parallelism
         }
         parameter: {
         	auto: *true | bool

--- a/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
+++ b/pkg/controller/core.oam.dev/v1alpha2/application/apply.go
@@ -212,6 +212,7 @@ func (h *AppHandler) ProduceArtifacts(ctx context.Context, comps []*types.Compon
 	return h.createResourcesConfigMap(ctx, h.currentAppRev, comps, policies)
 }
 
+// nolint
 func (h *AppHandler) collectHealthStatus(ctx context.Context, wl *appfile.Workload, appRev *v1beta1.ApplicationRevision, overrideNamespace string) (*common.ApplicationComponentStatus, bool, error) {
 	namespace := h.app.Namespace
 	if overrideNamespace != "" {

--- a/pkg/cue/model/value/value.go
+++ b/pkg/cue/model/value/value.go
@@ -516,6 +516,17 @@ func (val *Value) GetString(paths ...string) (string, error) {
 	return v.CueValue().String()
 }
 
+// GetStringSlice get string slice from val
+func (val *Value) GetStringSlice(paths ...string) ([]string, error) {
+	v, err := val.LookupValue(paths...)
+	if err != nil {
+		return nil, err
+	}
+	var s []string
+	err = v.UnmarshalTo(&s)
+	return s, err
+}
+
 // GetInt64 get the int value at a path starting from v.
 func (val *Value) GetInt64(paths ...string) (int64, error) {
 	v, err := val.LookupValue(paths...)

--- a/pkg/policy/envbinding/patch.go
+++ b/pkg/policy/envbinding/patch.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
@@ -180,7 +181,7 @@ func PatchComponents(baseComponents []common.ApplicationComponent, patchComponen
 			// 3. if the matched component uses a different type, the matched component will be overridden by the patch
 			// 4. if no component matches, and the component name is a valid kubernetes name, a new component will be added
 			addComponent := regexp.MustCompile("[a-z]([a-z-]{0,61}[a-z])?").MatchString(comp.Name)
-			if re, err := regexp.Compile(comp.Name); err == nil {
+			if re, err := regexp.Compile(strings.ReplaceAll(comp.Name, "*", ".*")); err == nil {
 				for compName, baseComp := range compMaps {
 					if re.MatchString(compName) {
 						addComponent = false

--- a/pkg/policy/topology_test.go
+++ b/pkg/policy/topology_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	clusterv1alpha1 "github.com/oam-dev/cluster-gateway/pkg/apis/cluster/v1alpha1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/apis/types"
+	"github.com/oam-dev/kubevela/pkg/features"
+	"github.com/oam-dev/kubevela/pkg/multicluster"
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+)
+
+func TestGetClusterLabelSelectorInTopology(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DeprecatedPolicySpec, true)()
+	multicluster.ClusterGatewaySecretNamespace = types.DefaultKubeVelaNS
+	cli := fake.NewClientBuilder().WithScheme(common.Scheme).WithObjects(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-a",
+			Namespace: multicluster.ClusterGatewaySecretNamespace,
+			Labels: map[string]string{
+				clusterv1alpha1.LabelKeyClusterCredentialType: string(clusterv1alpha1.CredentialTypeX509Certificate),
+				"key": "value",
+			},
+		},
+	}, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-b",
+			Namespace: multicluster.ClusterGatewaySecretNamespace,
+			Labels: map[string]string{
+				clusterv1alpha1.LabelKeyClusterCredentialType: string(clusterv1alpha1.CredentialTypeX509Certificate),
+				"key": "value",
+			},
+		},
+	}, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-c",
+			Namespace: multicluster.ClusterGatewaySecretNamespace,
+			Labels: map[string]string{
+				clusterv1alpha1.LabelKeyClusterCredentialType: string(clusterv1alpha1.CredentialTypeX509Certificate),
+				"key": "none",
+			},
+		},
+	}).Build()
+	appNs := "test"
+	testCases := map[string]struct {
+		Inputs              []v1beta1.AppPolicy
+		Outputs             []v1alpha1.PlacementDecision
+		Error               string
+		AllowCrossNamespace bool
+	}{
+		"invalid-topology-policy": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"cluster":"x"}`)},
+			}},
+			Error: "failed to parse topology policy",
+		},
+		"cluster-not-found": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"clusters":["cluster-x"]}`)},
+			}},
+			Error: "failed to get cluster",
+		},
+		"topology-by-clusters": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"clusters":["cluster-a"]}`)},
+			}},
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: ""}},
+		},
+		"topology-by-cluster-selector-404": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"clusterSelector":{"key":"bad-value"}}`)},
+			}},
+			Error: "failed to find any cluster matches given labels",
+		},
+		"topology-by-cluster-selector": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"clusterSelector":{"key":"value"}}`)},
+			}},
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: ""}, {Cluster: "cluster-b", Namespace: ""}},
+		},
+		"topology-by-cluster-label-selector": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"clusterLabelSelector":{"key":"value"}}`)},
+			}},
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: ""}, {Cluster: "cluster-b", Namespace: ""}},
+		},
+		"topology-by-cluster-selector-and-namespace-invalid": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"clusterSelector":{"key":"value"},"namespace":"override"}`)},
+			}},
+			Error: "cannot cross namespace",
+		},
+		"topology-by-cluster-selector-and-namespace": {
+			Inputs: []v1beta1.AppPolicy{{
+				Name:       "topology-policy",
+				Type:       "topology",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"clusterSelector":{"key":"value"},"namespace":"override"}`)},
+			}},
+			Outputs:             []v1alpha1.PlacementDecision{{Cluster: "cluster-a", Namespace: "override"}, {Cluster: "cluster-b", Namespace: "override"}},
+			AllowCrossNamespace: true,
+		},
+		"no-topology-policy": {
+			Inputs:  []v1beta1.AppPolicy{},
+			Outputs: []v1alpha1.PlacementDecision{{Cluster: "local", Namespace: ""}},
+		},
+	}
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			pds, err := GetPlacementsFromTopologyPolicies(context.Background(), cli, appNs, tt.Inputs, tt.AllowCrossNamespace)
+			if tt.Error != "" {
+				r.NotNil(err)
+				r.Contains(err.Error(), tt.Error)
+			} else {
+				r.NoError(err)
+				r.Equal(tt.Outputs, pds)
+			}
+		})
+	}
+}

--- a/pkg/resourcekeeper/containsresources.go
+++ b/pkg/resourcekeeper/containsresources.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcekeeper
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// ContainsResources check if resources all exist
+func (h *resourceKeeper) ContainsResources(resources []*unstructured.Unstructured) bool {
+	for _, rsc := range resources {
+		if rsc == nil {
+			continue
+		}
+		if (h._currentRT != nil && h._currentRT.ContainsManagedResource(rsc)) ||
+			(h._rootRT != nil && h._rootRT.ContainsManagedResource(rsc)) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/pkg/resourcekeeper/resourcekeeper.go
+++ b/pkg/resourcekeeper/resourcekeeper.go
@@ -41,6 +41,7 @@ type ResourceKeeper interface {
 	Delete(context.Context, []*unstructured.Unstructured, ...DeleteOption) error
 	GarbageCollect(context.Context, ...GCOption) (bool, []v1beta1.ManagedResource, error)
 	StateKeep(context.Context) error
+	ContainsResources([]*unstructured.Unstructured) bool
 
 	DispatchComponentRevision(context.Context, *v1.ControllerRevision) error
 	DeleteComponentRevision(context.Context, *v1.ControllerRevision) error

--- a/pkg/stdlib/op.cue
+++ b/pkg/stdlib/op.cue
@@ -25,6 +25,8 @@ import (
 
 #Delete: kube.#Delete
 
+#Deploy: multicluster.#Deploy
+
 #ApplyApplication: #Steps & {
 	load:       oam.#LoadComponetsInOrder @step(1)
 	components: #Steps & {
@@ -52,8 +54,6 @@ import (
 }
 
 #ApplyComponent: oam.#ApplyComponent
-
-#ApplyComponents: oam.#ApplyComponents
 
 #RenderComponent: oam.#RenderComponent
 
@@ -140,15 +140,11 @@ import (
 
 #ApplyEnvBindApp: multicluster.#ApplyEnvBindApp
 
-#HandleDeployPolicies: multicluster.#HandleDeployPolicies
-
 #DeployCloudResource: terraform.#DeployCloudResource
 
 #ShareCloudResource: terraform.#ShareCloudResource
 
 #LoadPolicies: oam.#LoadPolicies
-
-#LoadPoliciesInOrder: oam.#LoadPoliciesInOrder
 
 #ListClusters: multicluster.#ListClusters
 

--- a/pkg/stdlib/pkgs/multicluster.cue
+++ b/pkg/stdlib/pkgs/multicluster.cue
@@ -24,6 +24,7 @@
 		properties: {...}
 	}]
 	externalRevision?: string
+	dependsOn?: [...string]
 }
 
 #ReadPlacementDecisions: {
@@ -217,48 +218,9 @@
 	}
 }
 
-#ExpandTopology: {
+#Deploy: {
 	#provider: "multicluster"
-	#do:       "expand-topology"
-	inputs: {
-		policies: [...{...}]
-	}
-	outputs: {
-		decisions: [...#PlacementDecision]
-	}
-}
-
-#OverrideConfiguration: {
-	#provider: "multicluster"
-	#do:       "override-configuration"
-	inputs: {
-		policies: [...{...}]
-		components: [...#Component]
-	}
-	outputs: {
-		components: [...#Component]
-	}
-}
-
-#HandleDeployPolicies: #Steps & {
-	inputs: {
-		policies: [...{...}]
-		components: [...#Component]
-	}
-	_inputs:        inputs
-	expandTopology: #ExpandTopology & {
-		inputs: {
-			policies: _inputs.policies
-		}
-	}                      @step(1)
-	overrideConfiguration: #OverrideConfiguration & {
-		inputs: {
-			policies:   _inputs.policies
-			components: _inputs.components
-		}
-	} @step(2)
-	outputs: {
-		decisions:  expandTopology.outputs.decisions
-		components: overrideConfiguration.outputs.components
-	}
+	#do:       "deploy"
+	policies: [...string]
+	parallelism: int
 }

--- a/pkg/stdlib/pkgs/oam.cue
+++ b/pkg/stdlib/pkgs/oam.cue
@@ -10,22 +10,6 @@
 	...
 }
 
-#ApplyComponents: {
-	#provider:   "oam"
-	#do:         "components-apply"
-	parallelism: *5 | int
-	components: [string]: {
-		cluster:     *"" | string
-		env:         *"" | string
-		namespace:   *"" | string
-		waitHealthy: *true | bool
-		value: {...}
-		patch?: {...}
-		...
-	}
-	...
-}
-
 #RenderComponent: {
 	#provider: "oam"
 	#do:       "component-render"
@@ -49,14 +33,6 @@
 	#provider: "oam"
 	#do:       "load-policies"
 	value?: {...}
-	...
-}
-
-#LoadPoliciesInOrder: {
-	#provider: "oam"
-	#do:       "load-policies-in-order"
-	input?: [...string]
-	output?: [...{...}]
 	...
 }
 

--- a/pkg/workflow/providers/multicluster/deploy.go
+++ b/pkg/workflow/providers/multicluster/deploy.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/appfile"
+	pkgpolicy "github.com/oam-dev/kubevela/pkg/policy"
+	"github.com/oam-dev/kubevela/pkg/policy/envbinding"
+	"github.com/oam-dev/kubevela/pkg/resourcekeeper"
+	"github.com/oam-dev/kubevela/pkg/utils"
+	velaerrors "github.com/oam-dev/kubevela/pkg/utils/errors"
+	"github.com/oam-dev/kubevela/pkg/utils/parallel"
+	oamProvider "github.com/oam-dev/kubevela/pkg/workflow/providers/oam"
+)
+
+// DeployWorkflowStepExecutor executor to run deploy workflow step
+type DeployWorkflowStepExecutor interface {
+	Deploy(ctx context.Context, policyNames []string, parallelism int) (healthy bool, reason string, err error)
+}
+
+// NewDeployWorkflowStepExecutor .
+func NewDeployWorkflowStepExecutor(cli client.Client, af *appfile.Appfile, apply oamProvider.ComponentApply, healthCheck oamProvider.ComponentHealthCheck) DeployWorkflowStepExecutor {
+	return &deployWorkflowStepExecutor{
+		cli:         cli,
+		af:          af,
+		apply:       apply,
+		healthCheck: healthCheck,
+	}
+}
+
+type deployWorkflowStepExecutor struct {
+	cli         client.Client
+	af          *appfile.Appfile
+	apply       oamProvider.ComponentApply
+	healthCheck oamProvider.ComponentHealthCheck
+}
+
+// Deploy execute deploy workflow step
+func (executor *deployWorkflowStepExecutor) Deploy(ctx context.Context, policyNames []string, parallelism int) (bool, string, error) {
+	policies, err := selectPolicies(executor.af.Policies, policyNames)
+	if err != nil {
+		return false, "", err
+	}
+	components, err := loadComponents(ctx, executor.cli, executor.af, executor.af.Components)
+	if err != nil {
+		return false, "", err
+	}
+	placements, err := pkgpolicy.GetPlacementsFromTopologyPolicies(ctx, executor.cli, executor.af.Namespace, policies, resourcekeeper.AllowCrossNamespaceResource)
+	if err != nil {
+		return false, "", err
+	}
+	components, err = overrideConfiguration(policies, components)
+	if err != nil {
+		return false, "", err
+	}
+	return applyComponents(executor.apply, executor.healthCheck, components, placements, parallelism)
+}
+
+func selectPolicies(policies []v1beta1.AppPolicy, policyNames []string) ([]v1beta1.AppPolicy, error) {
+	policyMap := make(map[string]v1beta1.AppPolicy)
+	for _, policy := range policies {
+		policyMap[policy.Name] = policy
+	}
+	var selectedPolicies []v1beta1.AppPolicy
+	for _, policyName := range policyNames {
+		if policy, found := policyMap[policyName]; found {
+			selectedPolicies = append(selectedPolicies, policy)
+		} else {
+			return nil, errors.Errorf("policy %s not found", policyName)
+		}
+	}
+	return selectedPolicies, nil
+}
+
+func loadComponents(ctx context.Context, cli client.Client, af *appfile.Appfile, components []common.ApplicationComponent) ([]common.ApplicationComponent, error) {
+	var loadedComponents []common.ApplicationComponent
+	for _, comp := range components {
+		loadedComp, err := af.LoadDynamicComponent(ctx, cli, comp.DeepCopy())
+		if err != nil {
+			return nil, err
+		}
+		loadedComponents = append(loadedComponents, *loadedComp)
+	}
+	return loadedComponents, nil
+}
+
+func overrideConfiguration(policies []v1beta1.AppPolicy, components []common.ApplicationComponent) ([]common.ApplicationComponent, error) {
+	var err error
+	for _, policy := range policies {
+		if policy.Type == v1alpha1.OverridePolicyType {
+			overrideSpec := &v1alpha1.OverridePolicySpec{}
+			if err := utils.StrictUnmarshal(policy.Properties.Raw, overrideSpec); err != nil {
+				return nil, errors.Wrapf(err, "failed to parse override policy %s", policy.Name)
+			}
+			components, err = envbinding.PatchComponents(components, overrideSpec.Components, overrideSpec.Selector)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to apply override policy %s", policy.Name)
+			}
+		}
+	}
+	return components, nil
+}
+
+type applyTask struct {
+	component common.ApplicationComponent
+	placement v1alpha1.PlacementDecision
+}
+
+func (t *applyTask) key() string {
+	return fmt.Sprintf("%s/%s/%s", t.placement.Cluster, t.placement.Namespace, t.component.Name)
+}
+
+func (t *applyTask) dependents() []string {
+	var dependents []string
+	for _, dependent := range t.component.DependsOn {
+		dependents = append(dependents, fmt.Sprintf("%s/%s/%s", t.placement.Cluster, t.placement.Namespace, dependent))
+	}
+	return dependents
+}
+
+type applyTaskResult struct {
+	healthy bool
+	err     error
+}
+
+func applyComponents(apply oamProvider.ComponentApply, healthCheck oamProvider.ComponentHealthCheck, components []common.ApplicationComponent, placements []v1alpha1.PlacementDecision, parallelism int) (bool, string, error) {
+	var tasks []*applyTask
+	for _, comp := range components {
+		for _, pl := range placements {
+			tasks = append(tasks, &applyTask{component: comp, placement: pl})
+		}
+	}
+	healthCheckResults := parallel.Run(func(task *applyTask) *applyTaskResult {
+		healthy, err := healthCheck(task.component, nil, task.placement.Cluster, task.placement.Namespace, "")
+		return &applyTaskResult{healthy: healthy, err: err}
+	}, tasks, parallelism).([]*applyTaskResult)
+	taskHealthyMap := map[string]bool{}
+	for i, res := range healthCheckResults {
+		taskHealthyMap[tasks[i].key()] = res.healthy
+	}
+
+	var pendingTasks []*applyTask
+	var todoTasks []*applyTask
+	for _, task := range tasks {
+		if healthy, ok := taskHealthyMap[task.key()]; healthy && ok {
+			continue
+		}
+		pending := false
+		for _, dep := range task.dependents() {
+			if healthy, ok := taskHealthyMap[dep]; ok && !healthy {
+				pending = true
+				break
+			}
+		}
+		if pending {
+			pendingTasks = append(pendingTasks, task)
+		} else {
+			todoTasks = append(todoTasks, task)
+		}
+	}
+	var results []*applyTaskResult
+	if len(todoTasks) > 0 {
+		results = parallel.Run(func(task *applyTask) *applyTaskResult {
+			_, _, healthy, err := apply(task.component, nil, task.placement.Cluster, task.placement.Namespace, "")
+			return &applyTaskResult{healthy: healthy, err: err}
+		}, todoTasks, parallelism).([]*applyTaskResult)
+	}
+	var errs []error
+	var allHealthy = true
+	var reasons []string
+	for i, res := range results {
+		if res.err != nil {
+			errs = append(errs, res.err)
+		}
+		if !res.healthy {
+			allHealthy = false
+			reasons = append(reasons, fmt.Sprintf("%s is not healthy", todoTasks[i].key()))
+		}
+	}
+
+	for _, t := range pendingTasks {
+		reasons = append(reasons, fmt.Sprintf("%s is waiting dependents", t.key()))
+	}
+
+	return allHealthy && len(pendingTasks) == 0, strings.Join(reasons, ","), velaerrors.AggregateErrors(errs)
+}

--- a/pkg/workflow/providers/multicluster/deploy_test.go
+++ b/pkg/workflow/providers/multicluster/deploy_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicluster
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	apicommon "github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1alpha1"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/cue/model/value"
+)
+
+func TestOverrideConfiguration(t *testing.T) {
+	testCases := map[string]struct {
+		Policies   []v1beta1.AppPolicy
+		Components []apicommon.ApplicationComponent
+		Outputs    []apicommon.ApplicationComponent
+		Error      string
+	}{
+		"invalid-policies": {
+			Policies: []v1beta1.AppPolicy{{
+				Name:       "override-policy",
+				Type:       "override",
+				Properties: &runtime.RawExtension{Raw: []byte(`bad value`)},
+			}},
+			Error: "failed to parse override policy",
+		},
+		"normal": {
+			Policies: []v1beta1.AppPolicy{{
+				Name:       "override-policy",
+				Type:       "override",
+				Properties: &runtime.RawExtension{Raw: []byte(`{"components":[{"name":"comp","properties":{"x":5}}]}`)},
+			}},
+			Components: []apicommon.ApplicationComponent{{
+				Name:       "comp",
+				Traits:     []apicommon.ApplicationTrait{},
+				Properties: &runtime.RawExtension{Raw: []byte(`{"x":1}`)},
+			}},
+			Outputs: []apicommon.ApplicationComponent{{
+				Name:       "comp",
+				Traits:     []apicommon.ApplicationTrait{},
+				Properties: &runtime.RawExtension{Raw: []byte(`{"x":5}`)},
+			}},
+		},
+	}
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			comps, err := overrideConfiguration(tt.Policies, tt.Components)
+			if tt.Error != "" {
+				r.NotNil(err)
+				r.Contains(err.Error(), tt.Error)
+			} else {
+				r.NoError(err)
+				r.Equal(tt.Outputs, comps)
+			}
+		})
+	}
+}
+
+func TestApplyComponents(t *testing.T) {
+	r := require.New(t)
+	const n, m = 50, 5
+	var components []apicommon.ApplicationComponent
+	var placements []v1alpha1.PlacementDecision
+	for i := 0; i < n*3; i++ {
+		comp := apicommon.ApplicationComponent{Name: fmt.Sprintf("comp-%d", i)}
+		if i%3 != 0 {
+			comp.DependsOn = append(comp.DependsOn, fmt.Sprintf("comp-%d", i-1))
+		}
+		if i%3 == 2 {
+			comp.DependsOn = append(comp.DependsOn, fmt.Sprintf("comp-%d", i-1))
+		}
+		components = append(components, comp)
+	}
+	for i := 0; i < m; i++ {
+		placements = append(placements, v1alpha1.PlacementDecision{Cluster: fmt.Sprintf("cluster-%d", i)})
+	}
+
+	applyMap := &sync.Map{}
+	apply := func(comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
+		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
+		applyMap.Store(fmt.Sprintf("%s/%s", clusterName, comp.Name), true)
+		return nil, nil, true, nil
+	}
+	healthCheck := func(comp apicommon.ApplicationComponent, patcher *value.Value, clusterName string, overrideNamespace string, env string) (bool, error) {
+		_, found := applyMap.Load(fmt.Sprintf("%s/%s", clusterName, comp.Name))
+		return found, nil
+	}
+	parallelism := 10
+
+	countMap := func() int {
+		cnt := 0
+		applyMap.Range(func(key, value interface{}) bool {
+			cnt++
+			return true
+		})
+		return cnt
+	}
+
+	healthy, _, err := applyComponents(apply, healthCheck, components, placements, parallelism)
+	r.NoError(err)
+	r.False(healthy)
+	r.Equal(n*m, countMap())
+
+	healthy, _, err = applyComponents(apply, healthCheck, components, placements, parallelism)
+	r.NoError(err)
+	r.False(healthy)
+	r.Equal(2*n*m, countMap())
+
+	healthy, _, err = applyComponents(apply, healthCheck, components, placements, parallelism)
+	r.NoError(err)
+	r.True(healthy)
+	r.Equal(3*n*m, countMap())
+}

--- a/pkg/workflow/providers/oam/apply_test.go
+++ b/pkg/workflow/providers/oam/apply_test.go
@@ -17,20 +17,16 @@ limitations under the License.
 package oam
 
 import (
-	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/rand"
-
-	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
-	"github.com/oam-dev/kubevela/pkg/appfile"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
 
 	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
 	"github.com/oam-dev/kubevela/pkg/cue/model/value"
@@ -141,65 +137,6 @@ outputs: {
 `)
 }
 
-func TestApplyComponents(t *testing.T) {
-	r := require.New(t)
-	testcases := map[string]struct {
-		Input string
-		Error string
-	}{
-		"normal": {
-			Input: `{components:{first:{value:{name:"first"}},second:{value:{name:"second"}}},parallelism:5}`,
-		},
-		"no-components": {
-			Input: `{}`,
-			Error: "var(path=components) not exist",
-		},
-		"no-parallelism": {
-			Input: `{components:{first:{value:{name:"first"}},second:{value:{name:"second"}}}}`,
-			Error: "var(path=parallelism) not exist",
-		},
-		"invalid-parallelism": {
-			Input: `{components:{first:{value:{name:"first"}},second:{value:{name:"second"}}},parallelism:-1}`,
-			Error: "parallelism cannot be smaller than 1",
-		},
-		"bad-component": {
-			Input: `{components:{first:{value:{name:"error-first"}},second:{value:{name:"error-second"}},third:{value:{name:"third"}}},parallelism:5}`,
-			Error: "failed to apply component",
-		},
-	}
-	p := &provider{apply: simpleComponentApplyForTest}
-	for name, tt := range testcases {
-		t.Run(name, func(t *testing.T) {
-			act := &mock.Action{}
-			v, err := value.NewValue("", nil, "")
-			r.NoError(err)
-			r.NoError(v.FillRaw(tt.Input))
-			err = p.ApplyComponents(nil, v, act)
-			if tt.Error != "" {
-				r.NotNil(err)
-				r.Contains(err.Error(), tt.Error)
-			} else {
-				r.NoError(err)
-			}
-		})
-	}
-}
-
-func TestApplyComponentsHard(t *testing.T) {
-	r := require.New(t)
-	input := `comp0:{value:{name:"comp0"}}`
-	for i := 1; i < 1000; i++ {
-		input += fmt.Sprintf(`,comp%d:{value:{name:"comp%d"}}`, i, i)
-	}
-	input = fmt.Sprintf(`{components:{%s},parallelism:50}`, input)
-	p := &provider{apply: delayedComponentApplyForTest}
-	act := &mock.Action{}
-	v, err := value.NewValue("", nil, "")
-	r.NoError(err)
-	r.NoError(v.FillRaw(input))
-	r.NoError(p.ApplyComponents(nil, v, act))
-}
-
 func TestLoadComponent(t *testing.T) {
 	r := require.New(t)
 	p := &provider{
@@ -299,57 +236,6 @@ func TestLoadComponentInOrder(t *testing.T) {
 `)
 }
 
-func TestLoadPolicyInOrder(t *testing.T) {
-	r := require.New(t)
-	p := &provider{af: &appfile.Appfile{
-		Policies: []v1beta1.AppPolicy{{Name: "policy-1"}, {Name: "policy-2"}, {Name: "policy-3"}},
-	}, app: &v1beta1.Application{
-		Spec: v1beta1.ApplicationSpec{Policies: []v1beta1.AppPolicy{{Name: "policy-1"}, {Name: "policy-2"}}},
-	}}
-	testcases := map[string]struct {
-		Input  string
-		Output []v1beta1.AppPolicy
-		Error  string
-	}{
-		"normal": {
-			Input:  `{input:["policy-3","policy-1"]}`,
-			Output: []v1beta1.AppPolicy{{Name: "policy-3"}, {Name: "policy-1"}},
-		},
-		"empty-input": {
-			Input:  `{}`,
-			Output: []v1beta1.AppPolicy{{Name: "policy-1"}, {Name: "policy-2"}},
-		},
-		"invalid-input": {
-			Input: `{input:{"name":"policy"}}`,
-			Error: "failed to parse specified policy name",
-		},
-		"policy-not-found": {
-			Input: `{input:["policy-4","policy-1"]}`,
-			Error: "not found",
-		},
-	}
-	for name, tt := range testcases {
-		t.Run(name, func(t *testing.T) {
-			act := &mock.Action{}
-			v, err := value.NewValue("", nil, "")
-			r.NoError(err)
-			r.NoError(v.FillRaw(tt.Input))
-			err = p.LoadPoliciesInOrder(nil, v, act)
-			if tt.Error != "" {
-				r.NotNil(err)
-				r.Contains(err.Error(), tt.Error)
-			} else {
-				r.NoError(err)
-				v, err = v.LookupValue("output")
-				r.NoError(err)
-				var outputPolicies []v1beta1.AppPolicy
-				r.NoError(v.UnmarshalTo(&outputPolicies))
-				r.Equal(tt.Output, outputPolicies)
-			}
-		})
-	}
-}
-
 var testHealthy bool
 
 func simpleComponentApplyForTest(comp common.ApplicationComponent, _ *value.Value, _ string, _ string, _ string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
@@ -386,9 +272,4 @@ func simpleComponentApplyForTest(comp common.ApplicationComponent, _ *value.Valu
 	}
 	traits := []*unstructured.Unstructured{trait}
 	return workload, traits, testHealthy, nil
-}
-
-func delayedComponentApplyForTest(comp common.ApplicationComponent, v *value.Value, x string, y string, z string) (*unstructured.Unstructured, []*unstructured.Unstructured, bool, error) {
-	time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
-	return simpleComponentApplyForTest(comp, v, x, y, z)
 }

--- a/pkg/workflow/types/types.go
+++ b/pkg/workflow/types/types.go
@@ -88,6 +88,8 @@ const (
 	ContextPrefixFailedTimes = "failed_times"
 	// ContextPrefixBackoffTimes is the prefix that refer to the backoff times in workflow context config map.
 	ContextPrefixBackoffTimes = "backoff_times"
+	// ContextPrefixBackoffReason is the prefix that refer to the current backoff reason in workflow context config map
+	ContextPrefixBackoffReason = "backoff_reason"
 	// ContextKeyLastExecuteTime is the key that refer to the last execute time in workflow context config map.
 	ContextKeyLastExecuteTime = "last_execute_time"
 	// ContextKeyNextExecuteTime is the key that refer to the next execute time in workflow context config map.

--- a/references/cli/status.go
+++ b/references/cli/status.go
@@ -403,7 +403,7 @@ func printApplicationTree(c common.Args, cmd *cobra.Command, appName string, app
 	var placements []v1alpha1.PlacementDecision
 	af, err := pkgappfile.NewApplicationParser(cli, dm, pd).GenerateAppFile(context.Background(), app)
 	if err == nil {
-		placements, _ = policy.GetPlacementsFromTopologyPolicies(context.Background(), cli, app, af.Policies, true)
+		placements, _ = policy.GetPlacementsFromTopologyPolicies(context.Background(), cli, app.GetNamespace(), af.Policies, true)
 	}
 	format, _ := cmd.Flags().GetString("detail-format")
 	var maxWidth *int

--- a/vela-templates/definitions/internal/workflowstep/deploy.cue
+++ b/vela-templates/definitions/internal/workflowstep/deploy.cue
@@ -9,41 +9,9 @@ import (
 	description: "Deploy components with policies."
 }
 template: {
-	deploy: op.#Steps & {
-		load: op.#Load @step(1)
-		_components: [ for k, v in load.value {v}]
-		loadPoliciesInOrder: op.#LoadPoliciesInOrder & {
-			if parameter.policies != _|_ {
-						input: parameter.policies
-					}
-		}                     @step(2)
-		_policies:            loadPoliciesInOrder.output
-		handleDeployPolicies: op.#HandleDeployPolicies & {
-			inputs: {
-				components: _components
-				policies:   _policies
-			}
-		}                   @step(3)
-		_decisions:         handleDeployPolicies.outputs.decisions
-		_patchedComponents: handleDeployPolicies.outputs.components
-		deploy:             op.#ApplyComponents & {
-			parallelism: parameter.parallelism
-			components: {
-				for decision in _decisions {
-					for key, comp in _patchedComponents {
-						"\(decision.cluster)-\(decision.namespace)-\(key)": {
-							value: comp
-							if decision.cluster != _|_ {
-								cluster: decision.cluster
-							}
-							if decision.namespace != _|_ {
-								namespace: decision.namespace
-							}
-						}
-					}
-				}
-			}
-		} @step(4)
+	deploy: op.#Deploy & {
+		policies:    parameter.policies
+		parallelism: parameter.parallelism
 	}
 	parameter: {
 		auto: *true | bool


### PR DESCRIPTION
Signed-off-by: Somefive <yd219913@alibaba-inc.com>


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1. Rework the implementation of `deploy` workflowstep into GoLang in avoid of infinite loop explosion in CUELang. https://github.com/cue-lang/cue/issues/1660 This re-implementation does not affect any usage for `deploy` step.
2. `deploy` step supports `dependsOn` in components. This is done by (a) pre-check the health status of all components; (b) only apply components that have all dependents ready but are not healthy yet; (c) if not all components are healthy, wait for next reconcile loop. The backoff time will be reset when message changes.
3. If no topology policy specified in `deploy` step, previously no cluster will be deployed. In this PR, the default behavior is to deploy to the local cluster.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->