### PR TITLE
Chore: sync the cli binaries to OSS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  BUCKET: ${{ secrets.CLI_OSS_BUCKET }}
+  ENDPOINT: ${{ secrets.CLI_OSS_ENDPOINT }}
+  ACCESS_KEY: ${{ secrets.CLI_OSS_ACCESS_KEY }}
+  ACCESS_KEY_SECRET: ${{ secrets.CLI_OSS_ACCESS_KEY_SECRET }}
 
 jobs:
   build:
@@ -104,6 +108,18 @@ jobs:
           name: sha256sums
           path: ./_bin/sha256-${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}.txt
           retention-days: 1
+      - name: Install ossutil
+        run: wget http://gosspublic.alicdn.com/ossutil/1.7.0/ossutil64 && chmod +x ossutil64 && mv ossutil64 ossutil
+      - name: Configure Alibaba Cloud OSSUTIL
+        run: ./ossutil --config-file .ossutilconfig config -i ${ACCESS_KEY} -k ${ACCESS_KEY_SECRET} -e ${ENDPOINT} -c .ossutilconfig
+      - name: sync local to cloud
+        run: ./ossutil --config-file .ossutilconfig sync ./_bin/vela oss://$BUCKET/binary/vela/${{ env.VELA_VERSION }}
+      - name: sync the latest version file
+        run: |
+          touch ${{ env.VELA_VERSION }} > ./latest_version
+          ./ossutil --config-file .ossutilconfig ./latest_version oss://$BUCKET/binary/vela/latest_version
+
+
 
   upload-plugin-homebrew:
     needs: build

--- a/references/cli/traits.go
+++ b/references/cli/traits.go
@@ -237,7 +237,7 @@ func PrintInstalledTraitDef(c common2.Args, io cmdutil.IOStreams, filter filterF
 		}
 		capa, err := ParseCapability(dm, data)
 		if err != nil {
-			io.Errorf("error parsing capability: %s\n", td.Name)
+			io.Errorf("error parsing capability: %s (message: %s)\n", td.Name, err.Error())
 			continue
 		}
 		if filter != nil && !filter(capa) {


### PR DESCRIPTION
### Description of your changes

The PR oam-dev/kubevela.io#627 changes the script to install the vela form OSS, so, we should sync the vela new versioned binaries to OSS.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->