### PR TITLE
Feat: Support trait with custom resource be dispatched to hubcluster

### DIFF
--- a/apis/core.oam.dev/v1beta1/core_types.go
+++ b/apis/core.oam.dev/v1beta1/core_types.go
@@ -157,6 +157,9 @@ type TraitDefinitionSpec struct {
 	// SkipRevisionAffect defines the update this trait will not generate a new application Revision
 	// +optional
 	SkipRevisionAffect bool `json:"skipRevisionAffect,omitempty"`
+	// ControlPlaneOnly defines which cluster is dispatched to
+	// +optional
+	ControlPlaneOnly bool `json:"controlPlaneOnly,omitempty"`
 }
 
 // TraitDefinitionStatus is the status of TraitDefinition

--- a/charts/oam-runtime/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/oam-runtime/crds/core.oam.dev_traitdefinitions.yaml
@@ -372,6 +372,10 @@ spec:
                 items:
                   type: string
                 type: array
+              controlPlaneOnly:
+                description: ControlPlaneOnly defines which cluster is dispatched
+                  to
+                type: boolean
               definitionRef:
                 description: Reference to the CustomResourceDefinition that defines
                   this trait kind.

--- a/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_applicationrevisions.yaml
@@ -3585,6 +3585,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        controlPlaneOnly:
+                          description: ControlPlaneOnly defines which cluster is dispatched
+                            to
+                          type: boolean
                         definitionRef:
                           description: Reference to the CustomResourceDefinition that
                             defines this trait kind.

--- a/charts/vela-core/crds/core.oam.dev_definitionrevisions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_definitionrevisions.yaml
@@ -724,6 +724,10 @@ spec:
                         items:
                           type: string
                         type: array
+                      controlPlaneOnly:
+                        description: ControlPlaneOnly defines which cluster is dispatched
+                          to
+                        type: boolean
                       definitionRef:
                         description: Reference to the CustomResourceDefinition that
                           defines this trait kind.

--- a/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/vela-core/crds/core.oam.dev_traitdefinitions.yaml
@@ -372,6 +372,10 @@ spec:
                 items:
                   type: string
                 type: array
+              controlPlaneOnly:
+                description: ControlPlaneOnly defines which cluster is dispatched
+                  to
+                type: boolean
               definitionRef:
                 description: Reference to the CustomResourceDefinition that defines
                   this trait kind.

--- a/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_applicationrevisions.yaml
@@ -3585,6 +3585,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        controlPlaneOnly:
+                          description: ControlPlaneOnly defines which cluster is dispatched
+                            to
+                          type: boolean
                         definitionRef:
                           description: Reference to the CustomResourceDefinition that
                             defines this trait kind.

--- a/charts/vela-minimal/crds/core.oam.dev_definitionrevisions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_definitionrevisions.yaml
@@ -724,6 +724,10 @@ spec:
                         items:
                           type: string
                         type: array
+                      controlPlaneOnly:
+                        description: ControlPlaneOnly defines which cluster is dispatched
+                          to
+                        type: boolean
                       definitionRef:
                         description: Reference to the CustomResourceDefinition that
                           defines this trait kind.

--- a/charts/vela-minimal/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/vela-minimal/crds/core.oam.dev_traitdefinitions.yaml
@@ -372,6 +372,10 @@ spec:
                 items:
                   type: string
                 type: array
+              controlPlaneOnly:
+                description: ControlPlaneOnly defines which cluster is dispatched
+                  to
+                type: boolean
               definitionRef:
                 description: Reference to the CustomResourceDefinition that defines
                   this trait kind.

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_applicationrevisions.yaml
@@ -3585,6 +3585,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        controlPlaneOnly:
+                          description: ControlPlaneOnly defines which cluster is dispatched
+                            to
+                          type: boolean
                         definitionRef:
                           description: Reference to the CustomResourceDefinition that
                             defines this trait kind.

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_definitionrevisions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_definitionrevisions.yaml
@@ -724,6 +724,10 @@ spec:
                         items:
                           type: string
                         type: array
+                      controlPlaneOnly:
+                        description: ControlPlaneOnly defines which cluster is dispatched
+                          to
+                        type: boolean
                       definitionRef:
                         description: Reference to the CustomResourceDefinition that
                           defines this trait kind.

--- a/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
+++ b/legacy/charts/vela-core-legacy/crds/core.oam.dev_traitdefinitions.yaml
@@ -372,6 +372,10 @@ spec:
                 items:
                   type: string
                 type: array
+              controlPlaneOnly:
+                description: ControlPlaneOnly defines which cluster is dispatched
+                  to
+                type: boolean
               definitionRef:
                 description: Reference to the CustomResourceDefinition that defines
                   this trait kind.


### PR DESCRIPTION
Signed-off-by: Xiangbo Ma <maxiangboo@cmbchina.com>


### Description of your changes
Support trait with custom resource be dispatched to hubcluster
Fixes https://github.com/oam-dev/kubevela/issues/3754
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

