### PR TITLE
Fix: Add application name to the generated workload entities

### DIFF
--- a/charts/vela-core/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/cron-task.yaml
@@ -24,11 +24,17 @@ spec:
         			startingDeadlineSeconds: parameter.startingDeadlineSeconds
         		}
         		jobTemplate: {
-        			if parameter.labels != _|_ {
-        				metadata: labels: parameter.labels
-        			}
-        			if parameter.annotations != _|_ {
-        				metadata: annotations: parameter.annotations
+        			metadata: {
+        				labels: {
+        					if parameter.labels != _|_ {
+        						parameter.labels
+        					}
+        					"app.oam.dev/name":      context.appName
+        					"app.oam.dev/component": context.name
+        				}
+        				if parameter.annotations != _|_ {
+        					annotations: parameter.annotations
+        				}
         			}
         			spec: {
         				parallelism: parameter.count
@@ -41,11 +47,17 @@ spec:
         				}
         				backoffLimit: parameter.backoffLimit
         				template: {
-        					if parameter.labels != _|_ {
-        						metadata: labels: parameter.labels
-        					}
-        					if parameter.annotations != _|_ {
-        						metadata: annotations: parameter.annotations
+        					metadata: {
+        						labels: {
+        							if parameter.labels != _|_ {
+        								parameter.labels
+        							}
+        							"app.oam.dev/name":      context.appName
+        							"app.oam.dev/component": context.name
+        						}
+        						if parameter.annotations != _|_ {
+        							annotations: parameter.annotations
+        						}
         					}
         					spec: {
         						restartPolicy: parameter.restart

--- a/charts/vela-core/templates/defwithtemplate/task.yaml
+++ b/charts/vela-core/templates/defwithtemplate/task.yaml
@@ -18,11 +18,17 @@ spec:
         		parallelism: parameter.count
         		completions: parameter.count
         		template: {
-        			if parameter.labels != _|_ {
-        				metadata: labels: parameter.labels
-        			}
-        			if parameter.annotations != _|_ {
-        				metadata: annotations: parameter.annotations
+        			metadata: {
+        				labels: {
+        					if parameter.labels != _|_ {
+        						parameter.labels
+        					}
+        					"app.oam.dev/name":      context.appName
+        					"app.oam.dev/component": context.name
+        				}
+        				if parameter.annotations != _|_ {
+        					annotations: parameter.annotations
+        				}
         			}
         			spec: {
         				restartPolicy: parameter.restart

--- a/charts/vela-core/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-core/templates/defwithtemplate/webservice.yaml
@@ -134,6 +134,7 @@ spec:
         					if parameter.addRevisionLabel {
         						"app.oam.dev/revision": context.revision
         					}
+        					"app.oam.dev/name":      context.appName
         					"app.oam.dev/component": context.name
         				}
         				if parameter.annotations != _|_ {

--- a/charts/vela-core/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-core/templates/defwithtemplate/worker.yaml
@@ -124,7 +124,10 @@ spec:
         		selector: matchLabels: "app.oam.dev/component": context.name
 
         		template: {
-        			metadata: labels: "app.oam.dev/component": context.name
+        			metadata: labels: {
+        				"app.oam.dev/name":      context.appName
+        				"app.oam.dev/component": context.name
+        			}
 
         			spec: {
         				containers: [{

--- a/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/cron-task.yaml
@@ -24,11 +24,17 @@ spec:
         			startingDeadlineSeconds: parameter.startingDeadlineSeconds
         		}
         		jobTemplate: {
-        			if parameter.labels != _|_ {
-        				metadata: labels: parameter.labels
-        			}
-        			if parameter.annotations != _|_ {
-        				metadata: annotations: parameter.annotations
+        			metadata: {
+        				labels: {
+        					if parameter.labels != _|_ {
+        						parameter.labels
+        					}
+        					"app.oam.dev/name":      context.appName
+        					"app.oam.dev/component": context.name
+        				}
+        				if parameter.annotations != _|_ {
+        					annotations: parameter.annotations
+        				}
         			}
         			spec: {
         				parallelism: parameter.count
@@ -41,11 +47,17 @@ spec:
         				}
         				backoffLimit: parameter.backoffLimit
         				template: {
-        					if parameter.labels != _|_ {
-        						metadata: labels: parameter.labels
-        					}
-        					if parameter.annotations != _|_ {
-        						metadata: annotations: parameter.annotations
+        					metadata: {
+        						labels: {
+        							if parameter.labels != _|_ {
+        								parameter.labels
+        							}
+        							"app.oam.dev/name":      context.appName
+        							"app.oam.dev/component": context.name
+        						}
+        						if parameter.annotations != _|_ {
+        							annotations: parameter.annotations
+        						}
         					}
         					spec: {
         						restartPolicy: parameter.restart

--- a/charts/vela-minimal/templates/defwithtemplate/task.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/task.yaml
@@ -18,11 +18,17 @@ spec:
         		parallelism: parameter.count
         		completions: parameter.count
         		template: {
-        			if parameter.labels != _|_ {
-        				metadata: labels: parameter.labels
-        			}
-        			if parameter.annotations != _|_ {
-        				metadata: annotations: parameter.annotations
+        			metadata: {
+        				labels: {
+        					if parameter.labels != _|_ {
+        						parameter.labels
+        					}
+        					"app.oam.dev/name":      context.appName
+        					"app.oam.dev/component": context.name
+        				}
+        				if parameter.annotations != _|_ {
+        					annotations: parameter.annotations
+        				}
         			}
         			spec: {
         				restartPolicy: parameter.restart

--- a/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/webservice.yaml
@@ -134,6 +134,7 @@ spec:
         					if parameter.addRevisionLabel {
         						"app.oam.dev/revision": context.revision
         					}
+        					"app.oam.dev/name":      context.appName
         					"app.oam.dev/component": context.name
         				}
         				if parameter.annotations != _|_ {

--- a/charts/vela-minimal/templates/defwithtemplate/worker.yaml
+++ b/charts/vela-minimal/templates/defwithtemplate/worker.yaml
@@ -124,7 +124,10 @@ spec:
         		selector: matchLabels: "app.oam.dev/component": context.name
 
         		template: {
-        			metadata: labels: "app.oam.dev/component": context.name
+        			metadata: labels: {
+        				"app.oam.dev/name":      context.appName
+        				"app.oam.dev/component": context.name
+        			}
 
         			spec: {
         				containers: [{

--- a/vela-templates/definitions/internal/component/cron-task.cue
+++ b/vela-templates/definitions/internal/component/cron-task.cue
@@ -30,7 +30,7 @@ template: {
 						if parameter.labels != _|_ {
 							parameter.labels
 						}
-						"app.oam.dev/name": context.appName
+						"app.oam.dev/name":      context.appName
 						"app.oam.dev/component": context.name
 					}
 					if parameter.annotations != _|_ {
@@ -53,7 +53,7 @@ template: {
 								if parameter.labels != _|_ {
 									parameter.labels
 								}
-								"app.oam.dev/name": context.appName
+								"app.oam.dev/name":      context.appName
 								"app.oam.dev/component": context.name
 							}
 							if parameter.annotations != _|_ {

--- a/vela-templates/definitions/internal/component/cron-task.cue
+++ b/vela-templates/definitions/internal/component/cron-task.cue
@@ -25,11 +25,17 @@ template: {
 				startingDeadlineSeconds: parameter.startingDeadlineSeconds
 			}
 			jobTemplate: {
-				if parameter.labels != _|_ {
-					metadata: labels: parameter.labels
-				}
-				if parameter.annotations != _|_ {
-					metadata: annotations: parameter.annotations
+				metadata: {
+					labels: {
+						if parameter.labels != _|_ {
+							parameter.labels
+						}
+						"app.oam.dev/name": context.appName
+						"app.oam.dev/component": context.name
+					}
+					if parameter.annotations != _|_ {
+						annotations: parameter.annotations
+					}
 				}
 				spec: {
 					parallelism: parameter.count
@@ -42,11 +48,17 @@ template: {
 					}
 					backoffLimit: parameter.backoffLimit
 					template: {
-						if parameter.labels != _|_ {
-							metadata: labels: parameter.labels
-						}
-						if parameter.annotations != _|_ {
-							metadata: annotations: parameter.annotations
+						metadata: {
+							labels: {
+								if parameter.labels != _|_ {
+									parameter.labels
+								}
+								"app.oam.dev/name": context.appName
+								"app.oam.dev/component": context.name
+							}
+							if parameter.annotations != _|_ {
+								annotations: parameter.annotations
+							}
 						}
 						spec: {
 							restartPolicy: parameter.restart

--- a/vela-templates/definitions/internal/component/task.cue
+++ b/vela-templates/definitions/internal/component/task.cue
@@ -53,7 +53,7 @@ template: {
 						if parameter.labels != _|_ {
 							parameter.labels
 						}
-						"app.oam.dev/name": context.appName
+						"app.oam.dev/name":      context.appName
 						"app.oam.dev/component": context.name
 					}
 					if parameter.annotations != _|_ {

--- a/vela-templates/definitions/internal/component/task.cue
+++ b/vela-templates/definitions/internal/component/task.cue
@@ -48,11 +48,17 @@ template: {
 			parallelism: parameter.count
 			completions: parameter.count
 			template: {
-				if parameter.labels != _|_ {
-					metadata: labels: parameter.labels
-				}
-				if parameter.annotations != _|_ {
-					metadata: annotations: parameter.annotations
+				metadata: {
+					labels: {
+						if parameter.labels != _|_ {
+							parameter.labels
+						}
+						"app.oam.dev/name": context.appName
+						"app.oam.dev/component": context.name
+					}
+					if parameter.annotations != _|_ {
+						annotations: parameter.annotations
+					}
 				}
 				spec: {
 					restartPolicy: parameter.restart

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -177,6 +177,7 @@ template: {
 						if parameter.addRevisionLabel {
 							"app.oam.dev/revision": context.revision
 						}
+						"app.oam.dev/name": context.appName
 						"app.oam.dev/component": context.name
 					}
 					if parameter.annotations != _|_ {

--- a/vela-templates/definitions/internal/component/webservice.cue
+++ b/vela-templates/definitions/internal/component/webservice.cue
@@ -177,7 +177,7 @@ template: {
 						if parameter.addRevisionLabel {
 							"app.oam.dev/revision": context.revision
 						}
-						"app.oam.dev/name": context.appName
+						"app.oam.dev/name":      context.appName
 						"app.oam.dev/component": context.name
 					}
 					if parameter.annotations != _|_ {

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -167,7 +167,7 @@ template: {
 			template: {
 				metadata: {
 					labels: {
-						"app.oam.dev/name": context.appName
+						"app.oam.dev/name":      context.appName
 						"app.oam.dev/component": context.name
 					}
 				}

--- a/vela-templates/definitions/internal/component/worker.cue
+++ b/vela-templates/definitions/internal/component/worker.cue
@@ -165,7 +165,12 @@ template: {
 			selector: matchLabels: "app.oam.dev/component": context.name
 
 			template: {
-				metadata: labels: "app.oam.dev/component": context.name
+				metadata: {
+					labels: {
+						"app.oam.dev/name": context.appName
+						"app.oam.dev/component": context.name
+					}
+				}
 
 				spec: {
 					containers: [{


### PR DESCRIPTION
### Description of your changes

This PR adds the application name to the generated workloads metadata labels (e.g., deployments, jobs, etc) that are created using the standard component types: `webservice`, `worker`, `task`, and `cron-task`.

The motivation behind this change is to maintain the old behavior of the previous kubernetes runtime where generated entities such as deployments or their resulting pods carried the labels of the parent application and component. That enabled using label selectors to get all pods of an application:

```bash
$ k get pods -l=app.oam.dev/name=first-vela-app-as-webservice
NAME                                         READY   STATUS    RESTARTS   AGE
express-server-webservice-54dcccbf4b-qcskl   1/1     Running   0          2m21s
```

The ability of retrieving pods by application name and/or component is quite convenient for both final users and intermediate tools that rely on that capability.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary. 
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

To test the changes, deploy the updated component definitions, and deploy example applications. For example:

<details>
<summary>Webservice application</summary>

```
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: first-vela-app-as-webservice
spec:
  components:
    - name: express-server-webservice
      type: webservice
      properties:
        image: crccheck/hello-world
        ports:
          - port: 8000
            expose: true
```

</details>

Next create the application and check that the associated pods can be retrieved by component (as before) and by application name.

```bash
$ kubectl create -f first-vela-app.webservice.yaml
application.core.oam.dev/first-vela-app-as-webservice created
$ kubectl get pods -l=app.oam.dev/name=first-vela-app-as-webservice
NAME                                         READY   STATUS    RESTARTS   AGE
express-server-webservice-54dcccbf4b-6wdnn   1/1     Running   0          38s
$ kubectl get pods -l=app.oam.dev/component=express-server-webservice
NAME                                         READY   STATUS    RESTARTS   AGE
express-server-webservice-54dcccbf4b-6wdnn   1/1     Running   0          91s

```

This tests were also executed for the other types of entities.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->